### PR TITLE
feat(v0.4): self-describing help --json + schema

### DIFF
--- a/openspec/changes/v0-4-help-json-schema/.openspec.yaml
+++ b/openspec/changes/v0-4-help-json-schema/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/v0-4-help-json-schema/README.md
+++ b/openspec/changes/v0-4-help-json-schema/README.md
@@ -1,0 +1,3 @@
+# v0-4-help-json-schema
+
+v0.4: add agentpack help --json and agentpack schema for self-description

--- a/openspec/changes/v0-4-help-json-schema/specs/agentpack-cli/spec.md
+++ b/openspec/changes/v0-4-help-json-schema/specs/agentpack-cli/spec.md
@@ -1,0 +1,24 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: help --json is self-describing
+The system SHALL provide `agentpack help --json` which emits machine-consumable documentation, including:
+- a `commands` list describing available commands/subcommands, and
+- `mutating_commands` listing mutating command IDs that require `--yes` in `--json` mode.
+
+#### Scenario: help --json returns commands and mutating_commands
+- **WHEN** the user runs `agentpack help --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.commands` exists
+- **AND** `data.mutating_commands` exists
+
+### Requirement: schema command documents JSON output contract
+The system SHALL provide `agentpack schema` which documents:
+- the JSON envelope schema, and
+- the minimum expected `data` fields for key read commands (at least: `plan`, `diff`, `preview`, `status`).
+
+#### Scenario: schema --json returns envelope schema
+- **WHEN** the user runs `agentpack schema --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.envelope` exists

--- a/tests/cli_help_schema.rs
+++ b/tests/cli_help_schema.rs
@@ -1,0 +1,55 @@
+use std::process::Command;
+
+fn run_agentpack(args: &[&str]) -> std::process::Output {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", tmp.path())
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn help_json_is_self_describing() {
+    let output = run_agentpack(&["help", "--json"]);
+    assert!(output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "help");
+    assert!(v["data"]["commands"].is_array());
+    assert!(v["data"]["commands"].as_array().unwrap().len() > 5);
+    assert!(v["data"]["mutating_commands"].is_array());
+    assert!(
+        v["data"]["mutating_commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|x| x == "init")
+    );
+    assert!(
+        v["data"]["mutating_commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|x| x == "deploy --apply")
+    );
+}
+
+#[test]
+fn schema_json_includes_envelope_shape() {
+    let output = run_agentpack(&["schema", "--json"]);
+    assert!(output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "schema");
+    assert_eq!(v["data"]["envelope"]["schema_version"], 1);
+    assert!(v["data"]["envelope"]["fields"].is_object());
+}


### PR DESCRIPTION
Closes #35.

- Add `agentpack help --json` for machine-consumable self-description (includes `mutating_commands`).
- Add `agentpack schema --json` describing the JSON envelope and key command `data` fields.
- Disable clap’s built-in `help` subcommand so `agentpack help` can be a real command.
- Add tests for both commands.
- Add OpenSpec deltas under `openspec/changes/v0-4-help-json-schema/`.