### PR TITLE
feat(cli): add preview command

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -282,6 +282,14 @@ agentpack update [--lock] [--fetch] [--no-lock] [--no-fetch]
 - `--json` 模式下属于写入命令：要求同时提供 `--yes`（缺少则 `E_CONFIRM_REQUIRED`）。
 - `--json` 输出会聚合 steps：`data.steps=[{name, ok, detail}, ...]`。
 
+### 4.4.2 preview（组合命令）
+agentpack preview [--diff]
+- 总是执行 plan
+- 当 `--diff` 时额外输出 diff（human：unified diff；json：diff 摘要）
+
+补充：
+- preview 为纯读取操作，不需要 `--yes`。
+
 ### 4.5 plan / diff
 agentpack plan
 - 输出将要写入哪些 target、哪些文件、何种操作（create/update/delete）

--- a/openspec/changes/add-preview-command/.openspec.yaml
+++ b/openspec/changes/add-preview-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/add-preview-command/proposal.md
+++ b/openspec/changes/add-preview-command/proposal.md
@@ -1,0 +1,14 @@
+# Change: Add `agentpack preview` composite command
+
+## Why
+`plan` and `diff` are often run together during review and troubleshooting. A single, AI-friendly command reduces friction while keeping the workflow read-only.
+
+## What Changes
+- Add `agentpack preview` which always runs `plan`, and optionally includes `diff` via `--diff`.
+- `preview` is read-only and never requires `--yes`.
+- In `--json`, return `data.plan` and (when `--diff`) `data.diff`, plus `warnings[]`.
+
+## Acceptance
+- `agentpack preview` runs without writing outputs.
+- `agentpack preview --json` is parseable and includes `data.plan`.
+- `agentpack preview --diff --json` includes both `data.plan` and `data.diff`.

--- a/openspec/changes/add-preview-command/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-preview-command/specs/agentpack-cli/spec.md
@@ -1,0 +1,17 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: Preview composite command
+The system SHALL provide `agentpack preview` as a read-only composite command that runs `plan` and optionally includes `diff` via `--diff`.
+
+#### Scenario: preview --json includes plan
+- **WHEN** the user runs `agentpack preview --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.plan.summary` exists
+
+#### Scenario: preview --diff --json includes plan and diff
+- **WHEN** the user runs `agentpack preview --diff --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.plan.summary` exists
+- **AND** `data.diff.summary` exists

--- a/openspec/changes/add-preview-command/tasks.md
+++ b/openspec/changes/add-preview-command/tasks.md
@@ -1,0 +1,12 @@
+## 1. Implementation
+
+### 1.1 CLI + behavior
+- [x] Add `agentpack preview [--diff]`.
+- [x] Always compute plan; when `--diff`, include diffs in human mode.
+
+### 1.2 JSON output
+- [x] In `--json`, output `data.plan` and (when `--diff`) `data.diff`.
+
+### 1.3 Tests + docs
+- [x] Add integration tests for `preview --json` and `preview --diff --json`.
+- [x] Update `docs/SPEC.md` to document `agentpack preview`.

--- a/tests/cli_preview.rs
+++ b/tests/cli_preview.rs
@@ -1,0 +1,69 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn preview_json_contains_plan_and_optional_diff() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let init = agentpack_in(tmp.path(), &["init"]);
+    assert!(init.status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: true
+      write_user_prompts: false
+      write_user_skills: false
+
+modules: []
+"#,
+        codex_home.display()
+    );
+    let manifest_path = tmp.path().join("repo").join("agentpack.yaml");
+    std::fs::write(&manifest_path, manifest).expect("write manifest");
+
+    let preview = agentpack_in(tmp.path(), &["--target", "codex", "preview", "--json"]);
+    assert!(preview.status.success());
+    let v = parse_stdout_json(&preview);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "preview");
+    assert!(v["data"]["plan"]["summary"].is_object());
+
+    let preview_diff = agentpack_in(
+        tmp.path(),
+        &["--target", "codex", "preview", "--diff", "--json"],
+    );
+    assert!(preview_diff.status.success());
+    let v = parse_stdout_json(&preview_diff);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "preview");
+    assert!(v["data"]["plan"]["summary"].is_object());
+    assert!(v["data"]["diff"]["summary"].is_object());
+}


### PR DESCRIPTION
Fixes #14.

## What
- Add `agentpack preview [--diff]` composite command.
- `preview` always computes plan; with `--diff` it includes diffs in human mode and a diff summary in JSON.

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `openspec validate add-preview-command --strict`
