### PR TITLE
chore: bump to v0.3.0 + refresh quickstart docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on *Keep a Changelog*, and this project adheres to Semantic 
 
 - TBD
 
+## [0.3.0] - 2026-01-11
+
+- New composite commands: `update` (lock + fetch) and `preview` (plan + optional diff).
+- Cache miss safety net: auto-fetch missing git checkouts when a lockfile exists.
+- Overlays UX: `overlay edit --scope global|machine|project` + helper `overlay path`.
+- Stronger AI-first safety: `--json` write commands require `--yes` (stable `E_CONFIRM_REQUIRED`).
+- Git hygiene: `doctor` warns about `.agentpack.manifest.json` in git repos; `doctor --fix` updates `.gitignore`.
+
 ## [0.2.0] - 2026-01-11
 
 - Deploy safety via per-target `.agentpack.manifest.json` (safe deletes + manifest-based drift).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentpack"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentpack"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.87.0"
 authors = ["liqiongyu <li@libiao.co>"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Agentpack is an AI-first local “asset control plane” for managing and deploy
 See product and technical design docs in `docs/`:
 - `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/SPEC.md`, `docs/BACKLOG.md`
 
-## Usage (v0.2)
+## Usage (v0.3)
 
 ```bash
 # Create (or open) your config repo at $AGENTPACK_HOME/repo
@@ -26,13 +26,11 @@ agentpack doctor
 agentpack add instructions local:modules/instructions/base --id instructions:base --tags base
 agentpack add command local:modules/claude-commands/ap-plan.md --id command:ap-plan --tags base --targets claude_code
 
-# Lock and fetch git sources
-agentpack lock
-agentpack fetch
+# Lock and fetch (composite)
+agentpack update
 
-# Plan / diff / deploy
-agentpack plan --profile default
-agentpack diff --profile default
+# Preview changes (composite: plan + optional diff)
+agentpack preview --profile default --diff
 agentpack deploy --profile default --apply --yes --json
 
 # Drift + rollback
@@ -42,7 +40,7 @@ agentpack rollback --to <snapshot_id>
 # AI-first operator assets
 agentpack bootstrap --target all --scope both
 
-# Observability + proposals (v0.2 minimal loop)
+# Observability + proposals (v0.2+ loop)
 agentpack record < event.json
 agentpack score
 agentpack explain plan

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@
 
 参考链接见文末。
 
-## 快速开始（v0.2 期望体验）
+## 快速开始（v0.3 期望体验）
 
 1) 初始化 agentpack repo（单一真源）：
   agentpack init
@@ -38,13 +38,11 @@
   agentpack add prompt local:modules/prompts/draftpr.md --id prompt:draftpr --tags work
   agentpack add command local:modules/claude-commands/ap-plan.md --id command:ap-plan --tags base --targets claude_code
 
-5) 锁版本并拉取依赖：
-  agentpack lock
-  agentpack fetch
+5) 锁版本并拉取依赖（组合命令）：
+  agentpack update
 
 6) 预览变更：
-  agentpack plan --profile work
-  agentpack diff --profile work
+  agentpack preview --profile work --diff
 
 7) 部署（会备份、可回滚；并写入 `.agentpack.manifest.json`）：
   agentpack deploy --profile work --apply --yes --json


### PR DESCRIPTION
Closes #29.

- Bump crate version to `0.3.0` (aligns with shipped v0.3 features).
- Refresh `README.md` + `docs/README.md` to use `agentpack update` / `agentpack preview`.
- Add `CHANGELOG.md` entry for v0.3.0.