### PR TITLE
feat(cli): add update command

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -271,6 +271,17 @@ agentpack fetch
 v0.3 行为增强（减少脚枪）：
 - 当 lockfile 存在且某个 `<moduleId, commit>` 的 checkout 缓存缺失时，`plan/diff/deploy/overlay edit` 会自动补齐缺失 checkout（安全网络操作），不再强制要求用户先手动 `fetch`。
 
+### 4.4.1 update（组合命令）
+agentpack update [--lock] [--fetch] [--no-lock] [--no-fetch]
+- 默认策略：
+  - 若 lockfile 不存在：执行 lock + fetch
+  - 若 lockfile 已存在：默认只执行 fetch
+- 用途：减少常见链路（lock/fetch）摩擦，便于 AI/脚本编排。
+
+补充：
+- `--json` 模式下属于写入命令：要求同时提供 `--yes`（缺少则 `E_CONFIRM_REQUIRED`）。
+- `--json` 输出会聚合 steps：`data.steps=[{name, ok, detail}, ...]`。
+
 ### 4.5 plan / diff
 agentpack plan
 - 输出将要写入哪些 target、哪些文件、何种操作（create/update/delete）

--- a/openspec/changes/add-update-command/.openspec.yaml
+++ b/openspec/changes/add-update-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/add-update-command/proposal.md
+++ b/openspec/changes/add-update-command/proposal.md
@@ -1,0 +1,21 @@
+# Change: Add `agentpack update` composite command
+
+## Why
+Daily usage often requires running `lock` and/or `fetch` in sequence. A single `update` command reduces friction and makes the common workflow easier for both humans and AI agents.
+
+## What Changes
+- Add `agentpack update` as a composite command that orchestrates `lock` and `fetch`.
+- Default behavior:
+  - If `agentpack.lock.json` is missing: run `lock` then `fetch`.
+  - If `agentpack.lock.json` exists: run `fetch` only.
+- Provide flags to force/skip each step: `--lock`, `--fetch`, `--no-lock`, `--no-fetch`.
+- In `--json` mode, return aggregated step output (`data.steps`) and require `--yes` when the command will write.
+
+## Scope
+- CLI only; no change to lockfile format or store layout.
+- Affected spec: `agentpack-cli`.
+
+## Acceptance
+- `agentpack update` runs the correct default steps depending on lockfile existence.
+- `agentpack update --json` without `--yes` is refused with `E_CONFIRM_REQUIRED` when it would perform writes.
+- Behavior is covered by tests and documented in `docs/SPEC.md`.

--- a/openspec/changes/add-update-command/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-update-command/specs/agentpack-cli/spec.md
@@ -1,0 +1,21 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: Update composite command
+The system SHALL provide `agentpack update` as a composite command that orchestrates `lock` and `fetch` with a sensible default:
+- If the lockfile is missing, it runs `lock` then `fetch`.
+- If the lockfile exists, it runs `fetch` (unless explicitly overridden).
+
+#### Scenario: update runs lock+fetch when lockfile is missing
+- **GIVEN** an `AGENTPACK_HOME` with no `agentpack.lock.json`
+- **WHEN** the user runs `agentpack update`
+- **THEN** a lockfile is created
+- **AND** git sources are fetched/verified in the store
+
+#### Scenario: update --json without --yes is refused
+- **GIVEN** a lockfile exists (or `update` would otherwise perform a write step)
+- **WHEN** the user runs `agentpack update --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`

--- a/openspec/changes/add-update-command/tasks.md
+++ b/openspec/changes/add-update-command/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+### 1.1 CLI surface
+- [x] Add `agentpack update` command with flags: `--lock`, `--fetch`, `--no-lock`, `--no-fetch` (with sensible conflicts).
+- [x] Implement default step selection based on lockfile existence.
+
+### 1.2 JSON output + guardrails
+- [x] In `--json`, output aggregated `data.steps` with per-step details.
+- [x] In `--json` without `--yes`, refuse when `update` will run any write step, returning `E_CONFIRM_REQUIRED`.
+
+### 1.3 Tests + docs
+- [x] Add tests for default behavior and `--json` guardrails.
+- [x] Update `docs/SPEC.md` to describe `agentpack update`.

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -1,0 +1,59 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn json_mode_requires_yes_for_update() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = agentpack_in(tmp.path(), &["update", "--json"]);
+    assert!(!output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "update");
+    assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+}
+
+#[test]
+fn update_runs_lock_then_fetch_when_lockfile_is_missing_and_fetch_only_when_present() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let init = agentpack_in(tmp.path(), &["init"]);
+    assert!(init.status.success());
+
+    let first = agentpack_in(tmp.path(), &["update", "--json", "--yes"]);
+    assert!(first.status.success());
+    let first_json = parse_stdout_json(&first);
+    let first_steps = first_json["data"]["steps"].as_array().expect("steps array");
+    assert_eq!(first_steps.len(), 2);
+    assert_eq!(first_steps[0]["name"], "lock");
+    assert_eq!(first_steps[1]["name"], "fetch");
+
+    let lockfile = tmp.path().join("repo").join("agentpack.lock.json");
+    let first_lockfile = std::fs::read_to_string(&lockfile).expect("read lockfile");
+
+    let second = agentpack_in(tmp.path(), &["update", "--json", "--yes"]);
+    assert!(second.status.success());
+    let second_json = parse_stdout_json(&second);
+    let second_steps = second_json["data"]["steps"]
+        .as_array()
+        .expect("steps array");
+    assert_eq!(second_steps.len(), 1);
+    assert_eq!(second_steps[0]["name"], "fetch");
+
+    let second_lockfile = std::fs::read_to_string(&lockfile).expect("read lockfile");
+    assert_eq!(second_lockfile, first_lockfile);
+}


### PR DESCRIPTION
Fixes #9.

## What
- Add `agentpack update` composite command (default: `lock+fetch` if lockfile missing, otherwise `fetch`).
- Provide flags: `--lock`, `--fetch`, `--no-lock`, `--no-fetch`.
- In `--json`, return aggregated `data.steps` and require `--yes` when `update` will run write steps (returns `E_CONFIRM_REQUIRED`).

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `openspec validate add-update-command --strict`
