### PR TITLE
fix(v0.3): auto-fetch missing git checkouts

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -259,6 +259,9 @@ agentpack fetch
 - 根据 lockfile 把内容拉到 cache（git sources checkout）
 - 校验 sha256
 
+v0.3 行为增强（减少脚枪）：
+- 当 lockfile 存在且某个 `<moduleId, commit>` 的 checkout 缓存缺失时，`plan/diff/deploy/overlay edit` 会自动补齐缺失 checkout（安全网络操作），不再强制要求用户先手动 `fetch`。
+
 ### 4.5 plan / diff
 agentpack plan
 - 输出将要写入哪些 target、哪些文件、何种操作（create/update/delete）

--- a/docs/v3/ARCHITECTURE.md
+++ b/docs/v3/ARCHITECTURE.md
@@ -1,0 +1,123 @@
+# ARCHITECTURE.md (v0.3 draft)
+
+## 1. 总览
+
+Agentpack = CLI（AI-first） + Core Engine + Target Adapters +（可选）TUI
+
+它的本质仍然是“声明式资产编译器（declarative asset compiler）”：
+- 输入：manifest（想要什么） + overlays（怎么改） + lockfile（锁版本）
+- 输出：写入各工具“可发现”的目录/配置文件（真实文件，copy/render）
+- 闭环：plan → diff → apply → snapshot → rollback
+
+v0.3 的架构演进重点不是引入更多复杂模块，而是把“常用路径”做成更短、更稳、更适合 AI 调用的工作流。
+
+## 2. 三层存储模型（保持不变）
+
+A) Config Repo（Git 管理，建议同步到远端）
+- 内容：agentpack.yaml + overlays (+ 可选 modules)
+- 目标：可 review、可 PR、可回滚
+
+B) Cache/Store（不进 Git）
+- 内容：git checkouts、hash 校验、中间产物
+- 目标：可复现；允许丢弃后重建
+
+C) Deployed Outputs（不进 Git）
+- 写入到目标工具目录的“生效形态”
+- v0.2+：每个 target root 写入 `.agentpack.manifest.json`（托管清单）
+
+## 3. 目录布局（默认）
+
+AGENTPACK_HOME（默认）：`~/.agentpack`（可通过 `AGENTPACK_HOME` 覆盖）
+
+- repo/
+  - agentpack.yaml
+  - agentpack.lock.json
+  - modules/
+  - overlays/
+  - overlays/machines/<machineId>/
+  - projects/<projectId>/overlays/
+- cache/
+  - git/<moduleId>/<commit>/...
+- state/
+  - snapshots/<id>.json
+  - snapshots/<id>/backup/...
+  - logs/events.jsonl
+
+## 4. 关键组件
+
+### 4.1 CLI Frontend（AI-first）
+- 所有核心命令支持 `--json`
+- JSON 输出使用 envelope：schema_version / ok / command / version / data / warnings / errors
+- 对写入磁盘或改写 git 的命令：在 `--json` 下倾向要求 `--yes`（可配置/逐步收紧）
+
+v0.3 新增：组合命令（Composite Commands）
+- `agentpack update`：把 lock+fetch 变成一个可复用原子动作
+- `agentpack preview`：把 plan(+diff) 变成一个可复用动作
+
+这些组合命令本质上是“编排层（orchestrator）”，复用已有子命令能力，而不是重复实现。
+
+### 4.2 Config Loader
+- 读取 agentpack.yaml
+- 读取 lockfile（如果存在）
+- 读取项目上下文（cwd、git root、origin url）
+- 读取 machineId
+
+### 4.3 Resolver + Lock
+- 将 source（local/git）解析为具体版本
+- 产出 lockfile（commit + sha256 + file manifest）
+
+### 4.4 Cache Manager（Store）
+- `ensure_git_checkout()` 拉取并缓存第三方模块
+- `hash_tree()` 校验可复现
+
+v0.3 建议增强：
+- 当引擎需要某个 checkout 而本地缓存缺失时：
+  - 要么自动补齐（安全网络操作，默认可开）；
+  - 要么输出更清晰的错误信息（提示运行 update/fetch）。
+
+### 4.5 Overlay Engine
+- 四层覆盖（优先级从低到高）：
+  1) upstream module
+  2) global overlay
+  3) machine overlay
+  4) project overlay
+
+v0.3 建议增强：
+- `overlay edit` 的 scope 一致化：global/machine/project 都能一键生成 skeleton + 打开编辑器
+
+### 4.6 Renderer/Compiler
+- 将合成后的 module 编译为 target 所需的目录结构
+- v0.2/0.3 默认不做模板变量渲染（仅组合/复制内容）
+- 输出为 DesiredState（target+path→bytes+module_ids）
+
+### 4.7 Target Adapters
+- 负责：路径选择、输出布局、root 列表（用于 manifest 与 drift 扫描策略）
+- v0.2+：每个 root 写入 `.agentpack.manifest.json`
+
+### 4.8 Apply + Snapshot + Rollback
+- apply：原子写入 + 备份
+- snapshot：记录变更与备份位置
+- rollback：基于 snapshot 恢复
+
+### 4.9 Observability + Evolution
+- record：写入 events.jsonl
+- score：模块健康度（失败率、调用量等）
+- explain：plan/diff/status 的来源解释（upstream/global/machine/project）
+- evolve propose：把 drift 捕获为 overlay proposal 分支（可 review + merge）
+
+v0.3 建议增强：
+- bootstrap 的 operator assets 明确推荐“编辑 deployed → evolve propose → review/merge”的路径
+
+## 5. Git Hygiene（v0.3 新增关注点）
+
+`.agentpack.manifest.json` 写入位置属于 target root。
+当某个 root 位于项目 git repo 内时，会存在误提交风险。
+
+v0.3 推荐策略：
+- doctor 提示风险（发现 manifest 位于 git repo 且未被 ignore）。
+- 可选 `doctor --fix`：在用户明确同意的前提下写入 `.gitignore`。
+
+## 6. 扩展性
+
+- 新 target adapter 是 v1.0 重点（Cursor/VS Code 等）。
+- 不建议在 v0.3 引入 GUI；优先把 CLI 做成“人类可用 + AI 可编排”。

--- a/docs/v3/BACKLOG.md
+++ b/docs/v3/BACKLOG.md
@@ -1,0 +1,60 @@
+# BACKLOG.md (v0.3 draft)
+
+优先级：
+- P0：v0.3 必须完成（减少摩擦 + 稳定性）
+- P1：v0.3 强烈建议（AI-first 体验）
+- P2：v1.0+（扩展生态与 targets）
+
+## Milestone v0.2（已完成）
+
+- manifest/lock/store
+- overlays: upstream → global → machine → project
+- plan/diff/deploy + snapshot/rollback
+- per-root `.agentpack.manifest.json`
+- remote set / sync
+- bootstrap（operator assets）
+- record/score/explain/evolve propose
+
+## Milestone v0.3（P0/P1）
+
+### Epic K：减少摩擦（命令链缩短）
+- [P0] K1. `agentpack update` 组合命令（lock + fetch 编排）
+  - [P0] K1.1 默认策略：lockfile 缺失时 lock+fetch；存在时默认 fetch
+  - [P0] K1.2 --json 输出聚合 steps 信息
+  - [P0] K1.3 `--json` 下要求 `--yes`
+- [P1] K2. `agentpack preview` 组合命令（plan + 可选 diff）
+  - [P1] K2.1 JSON 输出同时包含 plan/diff 摘要
+
+### Epic L：Git checkout 缺失处理（消除脚枪）
+- [P0] L1. 选择策略 A（推荐）：lockfile 存在但缓存缺失时自动 ensure_git_checkout
+  - [P0] L1.1 仅对缺失 checkout 触发，不重复拉取
+  - [P0] L1.2 错误信息清晰（网络不可用/权限问题）
+- [P1] L2. （可选）提供 `--no-auto-fetch` 开关（给偏保守用户）
+
+### Epic M：Overlay 编辑体验一致化
+- [P0] M1. `overlay edit --scope global|machine|project`
+  - [P0] M1.1 保持 `--project` 兼容（deprecated）
+  - [P0] M1.2 machine scope 使用 `--machine` / 自动 machineId
+- [P1] M2. `overlay path`（AI/脚本定位 overlay 路径）
+
+### Epic N：写入安全规则强化（AI-first 保护栏）
+- [P0] N1. 扩展 `--json` + `--yes` 保护到更多写命令
+  - add/remove/lock/fetch/remote set/sync/record
+  - 统一错误码：E_CONFIRM_REQUIRED
+- [P1] N2. （可选）引入 `--interactive`（仅 human 模式）用于确认
+
+### Epic O：Git hygiene（manifest 误提交风险）
+- [P0] O1. doctor 增强：检测 `.agentpack.manifest.json` 是否位于 git repo 且未 ignore
+- [P1] O2. `doctor --fix`：幂等写入 `.gitignore`（需要显式启用）
+
+### Epic P：AI-first 闭环增强（模板与引导）
+- [P1] P1. 更新 bootstrap 内置 Codex skill 文案：加入 record/score/explain/evolve
+- [P1] P2. 增加 Claude slash command：/ap-evolve-propose（或在 /ap-status 中引导）
+
+## Milestone v1.0（P2）
+
+- 更多 targets adapters（Cursor/VS Code 等）
+- registry/index 对接与模块发现
+- overlay 3-way merge / patch overlays
+- TUI（ratatui）
+- 更完整的自动化进化（watcher、建议生成器等）

--- a/docs/v3/PRD.md
+++ b/docs/v3/PRD.md
@@ -1,0 +1,105 @@
+# PRD.md (v0.3 draft)
+
+## 1. 背景与问题
+
+你会同时使用多个 AI coding 工具（Codex CLI、Claude Code、Cursor 等），而这些工具又各自支持一套「可插拔资产」：AGENTS.md、skills、slash commands、prompts、subagents、/prompts、commands 等。
+
+这些资产带来的价值很大（效率与一致性），但现实里管理成本也很高：
+- 发现成本：同一类能力（例如 git review）可以有上百种实现，你需要搜索、理解、试用、筛选。
+- 维护成本：安装后会不断「微调」以适配自己的习惯与项目；上游更新后你还要合并。
+- 协同成本：多台电脑、多项目、多工具，版本不一致与路径差异会带来大量摩擦。
+- 可控性：想要可审计、可回滚、可复现，而不是“我也不知道现在生效的是哪个版本”。
+
+Agentpack 的定位是：在本地提供一个“资产控制平面（control plane）”，用声明式清单 + overlays + lockfile，把资产从「管理」到「分发」再到「回滚」统一起来，并对 AI/人类都友好（AI-first）。
+
+## 2. 目标用户
+
+- 深度 AI coding 用户：日常高频使用 Codex CLI/Claude Code 等，愿意把 prompts/skills 当作生产资料。
+- 多机器、多项目开发者：需要一致的基线 + 项目差异化。
+- 对可审计、可回滚、可复现有要求：不希望资产管理变成不可控的“脚本+提示词地狱”。
+
+## 3. v0.2 已实现能力（现状）
+
+v0.2 已经覆盖了核心闭环：
+- 单一真源 Config Repo（git 管理）：manifest + overlays
+- lockfile（agentpack.lock.json）：固定 git modules 的 commit + sha
+- store/cache：拉取 git sources 并校验 hash
+- overlays 分层：upstream → global → machine → project
+- plan/diff/deploy：生成与写入真实文件（copy/render），支持备份、快照与 rollback
+- 目标目录托管清单：每个 target root 写入 `.agentpack.manifest.json`，用于安全删除与可靠 drift/status
+- 多机器同步：remote set / sync
+- AI-first 自举：bootstrap 安装 Codex operator skill + Claude slash commands
+- 最小进化闭环：record/score + explain + evolve propose（把 drift 捕获成 overlay proposal 分支）
+
+## 4. v0.3 需要解决的新增痛点
+
+虽然 v0.2 已可用，但从“日常深度使用”的角度看，还存在几类明显摩擦：
+
+1) 命令链太长：
+- lock + fetch + plan + diff + deploy… 对人类和 AI 都有学习成本。
+
+2) 依赖预热的脚枪（sharp edges）：
+- lockfile 存在但 store 缓存缺失时，plan/materialize 可能报错；用户必须记得先 fetch。
+
+3) overlays 的编辑体验还不够顺滑：
+- 已有 global/project overlay edit，但 machine overlay 缺少同等体验（需要手工建目录）。
+
+4) “托管 manifest”可能污染项目仓库：
+- 某些 target root 是项目 repo root 或其子目录，`.agentpack.manifest.json` 有误提交风险。
+
+5) AI-first 的闭环还不够“顺手”：
+- v0.2 的 evolve propose 能把 drift 变成 overlay，但 operator assets 还可以更明确地引导 AI 走这条最佳路径。
+
+## 5. v0.3 产品目标
+
+P0（必须做到）：
+- 减少常见路径的命令数量，让“更新依赖/预览/应用”更接近一两个命令。
+- 消除 lockfile+缓存缺失导致的常见报错，要么自动补齐（安全网络操作），要么给出明确可操作的错误信息。
+- overlays 编辑体验覆盖 global/machine/project 三种 scope。
+- 降低 `.agentpack.manifest.json` 被误提交的概率（至少做到明确告警 + 可选自动修复）。
+
+P1（强烈建议做到）：
+- 为 AI 输出更“可直接拿去做下一步”的结构化信息（例如 update/preview 的 JSON 输出更聚合）。
+- operator assets 升级：包含 record / evolve propose 的推荐流程。
+
+## 6. 需求范围（v0.3 In-scope）
+
+- 新增组合命令（Composite Commands）：
+  - `agentpack update`：一键 lock+fetch（并可选只做其一），输出清晰的结果与错误提示。
+  - `agentpack preview`：一键 plan(+可选 diff)，便于 AI 工具调用。
+
+- 依赖缺失处理：
+  - 当 lockfile 指向的 git checkout 在 store 中缺失时，提供：
+    - 默认自动补齐（推荐）；或
+    - 明确错误提示“缺少缓存，请运行 agentpack fetch/agentpack update”。
+
+- overlays 编辑体验增强：
+  - `agentpack overlay edit --scope global|machine|project`（取代/兼容 `--project`）。
+  - （可选）`agentpack overlay path`：把 overlay 目录路径输出给 AI 或脚本。
+
+- Git hygiene：
+  - `agentpack doctor` 增加“manifest file 在 git repo 内是否被 ignore”的告警。
+  - （可选）`agentpack doctor --fix`：自动写入 `.gitignore`（默认不启用，需要显式用户同意）。
+
+- AI-first 资产升级：
+  - 更新 bootstrap 模板：让 Codex/Claude 的 operator 更自然地使用 record/score/explain/evolve。
+
+## 7. 非目标（v0.3 Out-of-scope）
+
+- MCP 全量生态管理（可先降低优先级）。
+- 复杂三方合并（3-way merge）与 patch overlays（可以在 v1.0 做）。
+- GUI（先保持 CLI + 可选 TUI）。
+- 远程 registry/marketplace 的完整发现体系（先以 git/local/手动为主，后续再做）。
+
+## 8. 成功指标（建议）
+
+- 日常使用的“平均命令长度”降低（从 4~6 个命令 → 1~2 个命令完成一次更新与预览）。
+- 新用户从安装到首次成功 deploy 的时间下降。
+- 因缓存缺失导致的报错显著降低。
+- evolve propose 的使用率上升（AI/人类更容易把改动沉淀为 overlays）。
+
+## 9. 里程碑
+
+- v0.2：已完成（稳定闭环）
+- v0.3：以“减少摩擦 + 强化 AI-first 闭环”为主
+- v1.0：扩展更多 targets（Cursor/VS Code），更强 overlays，registry 对接

--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -1,0 +1,82 @@
+# Agentpack
+
+Agentpack is an AI-first local “asset control plane” for managing and deploying:
+- `AGENTS.md` / instructions
+- Agent Skills (`SKILL.md`)
+- Claude Code slash commands (`.claude/commands`)
+- Codex custom prompts (`~/.codex/prompts`)
+
+It gives you a single source of truth (a git repo) + overlays (customization layers) + a lockfile (reproducible versions), then compiles those assets into each tool’s expected filesystem layout (copy/render; no symlinks).
+
+This repo contains both the implementation and the design docs:
+- `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/SPEC.md`, `docs/BACKLOG.md`
+
+## Status
+
+- v0.2: Core loop shipped (lock/fetch, overlay layers, plan/diff/deploy + rollback, per-root manifests, remote sync, bootstrap, record/score/explain/evolve-propose).
+- v0.3 (planned): reduce daily friction (composite commands), smoother overlay editing across scopes, better cache-miss behavior, safer AI-first guardrails.
+
+## Usage (v0.2)
+
+```bash
+# Create (or open) your config repo at $AGENTPACK_HOME/repo
+agentpack init
+
+# Optional: configure and sync your config repo across machines
+agentpack remote set https://github.com/you/agentpack-config.git
+agentpack sync --rebase
+
+# Self-check (machineId + target paths)
+agentpack doctor
+
+# Add modules to agentpack.yaml
+agentpack add instructions local:modules/instructions/base --id instructions:base --tags base
+agentpack add command local:modules/claude-commands/ap-plan.md --id command:ap-plan --tags base --targets claude_code
+
+# Lock and fetch git sources
+agentpack lock
+agentpack fetch
+
+# Preview / diff / apply
+agentpack plan --profile default
+agentpack diff --profile default
+agentpack deploy --profile default --apply --yes --json
+
+# Drift + rollback
+agentpack status --profile default
+agentpack rollback --to <snapshot_id>
+
+# AI-first operator assets
+agentpack bootstrap --target all --scope both
+
+# Observability + proposals (v0.2 minimal loop)
+agentpack record < event.json
+agentpack score
+agentpack explain plan
+agentpack evolve propose --scope global --yes
+```
+
+## Upcoming (v0.3 planned)
+
+```bash
+# One command for lock+fetch
+agentpack update --yes --json
+
+# One command for plan(+diff)
+agentpack preview --diff --json
+
+# Overlay editing by scope
+agentpack overlay edit skill:git-review --scope machine
+```
+
+## Development
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all --locked
+```
+
+## Contributing
+
+Start with `AGENTS.md` and `CONTRIBUTING.md`.

--- a/docs/v3/SPEC.md
+++ b/docs/v3/SPEC.md
@@ -1,0 +1,168 @@
+# SPEC.md (v0.3 draft)
+
+说明：本规范面向实现者（Rust + clap），用于指导 v0.3 的增量开发。
+
+本 spec 以 v0.2 已有行为为基础，只定义 v0.3 的新增/变更点。
+
+## 1. CLI 总则
+
+### 1.1 全局参数（沿用 v0.2）
+
+- `--repo <path>`：配置仓库目录（默认 `$AGENTPACK_HOME/repo`）
+- `--profile <name>`：profile（默认 `default`）
+- `--target <all|codex|claude_code>`：目标过滤（默认 `all`）
+- `--machine <id>`：覆盖 machineId（默认自动检测/环境变量）
+- `--json`：输出 JSON envelope
+- `--yes`：确认执行写入（主要用于 `--json` 场景）
+- `--dry-run`：强制不写入（即使显式 apply）
+
+### 1.2 写入安全规则（v0.3 强化）
+
+v0.2 已对 `deploy --apply`、`bootstrap --apply`、`evolve propose` 在 `--json` 下要求 `--yes`。
+
+v0.3 建议把同一规则扩展到“任何会写磁盘/改写 git 的命令”，至少包括：
+- `add`, `remove`, `lock`, `fetch`, `remote set`, `sync`, `record`（写日志也算写入）
+
+推荐策略：
+- 当 `--json` 且命令会写入时，如果缺少 `--yes`：
+  - 直接报错（machine-friendly），错误码建议 `E_CONFIRM_REQUIRED`。
+- 人类输出模式（无 `--json`）下：
+  - 允许交互式确认（y/N）或沿用现状（尽量不引入交互，除非明确需要）。
+
+## 2. 新增组合命令（Composite Commands）
+
+### 2.1 `agentpack update`
+
+目标：把常见的“锁版本 + 拉取依赖”合并为一个命令，减少日常摩擦。
+
+命令：
+- `agentpack update [--lock] [--fetch] [--no-lock] [--no-fetch]`
+
+默认行为（建议）：
+- 如果 lockfile 不存在：默认执行 lock + fetch
+- 如果 lockfile 已存在：默认只 fetch（更快），除非显式 `--lock`
+
+参数建议：
+- `--lock`：强制重新生成 lockfile
+- `--fetch`：强制执行 fetch
+- `--no-lock`：明确禁用 lock
+- `--no-fetch`：明确禁用 fetch
+
+输出：
+- human：显示执行了哪些步骤、耗时、拉取了多少模块
+- json：
+  - `data.steps`: [{name, ok, detail}]
+  - `data.lockfile_path`
+  - `data.store_path`
+  - `data.git_modules_fetched`
+  - `warnings[]`
+
+注意：
+- `update` 本质是 orchestrator，内部复用 lock/fetch 的逻辑，避免代码重复。
+- `--json` 下属于写入命令，需要 `--yes`（遵循 1.2）。
+
+### 2.2 `agentpack preview`
+
+目标：把“plan +（可选）diff”合并为一个 AI 友好的预览命令。
+
+命令：
+- `agentpack preview [--diff]`
+
+行为：
+- 总是运行 plan
+- 当 `--diff` 时再运行 diff（human 输出为 unified diff；json 输出为 diff 摘要即可）
+
+输出（json）：
+- `data.plan.summary` + `data.plan.changes`
+- 如果 `--diff`：`data.diff.summary` + `data.diff.changes`
+- `warnings[]`
+
+备注：
+- preview 是纯读取操作，不需要 `--yes`。
+
+## 3. Git source 缓存缺失处理（v0.3 行为变更）
+
+问题：当 lockfile 存在且 engine 优先使用 lockfile 指向的 checkout 时，如果本地 cache 缺失，materialize 会报错。
+
+v0.3 需要二选一（推荐 A）：
+
+A) 自动补齐（推荐默认）
+- 当 lockfile 解析到 `<moduleId, commit>` 时：
+  - 如果 checkout_dir 不存在，则自动执行 `ensure_git_checkout()`。
+- 这属于安全网络操作（只读拉取），不会写入 target outputs。
+
+B) 明确报错（保守默认）
+- 当 checkout_dir 不存在：
+  - 报错：`missing git checkout for module <id> at <commit>; run agentpack fetch/agentpack update`
+
+无论选择 A 或 B，都应保证错误信息可操作、对 AI 友好。
+
+## 4. Overlay 编辑体验一致化（v0.3）
+
+### 4.1 `agentpack overlay edit --scope`
+
+v0.2：
+- `agentpack overlay edit <module_id> [--project]`
+
+v0.3：
+- 新增 `--scope <global|machine|project>`（默认 global）
+- `--project` 仍兼容，但标记为 deprecated（内部映射到 `--scope project`）
+
+scope 行为：
+- global: `repo/overlays/<moduleId>/...`
+- machine: `repo/overlays/machines/<machineId>/<moduleId>/...`
+- project: `repo/projects/<projectId>/overlays/<moduleId>/...`
+
+编辑行为：
+- overlay 不存在时：复制 upstream → overlay_dir，写入 `.agentpack/baseline.json`
+- overlay 已存在时：不覆盖，只确保 baseline 存在
+- 如果设置了 `$EDITOR`：打开 overlay_dir
+
+json 输出：
+- `data.scope`
+- `data.module_id`
+- `data.overlay_dir`
+- `data.created`
+- `data.machine_id`（当 scope=machine）
+- `data.project_id`（当 scope=project）
+
+### 4.2 `agentpack overlay path`（可选但很实用）
+
+命令：
+- `agentpack overlay path <module_id> --scope <...>`
+
+用途：
+- 让 AI/脚本不需要理解目录布局，也能定位要写入的 overlay 路径。
+
+输出：
+- human：打印绝对路径
+- json：`data.overlay_dir`
+
+## 5. Git Hygiene（v0.3）
+
+### 5.1 doctor 增强
+
+当 target manifest `.agentpack.manifest.json` 位于某个 git repo 内时：
+- doctor 输出 warning：
+  - 该文件可能被误提交
+  - 建议把它加入 `.gitignore`
+
+### 5.2 `doctor --fix`（可选）
+
+命令：
+- `agentpack doctor --fix`（默认不开；需要用户明确使用）
+
+行为：
+- 在对应 repo 的 `.gitignore` 追加一行：`.agentpack.manifest.json`
+- 必须做到幂等：重复执行不会重复插入
+
+安全：
+- `--json` 下需要 `--yes`
+
+## 6. bootstrap 模板升级（v0.3）
+
+v0.3 建议更新内置 operator assets：
+- Codex skill：增加“如何使用 record/score/explain/evolve propose”的推荐流程
+- Claude commands：增加 /ap-evolve-propose 或在现有命令说明里加入 evolve 提示
+
+模板更新属于 repo 内置 assets，不影响 core 行为，但能显著提升“AI-first 闭环”。

--- a/openspec/changes/fix-auto-fetch-missing-checkouts/.openspec.yaml
+++ b/openspec/changes/fix-auto-fetch-missing-checkouts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/fix-auto-fetch-missing-checkouts/proposal.md
+++ b/openspec/changes/fix-auto-fetch-missing-checkouts/proposal.md
@@ -1,0 +1,17 @@
+# Change: Auto-fetch missing git checkouts when lockfile exists
+
+## Why
+With a lockfile present, the engine prefers lockfile-resolved git checkouts for reproducibility. Today, if the local checkout cache is missing (e.g., fresh machine, cache cleared), `plan`/materialization can fail even though the lockfile is valid. This is daily-friction and a sharp edge for AI-first usage.
+
+## What Changes
+- When a module is resolved from `agentpack.lock.json` and its git checkout directory is missing, Agentpack automatically runs a safe `ensure_git_checkout()` to populate the cache.
+- This only affects missing-checkout cases; existing checkouts are reused.
+- Error messages remain actionable when git operations fail.
+
+## Scope
+- In scope: git modules resolved via lockfile.
+- Out of scope: new CLI flags like `--no-auto-fetch` (can be added later if needed).
+
+## Acceptance
+- A missing checkout for a locked git module no longer causes plan/materialization failures.
+- Behavior is covered by tests.

--- a/openspec/changes/fix-auto-fetch-missing-checkouts/specs/agentpack/spec.md
+++ b/openspec/changes/fix-auto-fetch-missing-checkouts/specs/agentpack/spec.md
@@ -1,0 +1,12 @@
+# agentpack (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Reproducible materialization from lockfile
+When a module is resolved from `agentpack.lock.json` and its git checkout directory is missing locally, the system MUST automatically populate the missing checkout (safe network fetch) or fail with an actionable error instructing the user to run `agentpack fetch/update`.
+
+#### Scenario: Missing checkout is auto-fetched
+- **GIVEN** `agentpack.lock.json` pins a git module to commit `<commit>`
+- **AND** the local checkout directory for `<moduleId, commit>` does not exist
+- **WHEN** the system materializes that module as part of `plan/diff/deploy`
+- **THEN** the missing checkout is populated automatically

--- a/openspec/changes/fix-auto-fetch-missing-checkouts/tasks.md
+++ b/openspec/changes/fix-auto-fetch-missing-checkouts/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+
+### 1.1 Auto-fetch missing checkouts
+- [x] When using lockfile-resolved git modules, if the checkout dir is missing, call `ensure_git_checkout()`.
+- [x] Ensure this triggers only for missing checkouts (no redundant fetches).
+- [x] Keep errors actionable on failures.
+
+### 1.2 Tests + docs
+- [x] Add a test that simulates a missing checkout dir and verifies it is auto-populated.
+- [x] Update `docs/SPEC.md` to document the v0.3 cache-miss behavior.


### PR DESCRIPTION
Closes #10.

Fixes a v0.2 sharp edge: when `agentpack.lock.json` exists but the local git checkout cache is missing, module materialization now auto-populates the missing checkout (safe network op) instead of failing.

## OpenSpec
- Change: `openspec/changes/fix-auto-fetch-missing-checkouts/`

## Testing
- `pre-commit run -a`
- `cargo test --all --locked`
