### PR TITLE
docs(spec): merge v2 spec into canonical spec

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,12 +1,14 @@
 # SPEC.md
 
+> 本文是项目的**唯一权威 SPEC**（工程可执行、以当前实现为准）。`docs/v2/SPEC.md` 已合并弃用，仅保留为历史指针。
+
 ## 0. 约定
 
 命令名：agentpack
 配置 repo：agentpack config repo（本地 clone），默认位于 $AGENTPACK_HOME/repo
 
 默认数据目录：`~/.agentpack`（可通过 `AGENTPACK_HOME` 覆盖），目录结构：
-- repo/（config repo, git）
+- repo/（config repo, git；含 `agentpack.yaml`、`agentpack.lock.json`）
 - cache/（git sources cache）
 - state/snapshots/（deploy/rollback snapshots）
 - state/logs/（record events）
@@ -64,6 +66,7 @@ project_id 必须稳定（同项目多机一致）。
 
 示例：
 
+```yaml
 version: 1
 
 profiles:
@@ -122,6 +125,7 @@ modules:
     source:
       local_path:
         path: "modules/claude-commands/ap-plan.md"
+```
 
 备注：
 - instructions module 的 source 指向一个目录，里面可能包含：
@@ -150,26 +154,72 @@ modules:
 - lockfile 变更必须可 diff（JSON 字段顺序固定，数组排序稳定）
 - install/fetch 只能使用 lockfile 的 resolved_version
 
+### 2.3 <target root>/.agentpack.manifest.json（target manifest）
+
+目标：
+- 安全删除（只删除托管文件）
+- drift/status（changed/missing/extra）
+
+Schema（v1，示例）：
+
+```json
+{
+  "schema_version": 1,
+  "generated_at": "2026-01-11T00:00:00Z",
+  "tool": "codex",
+  "snapshot_id": "optional",
+  "managed_files": [
+    { "path": "skills/agentpack-operator/SKILL.md", "sha256": "…", "module_ids": ["skill:agentpack-operator"] }
+  ]
+}
+```
+
+要求：
+- `path` 必须是相对路径，且不允许包含 `..`。
+- manifest 仅记录 agentpack 本次/历史部署写入的托管文件；不得把用户原生文件视为托管文件。
+
+### 2.4 state/logs/events.jsonl（event log）
+
+`agentpack record` 写入的事件日志为 JSON Lines（每行一个 JSON 对象）。
+
+每行结构（v1，示例）：
+
+```json
+{
+  "schema_version": 1,
+  "recorded_at": "2026-01-11T00:00:00Z",
+  "machine_id": "my-macbook",
+  "event": { "module_id": "command:ap-plan", "success": true }
+}
+```
+
+约定：
+- `event` 为自由 JSON；`score` 仅解析 `module_id|moduleId` 与 `success|ok`。
+
 ## 3. Overlays
 
 ### 3.1 覆盖层级与优先级
 最终合成顺序（低 -> 高）：
-1) upstream module（store 中）
+1) upstream module（repo 本地目录或 cache 中）
 2) global overlay（repo/overlays/<module_id>/...）
 3) machine overlay（repo/overlays/machines/<machine_id>/<module_id>/...）
 4) project overlay（repo/projects/<project_id>/overlays/<module_id>/...）
 
-### 3.2 overlay 表达形式（v0.1）
+### 3.2 overlay 表达形式（v0.2）
 采用“文件覆盖”模型：
 - overlay 目录结构与 module 一致
 - 同路径文件：直接覆盖
-- v0.2 可加入 patch/diff 模型（支持 3-way merge）
+- （future）可加入 patch/diff 模型（如 3-way merge），但当前实现未支持
 
 ### 3.3 overlay 编辑命令（见 CLI）
 agentpack overlay edit <module_id> [--project] 会：
-- 若不存在 overlay：复制 upstream 到 overlay 工作区（仅复制用户选中的文件/或全部，二选一策略见实现）
+- 若不存在 overlay：复制 upstream module 的完整文件树到 overlay 目录
 - 打开编辑器（$EDITOR）
 - 保存后 deploy 生效
+
+### 3.4 overlay 元数据（.agentpack）
+- overlay skeleton 会写入 `<overlay_dir>/.agentpack/baseline.json`，用于 overlay drift warnings（不参与部署）。
+- `.agentpack/` 目录为保留元数据目录：不会被 deploy 到 target roots；也不应被写入模块产物中。
 
 ## 4. CLI 命令（v0.2）
 
@@ -180,11 +230,14 @@ agentpack overlay edit <module_id> [--project] 会：
 - --machine <id>：指定 machine overlay（默认自动探测 machineId）
 - --json：输出 JSON
 - --yes：跳过确认
-- --dry-run：只 plan，不 apply（默认 true，除非显式 deploy --apply）
+- --dry-run：强制不写入（即使 `deploy --apply`）；默认 false
+
+安全约定：
+- 对会写入磁盘/改写 git 的命令，`--json` 模式下通常要求同时提供 `--yes`（避免 LLM/脚本误触写入）。
 
 ### 4.1 init
 agentpack init
-- 创建 $AGENTPACK_HOME/repo（可选：初始化 git）
+- 创建 $AGENTPACK_HOME/repo（不会自动 `git init`）
 - 写入最小 agentpack.yaml skeleton
 - 生成 modules/ 目录
 
@@ -221,6 +274,10 @@ agentpack deploy [--apply]
 - 删除保护：仅删除 manifest 中记录的托管文件（不会删除用户非托管文件）
 - 若不带 --apply：只展示计划（等价 plan+diff）
 
+补充：
+- `--json` + `--apply` 必须同时提供 `--yes`，否则报错。
+- 即使 plan 为空，只要目标 root 缺失 manifest，也会写入 manifest（保证后续 drift/safe-delete 可用）。
+
 ### 4.7 status
 agentpack status
 - 若目标目录存在 `.agentpack.manifest.json`：基于 manifest 做 drift（changed/missing/extra）
@@ -241,6 +298,9 @@ agentpack bootstrap [--target codex|claude_code|all] [--scope user|project|both]
 要求：
 - Claude commands 若含 bash 执行，必须写 allowed-tools（最小化）
 
+补充：
+- `--json` 模式下要求同时提供 `--yes`（因为会写入目标目录）。
+
 ### 4.10 doctor
 agentpack doctor
 - 输出 machineId（用于 machine overlays）
@@ -256,6 +316,12 @@ agentpack sync [--rebase] [--remote origin]
 agentpack record   # 从 stdin 读取 JSON 并写入 state/logs/events.jsonl
 agentpack score    # 根据 events.jsonl 计算 module 失败率等指标
 
+事件字段约定（v0.2）：
+- `record` 读取 stdin 的 JSON 为 `event`（不做强 schema 限制）。
+- `score` 识别：
+  - module id：`module_id` 或 `moduleId`
+  - success：`success` 或 `ok`（缺省视为 true）
+
 ### 4.13 explain
 agentpack explain plan|diff|status
 - 输出变更/漂移的“来源解释”：moduleId + overlay layer（project/machine/global/upstream）
@@ -263,6 +329,10 @@ agentpack explain plan|diff|status
 ### 4.14 evolve propose
 agentpack evolve propose [--module-id <id>] [--scope global|machine|project]
 - 捕获 drifted 的已部署文件内容，生成 overlay 变更（在 config repo 创建 proposal branch；不自动 deploy）
+
+补充：
+- `--json` 模式下要求同时提供 `--yes`。
+- 要求 config repo 工作树干净；会创建分支并尝试提交（若 git identity 缺失导致提交失败，会提示并保留分支与改动）。
 
 ## 5. Target Adapter 细则
 
@@ -296,7 +366,7 @@ Paths：
 部署规则：
 - command module 是一个 .md 文件，文件名=slash command 名称
 - 若 command 内含 !`bash`，必须写 frontmatter allowed-tools: Bash(...)
-- v0.1 不强制插件输出；v0.2 可支持 plugin mode（输出 .claude-plugin/plugin.json）
+- （future）可支持 plugin mode（输出 .claude-plugin/plugin.json），但当前实现未支持
 
 ## 6. JSON 输出规范（v0.2）
 

--- a/docs/v2/SPEC.md
+++ b/docs/v2/SPEC.md
@@ -1,76 +1,8 @@
-# SPEC.md (v0.2)
+# SPEC.md (deprecated)
 
-> 本文是工程可执行规格：命令、配置、文件格式、算法、输出 schema。
+`docs/v2/` 是 v0.2 规划阶段的历史文档集合。
 
-## 1. 目录约定
+本仓库当前唯一权威、与实现对齐的 SPEC 已合并到：
+- `docs/SPEC.md`
 
-默认：
-- AGENTPACK_HOME: `~/.agentpack`（可用 env 覆盖）
-- Repo: `$AGENTPACK_HOME/repo`（git）
-- Cache: `$AGENTPACK_HOME/cache`
-- State: `$AGENTPACK_HOME/state`
-  - lock: `$AGENTPACK_HOME/state/agentpack.lock`
-  - snapshots: `$AGENTPACK_HOME/state/snapshots/`
-  - logs: `$AGENTPACK_HOME/state/logs/`
-
-项目级：
-- 在项目根目录允许存在 `agentpack.project.yaml`（只覆盖 project overlay 与 profile 选择，不直接改全局 repo）
-
-## 2. 配置文件
-
-### 2.1 agentpack.yaml（repo 内）
-```yaml
-schemaVersion: 1
-
-defaults:
-  profile: default
-  deployMode: copy   # copy|symlink (v0.2 默认 copy)
-  targets: [claude_code, codex_cli]
-
-machines:
-  # 可选：机器级覆盖（优先级高于 global，低于 project）
-  # machineId 由 `agentpack doctor` 生成/展示（例如 hostname 或自定义）
-  my-macbook:
-    overlays:
-      - id: machine:mac
-        tags: [mac]
-        vars:
-          codexPromptsDir: "~/.codex/prompts"
-
-modules:
-  - id: instructions:base
-    kind: instructions
-    source: "local:modules/instructions/base"
-    targets: [all]
-    tags: [base]
-
-  - id: command:ap-plan
-    kind: command
-    source: "local:modules/claude-commands/ap-plan.md"
-    targets: [claude_code]
-    tags: [base, operator]
-
-profiles:
-  default:
-    includeTags: [base]
-    targetOverrides: {}
-    overlays:
-      global:
-        - id: overlay:global-defaults
-          selectors:
-            tagsAny: [base]
-          patches: []
-
-projects:
-  # 可选：project registry（也可不写，改用 agentpack.project.yaml）
-  repo-a:
-    match:
-      pathPrefix: "/path/to/repo-a"
-    overlays:
-      - id: project:repo-a
-        selectors:
-          tagsAny: [rust]
-        patches:
-          - replaceFile:
-              targetPath: "AGENTS.md"
-              from: "local:overlays/repo-a/AGENTS.md"
+如果你在这里看到与实现不一致的字段（例如曾经设想的 `schemaVersion/defaults/machines/projects` 配置结构），请以 `docs/SPEC.md` 与代码实现为准。


### PR DESCRIPTION
Unifies the v0.2 specification into a single canonical spec and removes the incomplete draft in `docs/v2/SPEC.md`.

## What changed
- `docs/SPEC.md` is now explicitly the single source of truth and was updated to better match the implementation (dry-run semantics, JSON+yes safety notes, manifest/event schemas, overlay metadata).
- `docs/v2/SPEC.md` is converted into a short deprecated pointer to avoid spec drift.

## Validation
- `pre-commit run -a`
- `cargo test --all --locked`
