### PR TITLE
feat(cli): require --yes for --json writes

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -241,7 +241,8 @@ scope → 路径映射：
 - --dry-run：强制不写入（即使 `deploy --apply`）；默认 false
 
 安全约定：
-- 对会写入磁盘/改写 git 的命令，`--json` 模式下通常要求同时提供 `--yes`（避免 LLM/脚本误触写入）。
+- 对会写入磁盘/改写 git 的命令，`--json` 模式下要求同时提供 `--yes`（避免 LLM/脚本误触写入）。
+- 若缺少 `--yes`：退出码非 0，stdout 仍为合法 JSON（`ok=false`），并返回稳定错误码 `E_CONFIRM_REQUIRED`（`errors[0].code`）。
 
 ### 4.1 init
 agentpack init
@@ -286,7 +287,7 @@ agentpack deploy [--apply]
 - 若不带 --apply：只展示计划（等价 plan+diff）
 
 补充：
-- `--json` + `--apply` 必须同时提供 `--yes`，否则报错。
+- `--json` + `--apply` 必须同时提供 `--yes`，否则报错（`E_CONFIRM_REQUIRED`）。
 - 即使 plan 为空，只要目标 root 缺失 manifest，也会写入 manifest（保证后续 drift/safe-delete 可用）。
 
 ### 4.7 status
@@ -310,7 +311,7 @@ agentpack bootstrap [--target codex|claude_code|all] [--scope user|project|both]
 - Claude commands 若含 bash 执行，必须写 allowed-tools（最小化）
 
 补充：
-- `--json` 模式下要求同时提供 `--yes`（因为会写入目标目录）。
+- `--json` 模式下要求同时提供 `--yes`（因为会写入目标目录；缺少则 `E_CONFIRM_REQUIRED`）。
 
 ### 4.10 doctor
 agentpack doctor
@@ -342,7 +343,7 @@ agentpack evolve propose [--module-id <id>] [--scope global|machine|project]
 - 捕获 drifted 的已部署文件内容，生成 overlay 变更（在 config repo 创建 proposal branch；不自动 deploy）
 
 补充：
-- `--json` 模式下要求同时提供 `--yes`。
+- `--json` 模式下要求同时提供 `--yes`（缺少则 `E_CONFIRM_REQUIRED`）。
 - 要求 config repo 工作树干净；会创建分支并尝试提交（若 git identity 缺失导致提交失败，会提示并保留分支与改动）。
 
 ## 5. Target Adapter 细则

--- a/openspec/changes/update-json-yes-guardrails/.openspec.yaml
+++ b/openspec/changes/update-json-yes-guardrails/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/update-json-yes-guardrails/proposal.md
+++ b/openspec/changes/update-json-yes-guardrails/proposal.md
@@ -1,0 +1,16 @@
+# Change: Require `--yes` for `--json` write commands (stable error code)
+
+## Why
+AI-first usage relies on `--json` output as an API. For safety, write commands should not execute silently in `--json` mode unless explicitly confirmed, and missing confirmation should return a stable, machine-readable error code (not a generic unexpected error).
+
+## What Changes
+- In `--json` mode, commands that write to disk or mutate git require `--yes`.
+- Missing `--yes` returns `ok=false` with error code `E_CONFIRM_REQUIRED`.
+- Align existing guardrails (`deploy --apply`, `bootstrap`, `evolve propose`) to use the same stable code.
+
+## Scope
+- Applies at least to: `add`, `remove`, `lock`, `fetch`, `remote set`, `sync`, `record`.
+
+## Acceptance
+- Missing `--yes` in `--json` mode does not perform writes and returns `E_CONFIRM_REQUIRED`.
+- Behavior is covered by tests.

--- a/openspec/changes/update-json-yes-guardrails/specs/agentpack/spec.md
+++ b/openspec/changes/update-json-yes-guardrails/specs/agentpack/spec.md
@@ -1,0 +1,12 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: JSON-mode write confirmation
+When invoked with `--json`, any command that performs writes (filesystem or git) MUST require an explicit `--yes` confirmation. If `--yes` is missing, the system MUST return a JSON error with a stable code `E_CONFIRM_REQUIRED` and MUST NOT perform the write.
+
+#### Scenario: add --json without --yes is refused
+- **WHEN** the user runs `agentpack add ... --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`

--- a/openspec/changes/update-json-yes-guardrails/tasks.md
+++ b/openspec/changes/update-json-yes-guardrails/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+### 1.1 Stable error code for confirmation
+- [x] Add a typed CLI error that preserves a stable `code` in `--json` mode.
+- [x] Update the `--json` error envelope to emit the typed error code (defaulting to `E_UNEXPECTED`).
+
+### 1.2 Guardrails for write commands
+- [x] Require `--yes` for `--json` mode on: add/remove/lock/fetch/remote set/sync/record.
+- [x] Update existing write guardrails (deploy/apply, bootstrap, evolve propose) to use `E_CONFIRM_REQUIRED`.
+
+### 1.3 Tests + docs
+- [x] Add integration tests that assert `E_CONFIRM_REQUIRED` on missing `--yes`.
+- [x] Update `docs/SPEC.md` to document the rule and the error code.

--- a/tests/cli_guardrails.rs
+++ b/tests/cli_guardrails.rs
@@ -1,0 +1,38 @@
+use std::process::Command;
+
+fn run_agentpack(args: &[&str]) -> std::process::Output {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", tmp.path())
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn json_mode_requires_yes_for_add() {
+    let output = run_agentpack(&["add", "skill", "local:modules/skill_test", "--json"]);
+    assert!(!output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "add");
+    assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+}
+
+#[test]
+fn json_mode_requires_yes_for_fetch() {
+    let output = run_agentpack(&["fetch", "--json"]);
+    assert!(!output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "fetch");
+    assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+}


### PR DESCRIPTION
Fixes #12.

## What
- Add stable JSON error code `E_CONFIRM_REQUIRED` when `--json` write commands are invoked without `--yes`.
- Extend the guardrail to write commands: `add`, `remove`, `lock`, `fetch`, `remote set`, `sync`, `record`.
- Align existing guardrails (`deploy --apply`, `bootstrap`, `evolve propose`) to use the same stable code.
- Add CLI integration tests asserting `E_CONFIRM_REQUIRED`.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `openspec validate update-json-yes-guardrails --strict`
