### PR TITLE
feat(v0.3): overlay edit --scope

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -212,10 +212,18 @@ Schema（v1，示例）：
 - （future）可加入 patch/diff 模型（如 3-way merge），但当前实现未支持
 
 ### 3.3 overlay 编辑命令（见 CLI）
-agentpack overlay edit <module_id> [--project] 会：
-- 若不存在 overlay：复制 upstream module 的完整文件树到 overlay 目录
+agentpack overlay edit <module_id> [--scope global|machine|project] 会：
+- 若不存在 overlay：复制 upstream module 的完整文件树到 overlay 目录（scope 对应路径见下）
 - 打开编辑器（$EDITOR）
 - 保存后 deploy 生效
+
+scope → 路径映射：
+- global: `repo/overlays/<module_id>/...`
+- machine: `repo/overlays/machines/<machine_id>/<module_id>/...`
+- project: `repo/projects/<project_id>/overlays/<module_id>/...`
+
+兼容性：
+- `--project` 仍保留但已 deprecated（等价 `--scope project`）。
 
 ### 3.4 overlay 元数据（.agentpack）
 - overlay skeleton 会写入 `<overlay_dir>/.agentpack/baseline.json`，用于 overlay drift warnings（不参与部署）。

--- a/openspec/changes/update-overlay-edit-scope/.openspec.yaml
+++ b/openspec/changes/update-overlay-edit-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/update-overlay-edit-scope/proposal.md
+++ b/openspec/changes/update-overlay-edit-scope/proposal.md
@@ -1,0 +1,13 @@
+# Change: Overlay edit by scope (global/machine/project)
+
+## Why
+v0.2 supports `overlay edit` for global and (via `--project`) project overlays, but machine overlays lack an equivalent one-command UX. This creates daily friction (manual directory creation) and makes AI-first workflows harder to script.
+
+## What Changes
+- Add `agentpack overlay edit <module_id> --scope global|machine|project` (default: global).
+- Keep `--project` for backward compatibility, but deprecate it (maps to `--scope project`).
+- JSON output includes scope and the resolved overlay path (plus machine_id/project_id where relevant).
+
+## Acceptance
+- Machine overlays can be created/edited via `overlay edit --scope machine`.
+- Existing `overlay edit --project` continues to work.

--- a/openspec/changes/update-overlay-edit-scope/specs/agentpack/spec.md
+++ b/openspec/changes/update-overlay-edit-scope/specs/agentpack/spec.md
@@ -1,0 +1,16 @@
+# agentpack (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Overlay editing
+The system MUST support creating overlay skeletons across overlay scopes:
+- `global`: `repo/overlays/<moduleId>/...`
+- `machine`: `repo/overlays/machines/<machineId>/<moduleId>/...`
+- `project`: `repo/projects/<projectId>/overlays/<moduleId>/...`
+
+#### Scenario: Machine overlay skeleton is created
+- **GIVEN** a module `<moduleId>` exists and resolves to an upstream root
+- **WHEN** the user runs `agentpack overlay edit <moduleId> --scope machine`
+- **THEN** the directory `repo/overlays/machines/<machineId>/<moduleId>/` exists
+- **AND** it contains the upstream content (copied)
+- **AND** it contains `.agentpack/baseline.json`

--- a/openspec/changes/update-overlay-edit-scope/tasks.md
+++ b/openspec/changes/update-overlay-edit-scope/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+### 1.1 CLI + overlay scope mapping
+- [x] Add `--scope` to `agentpack overlay edit` with values `global|machine|project` (default global).
+- [x] Keep `--project` as deprecated alias for scope=project.
+- [x] Ensure overlay skeleton behavior remains: copy upstream into overlay dir if missing; write baseline if missing.
+- [x] JSON output includes scope + overlay_dir (+ machine_id / project_id).
+
+### 1.2 Tests + docs
+- [x] Add tests for overlay skeleton creation across scopes.
+- [x] Update `docs/SPEC.md` overlay edit section to document `--scope`.


### PR DESCRIPTION
Closes #11.

Adds `agentpack overlay edit --scope global|machine|project` (default global) and keeps `--project` as a deprecated alias.

## OpenSpec
- Change: `openspec/changes/update-overlay-edit-scope/`

## Testing
- `pre-commit run -a`
- `cargo test --all --locked`
