### PR TITLE
docs(bootstrap): update operator templates

### DIFF
--- a/openspec/changes/update-bootstrap-templates/.openspec.yaml
+++ b/openspec/changes/update-bootstrap-templates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/update-bootstrap-templates/proposal.md
+++ b/openspec/changes/update-bootstrap-templates/proposal.md
@@ -1,0 +1,16 @@
+# Change: Update bootstrap operator templates (AI-first guidance)
+
+## Why
+Bootstrap installs “operator assets” (Codex skill + Claude commands). Improving the guidance in these templates makes the record/score/explain/evolve loop easier to discover without changing core deploy behavior.
+
+## What Changes
+- Update `templates/codex/skills/agentpack-operator/SKILL.md` to include a recommended workflow using:
+  - `plan` / `preview`
+  - `deploy --apply`
+  - `record` / `score`
+  - `explain`
+  - `evolve propose`
+- Update existing Claude command templates to mention `evolve propose` (no new commands added).
+
+## Acceptance
+- Template changes are reflected in `agentpack bootstrap` outputs (no code behavior changes).

--- a/openspec/changes/update-bootstrap-templates/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-bootstrap-templates/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: Bootstrap templates guide the AI-first loop
+The system SHALL ship bootstrap operator templates that guide the user through an AI-first loop including `record`, `score`, `explain`, and `evolve propose`.
+
+#### Scenario: bootstrap Codex operator skill references evolve propose
+- **WHEN** the user runs `agentpack bootstrap`
+- **THEN** the installed Codex operator skill text includes guidance mentioning `agentpack evolve propose`

--- a/openspec/changes/update-bootstrap-templates/tasks.md
+++ b/openspec/changes/update-bootstrap-templates/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+### 1.1 Templates
+- [x] Update `templates/codex/skills/agentpack-operator/SKILL.md` content to cover record/score/explain/evolve propose workflow.
+- [x] Update relevant `templates/claude/commands/*.md` content to mention evolve usage.
+
+### 1.2 Validation
+- [x] Run `cargo test` to ensure no regressions (templates are embedded into the binary).
+- [x] Run `openspec validate update-bootstrap-templates --strict`.

--- a/templates/claude/commands/ap-status.md
+++ b/templates/claude/commands/ap-status.md
@@ -8,3 +8,7 @@ Check for drift (missing/modified/extra files) for the current project.
 
 !bash
 agentpack status --json
+
+If drift is found, consider:
+- `agentpack explain status --json` (why a file comes from which module/overlay)
+- `agentpack evolve propose --yes --json` (capture drift into overlays on a proposal branch)

--- a/templates/codex/skills/agentpack-operator/SKILL.md
+++ b/templates/codex/skills/agentpack-operator/SKILL.md
@@ -4,9 +4,12 @@ Operate Agentpack (plan/diff/deploy/status/rollback) safely and reproducibly.
 
 ## What you can do
 - Self-check environment: `agentpack doctor --json`
-- Preview changes: `agentpack plan --json` and `agentpack diff --json`
+- Preview changes: `agentpack preview --json` (or `agentpack plan --json` + `agentpack diff --json`)
 - Apply changes: `agentpack deploy --apply --yes --json`
 - Verify drift: `agentpack status --json`
+- Explain why things look the way they do: `agentpack explain plan|diff|status --json`
+- Record outcomes and score modules: `agentpack record` + `agentpack score`
+- Propose overlay updates from drift: `agentpack evolve propose --yes --json`
 - Roll back: `agentpack rollback --to <snapshot_id>`
 
 ## Safety rules
@@ -40,4 +43,24 @@ agentpack deploy --apply --yes --json
 ### 4) Status
 ```bash
 agentpack status --json
+```
+
+## AI-first feedback loop (optional)
+
+### Explain (optional)
+```bash
+agentpack explain status --json
+```
+
+### Record + score (optional)
+Record a lightweight execution event (example):
+```bash
+echo '{"module_id":"command:ap-deploy","success":true}' | agentpack record
+agentpack score
+```
+
+### Evolve overlays (optional)
+Capture drifted deployed files into overlays (creates a local git branch):
+```bash
+agentpack evolve propose --yes --json
 ```


### PR DESCRIPTION
Fixes #16.

## What
- Update Codex operator skill template to include the `record`/`score`/`explain`/`evolve propose` loop.
- Update Claude `/ap-status` template with next-step guidance for explain/evolve.

## Validation
- `cargo test`
- `openspec validate update-bootstrap-templates --strict`
