### PR TITLE
docs(openspec): fill spec purposes

### DIFF
--- a/openspec/specs/agentpack-cli/spec.md
+++ b/openspec/specs/agentpack-cli/spec.md
@@ -1,7 +1,7 @@
 # agentpack-cli Specification
 
 ## Purpose
-TBD - created by archiving change add-agentpack-v0-1. Update Purpose after archive.
+Define the user-facing CLI contract for `agentpack`: supported commands, stable `--json` envelope behavior, and composite helpers that reduce operational friction. This spec is intentionally API-like so automation (agents/scripts) can depend on consistent command semantics and machine-readable output.
 ## Requirements
 ### Requirement: Provide v0.1 command suite
 The system SHALL implement the v0.1 CLI commands described in `docs/SPEC.md`, including:

--- a/openspec/specs/agentpack/spec.md
+++ b/openspec/specs/agentpack/spec.md
@@ -1,7 +1,7 @@
 # agentpack Specification
 
 ## Purpose
-TBD - created by archiving change update-agentpack-v0-2. Update Purpose after archive.
+Define the core safety and state-management guarantees of Agentpack’s deployment engine. This spec covers properties that protect user-owned files (target manifests + safe deletes), enable recoverability (snapshots/rollback), and support multi-machine and multi-scope customization (sync and overlays). It also defines critical operator guardrails for automation, especially in `--json` mode.
 ## Requirements
 ### Requirement: Target Manifest
 `agentpack deploy --apply` MUST write a `.agentpack.manifest.json` file into each managed target root directory that records the managed files and their hashes.


### PR DESCRIPTION
## What
- Replace placeholder `Purpose` sections in OpenSpec specs with concise, v0.3-accurate descriptions.

## Validation
- `openspec validate --all --strict --no-interactive`
- `cargo test`
