### PR TITLE
docs: add v0.4 planning snapshot

### DIFF
--- a/docs/versions/v0.4/ARCHITECTURE.md
+++ b/docs/versions/v0.4/ARCHITECTURE.md
@@ -1,0 +1,69 @@
+# ARCHITECTURE.md (v0.4 draft)
+
+## 1. v0.4 架构目标
+
+v0.4 的目标不是“加更多功能”，而是把 v0.3 的实现平台化：
+- core/targets 解耦更清晰
+- 契约（contract）更稳定
+- 回归测试更系统化（conformance tests）
+
+## 2. 分层建议（不强制拆 crate，但建议按目录/模块清晰分层）
+
+- core（核心管道）
+  - config / lockfile / sources / overlays
+  - planner / differ
+  - apply / snapshot / rollback
+  - manifest（ownership/delete 的核心语义在这里 enforce）
+  - json_contract（envelope + error codes + schema 输出）
+
+- targets（目标适配层）
+  - codex adapter
+  - claude_code adapter
+  - common helpers（root 定义、ignore 规则）
+  - conformance test harness
+
+- cli
+  - 参数解析
+  - 调用 core/targets
+  - 输出 human 或 JSON
+
+## 3. TargetAdapter 边界（v0.4 要钉死）
+
+目标：新增 target 时，贡献者只需要实现“映射规则 + roots + 校验”，不用理解 core 细节。
+
+建议的 TargetAdapter 最小接口（概念）：
+- detect(ctx) -> DetectReport
+- roots(ctx) -> Vec<Root>
+- map(desired_state, ctx) -> MappedOutputs
+- validate(mapped_outputs, ctx) -> ValidationReport
+
+核心语义由 core enforce：
+- delete 只能针对 manifest 管控的 path
+- 没有 manifest 时，delete 必须跳过，并输出 warning
+- apply 必须写 per-root manifest
+- status/drift 基于 manifest 判定 missing/modified/extra
+
+## 4. Conformance Tests（v0.4 的质量护城河）
+
+新增/重构目标：
+- 一套通用测试，任何 target 都必须通过（至少 codex、claude_code）
+- 重点锁定“危险语义”：
+  1) 删除保护（ownership）
+  2) manifest 写入与读取
+  3) drift 分类（missing/modified/extra）
+  4) rollback 可恢复 create/update/delete
+  5) JSON 合约（schema_version、错误码）
+
+建议做法：
+- 以临时目录模拟 target roots
+- 通过真实管道跑 plan/apply/status
+- 用 golden tests 固化行为（尤其 plan 的排序/解释字段）
+
+## 5. AI-first 的平台化
+
+v0.4 建议把“AI-first”从文案变成接口能力：
+- `agentpack help --json`：输出命令树、参数、哪些是写命令（需 --yes）
+- `agentpack schema`：输出 JSON envelope 合约与关键命令 data 的字段定义
+- `preview --json --diff`：输出结构化 diff.files（让 AI 直接用于下一步判断/解释/生成 PR 描述）
+
+operator assets（bootstrap）要以这些稳定接口为基础，让 AI 更“闭环”。

--- a/docs/versions/v0.4/BACKLOG.md
+++ b/docs/versions/v0.4/BACKLOG.md
@@ -1,0 +1,45 @@
+# BACKLOG.md (v0.4 draft)
+
+优先级：
+- P0：v0.4 必须完成（平台化 & 合约固化）
+- P1：v0.4 强烈建议（质量护城河）
+- P2：可选（TUI/高级 evolve）
+- P3：v0.5+（新增 targets）
+
+## Milestone v0.4（P0/P1）
+
+### Epic A：Docs / Contract 对齐（P0）
+- [P0] A1. docs/ 作为最新文档；历史版本放 `docs/versions/`
+- [P0] A2. README/PRD/ARCH/SPEC/BACKLOG 的版本标识一致（Current as of v0.4）
+- [P0] A3. 版本号与 changelog 对齐（发布就绪）
+
+### Epic B：Guardrails 全覆盖（P0）
+- [P0] B1. 在代码中集中维护“写入命令集合”
+- [P0] B2. `--json` + 无 `--yes` → `E_CONFIRM_REQUIRED`（覆盖 init/overlay edit 等边角命令）
+- [P0] B3. guardrails tests 矩阵（每个写入命令至少 1 条）
+
+### Epic C：TargetAdapter 平台化（P0）
+- [P0] C1. 整理 targets 相关代码到 `targets/` 模块（减少 core/cli 中散落 if/else）
+- [P0] C2. 固化 TargetAdapter 接口与 registry
+- [P0] C3. core 统一 enforce 删除保护（manifest 规则）
+
+### Epic D：AI-first 自描述能力（P0）
+- [P0] D1. `agentpack help --json`（命令树 + 写入命令列表）
+- [P0] D2. `agentpack schema`（JSON envelope + 关键命令 data 字段）
+- [P0] D3. `preview --json --diff` 的 diff.files 结构 + size guard
+
+### Epic E：Bootstrap 打磨（P0）
+- [P0] E1. operator assets 覆盖 update/preview/status/explain/evolve propose
+- [P0] E2. operator assets 写入版本标记，status 提示陈旧
+- [P0] E3. bootstrap 行为与 guardrails 一致（json 必须 --yes）
+
+### Epic F：Conformance Tests（P1）
+- [P1] F1. conformance harness（对 codex/claude_code 跑通）
+- [P1] F2. CI 中要求 conformance tests 通过（防回归）
+- [P1] F3. 新增 target 的贡献者指南（TARGET_SDK / TARGET_CONFORMANCE）
+
+## Milestone v0.5+（P3）
+- 新 targets（Cursor/VS Code 等）：优先交给社区贡献或 v0.5+ 再做
+- 更强 overlays（patch/3-way merge）
+- registry/index 与模块发现
+- eval gate + evolve apply（更自动化但仍可控）

--- a/docs/versions/v0.4/PRD.md
+++ b/docs/versions/v0.4/PRD.md
@@ -1,0 +1,99 @@
+# PRD.md
+
+> Current as of **v0.4 (draft)** (2026-01-11). Historical snapshots live under `docs/versions/`.
+
+## 1. 背景与问题
+
+v0.3 已经把 Agentpack 的核心闭环跑通（可用、可回滚、可同步、AI-first）：
+- 单一真源（config repo）+ lockfile + cache
+- overlays（upstream → global → machine → project）
+- plan/diff/deploy + snapshot/rollback
+- per-root `.agentpack.manifest.json`（安全删除 + drift/status）
+- remote/sync（多机器一致性）
+- AI-first：`--json` 合约、guardrails、bootstrap（operator assets）
+- evolve：record/score/explain/evolve propose（提案式进化）
+
+因此 v0.4 **不急着新增 targets**。加 targets 永远有价值，但它更适合作为：
+- v0.5+ 的官方扩展；或
+- 社区 contributor 的增量贡献。
+
+v0.4 更重要的是把“平台基础”与 “AI-first bootstrap” 打磨到足够稳定，降低后续扩展成本与回归风险。
+
+## 2. v0.4 的主题：Platformize（平台化）
+
+v0.4 要解决三类“长期稳定性问题”：
+
+1) Contract 稳定
+- JSON 输出与错误码要足够稳定，AI 才能可靠编排。
+- schema/版本/兼容策略要明确，避免每次 refactor 都把上层工具打碎。
+
+2) Targets 抽象更清晰
+- 新增 target 不应需要修改一堆核心逻辑（engine/cli 里到处 if/else）。
+- 需要明确的 TargetAdapter 边界 + 一套 conformance tests（语义回归）。
+
+3) Operator assets（bootstrap）更“顺手”
+- 让 Codex/Claude 的 operator assets 不只是“能调用 agentpack”，而是能引导最佳实践路径：
+  - doctor → update → preview → (explain) → deploy
+  - status → evolve propose → review → deploy
+- 同时要更安全：默认只读/预览，apply 必须显式确认。
+
+## 3. v0.4 目标
+
+### P0（必须）
+A. Contract & Compatibility
+- 明确并固化：JSON envelope schema_version、错误码枚举、manifest/lockfile 的版本策略
+- `--json` 下所有“写入命令”统一要求 `--yes`（含 init、overlay edit 等边角命令）
+- `preview --json --diff` 输出结构增强（给 AI 直接消费）
+
+B. TargetAdapter 抽象与贡献者路径
+- 整理代码结构：targets 的路径/布局/校验集中在一个模块
+- 提供 Target SDK 文档与 conformance tests（至少 codex/claude_code 先跑通）
+- CI 中引入 conformance tests（防回归）
+
+C. AI-first bootstrap 打磨
+- operator assets 覆盖 update/preview/status/explain/evolve propose 的推荐路径
+- operator assets 写入版本标记，status 可提示“operator 已过期，需要 bootstrap 更新”
+- 提供自描述能力：`agentpack help --json` / `agentpack schema`（让 AI 学会怎么用）
+
+### P1（强烈建议）
+- `agentpack migrate`（仅当 schema 真的发生变化时；默认不需要）
+- 可选 TUI（只读）：profile/modules/targets 列表、preview/status 视图
+
+## 4. 非目标（v0.4 Out-of-scope）
+
+- 新增新的 targets（Cursor/VS Code 等）
+- MCP 全量生态管理（保持低优先级）
+- GUI
+- 自动无监督“自我进化直接落地”（依旧保持 proposal → review → deploy）
+
+## 5. 用户旅程（v0.4 期望更顺滑）
+
+Journey 1：新机器初始化（人/AI）
+1) `agentpack init`（或 init --clone）
+2) `agentpack doctor --fix`
+3) `agentpack update`
+4) `agentpack preview --diff`
+5) `agentpack deploy --apply`
+
+Journey 2：项目定制（overlay）
+1) `agentpack overlay edit --scope project`
+2) `agentpack preview --project <path> --diff`
+3) `agentpack deploy --apply`
+
+Journey 3：提案式进化（evolve propose）
+1) `agentpack status`
+2) `agentpack evolve propose --module <id>`
+3) review diff /（可选）eval gate
+4) `agentpack deploy --apply`
+
+## 6. 成功指标（v0.4）
+
+- 新增一个 target 的 PR：大部分改动只在 `targets/` 与 conformance tests，不需要理解 core 全部细节
+- AI 编排可靠性：AI 基于 `help --json` + `schema` + `preview --json --diff` 可稳定执行部署
+- 回归率下降：核心语义由 conformance tests 锁住
+
+## 7. 里程碑
+
+- v0.4.0：contract 固化 + adapter 抽象 + bootstrap 打磨 + conformance tests 初版
+- v0.4.1：conformance tests 完善 + docs/README 对齐 + 可选 migrate
+- v0.5.0：新增 targets（可由社区贡献优先）

--- a/docs/versions/v0.4/README.md
+++ b/docs/versions/v0.4/README.md
@@ -1,0 +1,23 @@
+# README.md (v0.4 plan)
+
+v0.4 的主题：**把基础打扎实**（contract + adapter 抽象 + conformance tests + operator UX），而不是急着加 targets。
+
+## v0.3 已具备的能力（基线）
+- config repo + lockfile + cache
+- overlays：upstream → global → machine → project
+- plan/diff/deploy + snapshot/rollback
+- per-root manifest（安全删除 + drift/status）
+- remote/sync（多机器）
+- AI-first：--json + guardrails + bootstrap operator assets
+- evolve：record/score/explain/evolve propose（提案式）
+
+## v0.4 要新增/固化的能力
+- 合约固化：错误码/JSON schema/版本策略
+- 自描述：help --json / schema
+- preview JSON diff 增强（diff.files）
+- TargetAdapter 平台化 + conformance tests
+- operator assets 版本标记与“过期提示”
+
+## 为什么 v0.4 不加 targets？
+- targets 增加不会改变核心价值，但会显著增加维护与回归成本。
+- v0.4 先把 adapter 贡献路径铺好，后续 targets 更适合交给社区 contributor。

--- a/docs/versions/v0.4/SPEC.md
+++ b/docs/versions/v0.4/SPEC.md
@@ -1,0 +1,120 @@
+# SPEC.md (v0.4 draft)
+
+> 本文描述 v0.4 计划固化的“契约与抽象”。v0.4 目标是 platformization，因此很多条目属于“行为约束/输出合约”，而不是新增业务功能。
+
+## 0. Versioning / Compatibility
+
+- JSON envelope：`schema_version`（破坏性变更才 bump）
+- manifest：`.agentpack.manifest.json` 内 `schema_version`
+- lockfile：`agentpack.lock.json` 内 `version`
+- config：`agentpack.yaml` 内 `version`
+
+兼容策略：
+- v0.4 必须兼容 v0.3 的 repo/lock/manifest（除非提供 migrate）
+- 若必须变更：
+  - 提供 `agentpack migrate --plan/--apply`（幂等）
+
+## 1. `--json` Guardrails（统一化）
+
+规则：
+- 当 `--json` 时，任何会写磁盘或修改 git 的命令必须要求 `--yes`
+- 否则：
+  - exit code != 0
+  - JSON `errors[0].code = "E_CONFIRM_REQUIRED"`
+
+写入命令集合（v0.4 明确列出并保持文档一致）：
+- init（含 init --clone）
+- add / remove
+- lock / fetch / update
+- deploy --apply
+- rollback --apply（或 rollback 默认 apply 的实现）
+- bootstrap
+- doctor --fix
+- overlay edit（所有 scope）
+- remote set / sync
+- record
+- evolve propose（若会创建 branch/写 overlay）
+
+## 2. JSON Envelope 合约（固定字段）
+
+所有 `--json` 输出必须包含：
+
+```json
+{
+  "schema_version": 1,
+  "ok": true,
+  "command": "plan",
+  "data": {},
+  "warnings": [],
+  "errors": []
+}
+```
+
+错误结构：
+
+```json
+{ "code": "E_SOMETHING", "message": "human readable", "details": { } }
+```
+
+要求：
+- 新增字段只能追加，不允许删除/重命名旧字段（除非 bump schema_version）
+- warnings/errors 的 code 枚举需写入文档（至少核心错误）
+
+## 3. 自描述能力（供 AI 学习与编排）
+
+新增/固化：
+
+### 3.1 `agentpack help --json`
+输出：
+- commands: 命令树（name、args、是否写入、是否支持 --json）
+- mutating_commands: 写入命令列表（与 Guardrails 集合一致）
+- notes: 推荐 best-practice 顺序（doctor → update → preview → deploy）
+
+### 3.2 `agentpack schema`
+输出：
+- JSON envelope schema
+- 关键命令（plan/diff/preview/status）data 字段说明（最小集合）
+
+## 4. `preview --json --diff` 结构增强
+
+当 `preview --json --diff` 时，data 需要包含：
+
+- plan: summary + changes（沿用现有）
+- diff:
+  - summary: {create, update, delete, noop}
+  - files: [
+      {
+        "target": "codex",
+        "root": "repo_root",
+        "path": "AGENTS.md",
+        "op": "update",
+        "before_hash": "sha256:...",
+        "after_hash": "sha256:...",
+        "unified": "@@ ...",          // 可选；需 size guard
+        "provenance": { ... }         // 可选；来源解释
+      }
+    ]
+
+size guard：
+- unified diff 文本若超过阈值（例如 100KB），应置空并给出 warning（避免 AI 上下文爆炸）
+
+## 5. TargetAdapter 抽象（最低要求）
+
+v0.4 要把新增 target 的最小工作量降到“实现 adapter + 过 conformance tests”。
+
+Adapter 必须能回答：
+- roots：哪些目录是 managed roots（每个 root 都写 manifest）
+- mapping：把 modules+overlays 的最终文件树映射到 root 下的目标路径
+- validation：frontmatter/结构最小校验（例如 Claude command 的 description/allowed-tools）
+
+核心语义由 core enforce：
+- delete 只能发生在 manifest.managed_files 内
+- manifest 缺失时，delete 必须跳过，并输出 `W_MANIFEST_MISSING_DELETE_SKIPPED`
+
+## 6. Bootstrap operator assets（更可维护）
+
+v0.4 对 operator assets 的要求：
+- 覆盖 update/preview/status/explain/evolve propose/deploy 的推荐路径
+- 每个 operator 文件写入版本标记（frontmatter 或注释）：
+  - `agentpack_version: x.y.z`
+- status 可提示“operator assets 版本落后，可运行 bootstrap 更新”

--- a/docs/versions/v0.4/TARGET_CONFORMANCE.md
+++ b/docs/versions/v0.4/TARGET_CONFORMANCE.md
@@ -1,0 +1,15 @@
+# TARGET_CONFORMANCE.md (v0.4 draft)
+
+v0.4 的质量护城河：任何 target 都必须通过 conformance tests。
+
+## 必须覆盖的语义
+1) 删除保护：plan 只能删除 manifest managed files
+2) apply 必写 per-root manifest
+3) status 能区分 missing/modified/extra（extra 不触发删除）
+4) rollback 可恢复 create/update/delete
+5) JSON envelope schema_version 与错误码一致
+
+## 推荐做法
+- 使用临时目录模拟 target roots（fixture）
+- 通过真实管道跑 plan/apply/status
+- 用 golden 输出固定住行为（尤其 plan 排序与 provenance 字段）

--- a/docs/versions/v0.4/TARGET_SDK.md
+++ b/docs/versions/v0.4/TARGET_SDK.md
@@ -1,0 +1,15 @@
+# TARGET_SDK.md (v0.4 draft)
+
+目标：让新增 target 的贡献者“照着做就行”。
+
+## 1) 新增 target 的最小 checklist
+1. 定义 target id（例如 cursor）
+2. 定义 roots（哪些目录算一个 managed root；每个 root 都写 manifest）
+3. 定义 mapping（modules -> paths）
+4. 最小 validate（结构/必需字段校验）
+5. 通过 conformance tests
+
+## 2) 贡献者应该避免的坑
+- 不要扫描用户目录并删除“非托管文件”
+- 不要依赖 symlink（默认 copy/render）
+- target-specific 的覆盖/优先级语义必须写进 docs


### PR DESCRIPTION
Refs #33.

Adds the v0.4 draft plan docs from GPT-pro as a historical snapshot under `docs/versions/v0.4/`.

No code changes.