### PR TITLE
feat(v0.4): full --json guardrails coverage

### DIFF
--- a/openspec/changes/v0-4-guardrails-full-coverage/.openspec.yaml
+++ b/openspec/changes/v0-4-guardrails-full-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/v0-4-guardrails-full-coverage/README.md
+++ b/openspec/changes/v0-4-guardrails-full-coverage/README.md
@@ -1,0 +1,3 @@
+# v0-4-guardrails-full-coverage
+
+v0.4: centralize mutating command set and require --yes in --json for all writes

--- a/openspec/changes/v0-4-guardrails-full-coverage/specs/agentpack-cli/spec.md
+++ b/openspec/changes/v0-4-guardrails-full-coverage/specs/agentpack-cli/spec.md
@@ -1,0 +1,14 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: Mutating command set is centrally maintained
+The system SHALL centrally define the set of “mutating” operations/command IDs (writes to disk or git) and use that single source of truth for:
+- enforcing `--json` + `--yes` guardrails, and
+- self-description output (e.g., `help --json`) when present.
+
+#### Scenario: lock --json without --yes is refused
+- **WHEN** the user runs `agentpack lock --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`

--- a/openspec/changes/v0-4-guardrails-full-coverage/specs/agentpack/spec.md
+++ b/openspec/changes/v0-4-guardrails-full-coverage/specs/agentpack/spec.md
@@ -1,0 +1,20 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: JSON-mode write confirmation covers all write-capable commands
+When invoked with `--json`, any command that performs writes (filesystem or git) MUST require an explicit `--yes` confirmation. If `--yes` is missing, the system MUST return a JSON error with a stable code `E_CONFIRM_REQUIRED` and MUST NOT perform the write.
+
+This includes (at minimum): `init`, `lock`, `fetch`, `overlay edit`, `remote set`, `sync`, `record`, and `rollback` (in addition to existing covered commands like `add/remove/update/deploy/bootstrap/doctor --fix/evolve propose`).
+
+#### Scenario: init --json without --yes is refused
+- **WHEN** the user runs `agentpack init --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`
+
+#### Scenario: overlay edit --json without --yes is refused
+- **WHEN** the user runs `agentpack overlay edit <moduleId> --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`


### PR DESCRIPTION
Closes #34.

- Extend `--json` write guardrails to cover `init`, `overlay edit`, and `rollback` (plus consistent command IDs like "deploy --apply").
- Introduce a centralized `MUTATING_COMMAND_IDS` list for v0.4 contract hardening.
- Add a matrix test covering common mutating commands returning `E_CONFIRM_REQUIRED` without `--yes`.
- Add OpenSpec deltas under `openspec/changes/v0-4-guardrails-full-coverage/`.