### PR TITLE
feat(cli): add overlay path command

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -225,6 +225,11 @@ scope → 路径映射：
 兼容性：
 - `--project` 仍保留但已 deprecated（等价 `--scope project`）。
 
+补充（v0.3）：
+- `agentpack overlay path <module_id> [--scope global|machine|project]`
+  - human：打印 overlay 目录绝对路径
+  - json：`data.overlay_dir`
+
 ### 3.4 overlay 元数据（.agentpack）
 - overlay skeleton 会写入 `<overlay_dir>/.agentpack/baseline.json`，用于 overlay drift warnings（不参与部署）。
 - `.agentpack/` 目录为保留元数据目录：不会被 deploy 到 target roots；也不应被写入模块产物中。

--- a/openspec/changes/add-overlay-path-command/.openspec.yaml
+++ b/openspec/changes/add-overlay-path-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/add-overlay-path-command/proposal.md
+++ b/openspec/changes/add-overlay-path-command/proposal.md
@@ -1,0 +1,14 @@
+# Change: Add `agentpack overlay path`
+
+## Why
+AI agents and scripts often need to locate the overlay directory without duplicating path mapping logic (global/machine/project).
+
+## What Changes
+- Add `agentpack overlay path <module_id> --scope <global|machine|project>` (default: global).
+- The command is read-only:
+  - human: prints the absolute overlay directory path
+  - json: `data.overlay_dir`
+
+## Acceptance
+- Path mapping matches `overlay edit --scope`.
+- `--json` output is parseable and includes `data.overlay_dir`.

--- a/openspec/changes/add-overlay-path-command/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-overlay-path-command/specs/agentpack-cli/spec.md
@@ -1,0 +1,11 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: Overlay path helper
+The system SHALL provide `agentpack overlay path` to resolve the overlay directory for a module id and scope without performing writes.
+
+#### Scenario: overlay path --json outputs overlay_dir
+- **WHEN** the user runs `agentpack overlay path <module_id> --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.overlay_dir` is present

--- a/openspec/changes/add-overlay-path-command/tasks.md
+++ b/openspec/changes/add-overlay-path-command/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+### 1.1 CLI + behavior
+- [x] Add `agentpack overlay path` subcommand.
+- [x] Reuse the same scope-to-path mapping as `overlay edit --scope`.
+
+### 1.2 Tests + docs
+- [x] Add an integration test asserting the returned path for each scope.
+- [x] Update `docs/SPEC.md` to document `agentpack overlay path`.

--- a/tests/cli_overlay_path.rs
+++ b/tests/cli_overlay_path.rs
@@ -1,0 +1,111 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use sha2::Digest as _;
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn compute_project_id(project_root: &Path) -> String {
+    let basis = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf())
+        .to_string_lossy()
+        .to_string();
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(basis.as_bytes());
+    let hex = hex::encode(hasher.finalize());
+    hex.chars().take(16).collect()
+}
+
+#[test]
+fn overlay_path_resolves_global_machine_and_project_scopes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    let project_dir = home.join("project");
+    std::fs::create_dir_all(&project_dir).expect("create project dir");
+
+    let init = agentpack_in(home, &project_dir, &["init"]);
+    assert!(init.status.success());
+
+    let doctor = agentpack_in(
+        home,
+        &project_dir,
+        &["--target", "codex", "doctor", "--json"],
+    );
+    assert!(doctor.status.success());
+    let doctor_json = parse_stdout_json(&doctor);
+    let machine_id = doctor_json["data"]["machine_id"]
+        .as_str()
+        .expect("machine_id")
+        .to_string();
+
+    let module_id = "skill_test";
+    let repo_dir = home.join("repo");
+
+    let global = agentpack_in(
+        home,
+        &project_dir,
+        &["overlay", "path", module_id, "--scope", "global", "--json"],
+    );
+    assert!(global.status.success());
+    let global_json = parse_stdout_json(&global);
+    let global_dir = global_json["data"]["overlay_dir"]
+        .as_str()
+        .expect("overlay_dir");
+    assert_eq!(
+        PathBuf::from(global_dir),
+        repo_dir.join("overlays").join(module_id)
+    );
+
+    let machine = agentpack_in(
+        home,
+        &project_dir,
+        &["overlay", "path", module_id, "--scope", "machine", "--json"],
+    );
+    assert!(machine.status.success());
+    let machine_json = parse_stdout_json(&machine);
+    let machine_dir = machine_json["data"]["overlay_dir"]
+        .as_str()
+        .expect("overlay_dir");
+    assert_eq!(
+        PathBuf::from(machine_dir),
+        repo_dir
+            .join("overlays/machines")
+            .join(&machine_id)
+            .join(module_id)
+    );
+
+    let project = agentpack_in(
+        home,
+        &project_dir,
+        &["overlay", "path", module_id, "--scope", "project", "--json"],
+    );
+    assert!(project.status.success());
+    let project_json = parse_stdout_json(&project);
+    let project_dir_out = project_json["data"]["overlay_dir"]
+        .as_str()
+        .expect("overlay_dir");
+    let project_id = compute_project_id(&project_dir);
+    assert_eq!(
+        PathBuf::from(project_dir_out),
+        repo_dir
+            .join("projects")
+            .join(project_id)
+            .join("overlays")
+            .join(module_id)
+    );
+}


### PR DESCRIPTION
Fixes #15.

## What
- Add `agentpack overlay path <module_id> --scope <global|machine|project>`.
- Read-only helper: prints the resolved overlay directory (human) or `data.overlay_dir` (json).

## Validation
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `openspec validate add-overlay-path-command --strict`
