### PR TITLE
feat(v0.4): structured preview JSON diff.files

### DIFF
--- a/openspec/changes/v0-4-preview-json-diff-files/.openspec.yaml
+++ b/openspec/changes/v0-4-preview-json-diff-files/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/v0-4-preview-json-diff-files/README.md
+++ b/openspec/changes/v0-4-preview-json-diff-files/README.md
@@ -1,0 +1,3 @@
+# v0-4-preview-json-diff-files
+
+v0.4: preview --json --diff emits structured diff.files with size guard

--- a/openspec/changes/v0-4-preview-json-diff-files/specs/agentpack-cli/spec.md
+++ b/openspec/changes/v0-4-preview-json-diff-files/specs/agentpack-cli/spec.md
@@ -1,0 +1,16 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: preview --json --diff includes structured per-file diffs
+When invoked as `agentpack preview --json --diff`, the system SHALL include a structured diff payload under `data.diff`:
+- `summary` (counts)
+- `files[]` with, at minimum: `target`, `root`, `path`, `op`, `before_hash`, `after_hash`
+
+`unified` diffs are optional and MAY be omitted; if omitted due to size limits, the system SHOULD add a warning.
+
+#### Scenario: preview --json --diff includes diff.files
+- **WHEN** the user runs `agentpack preview --json --diff`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.diff.summary` exists
+- **AND** `data.diff.files` exists

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,6 +16,8 @@ use crate::source::parse_source_spec;
 use crate::state::latest_snapshot;
 use crate::store::Store;
 
+const UNIFIED_DIFF_MAX_BYTES: usize = 100 * 1024;
+
 const TEMPLATE_CODEX_OPERATOR_SKILL: &str =
     include_str!("../templates/codex/skills/agentpack-operator/SKILL.md");
 const TEMPLATE_CLAUDE_AP_PLAN: &str = include_str!("../templates/claude/commands/ap-plan.md");
@@ -753,7 +755,7 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
             let targets = selected_targets(&engine.manifest, &cli.target)?;
             let render = engine.desired_state(&cli.profile, &cli.target)?;
             let desired = render.desired;
-            let warnings = render.warnings;
+            let mut warnings = render.warnings;
             let roots = render.roots;
             let managed_paths_from_manifest =
                 crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
@@ -781,9 +783,11 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
                     },
                 });
                 if *diff {
+                    let files = preview_diff_files(&plan, &desired, &roots, &mut warnings)?;
                     data["diff"] = serde_json::json!({
                         "changes": plan.changes,
                         "summary": plan.summary,
+                        "files": files,
                     });
                 }
 
@@ -1953,6 +1957,92 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[derive(serde::Serialize)]
+struct PreviewDiffFile {
+    target: String,
+    root: String,
+    path: String,
+    op: crate::deploy::Op,
+    before_hash: Option<String>,
+    after_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unified: Option<String>,
+}
+
+fn preview_diff_files(
+    plan: &crate::deploy::PlanResult,
+    desired: &crate::deploy::DesiredState,
+    roots: &[crate::targets::TargetRoot],
+    warnings: &mut Vec<String>,
+) -> anyhow::Result<Vec<PreviewDiffFile>> {
+    let mut out = Vec::new();
+
+    for c in &plan.changes {
+        let abs_path = std::path::PathBuf::from(&c.path);
+        let root_idx = best_root_idx(roots, &c.target, &abs_path);
+        let root = root_idx
+            .and_then(|idx| roots.get(idx))
+            .map(|r| r.root.display().to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+
+        let rel_path = root_idx
+            .and_then(|idx| roots.get(idx))
+            .and_then(|r| abs_path.strip_prefix(&r.root).ok())
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| c.path.clone());
+
+        let before_hash = c.before_sha256.as_ref().map(|h| format!("sha256:{h}"));
+        let after_hash = c.after_sha256.as_ref().map(|h| format!("sha256:{h}"));
+
+        let mut unified: Option<String> = None;
+        if matches!(c.op, crate::deploy::Op::Create | crate::deploy::Op::Update) {
+            let before_bytes = std::fs::read(&abs_path).unwrap_or_default();
+            let tp = TargetPath {
+                target: c.target.clone(),
+                path: abs_path.clone(),
+            };
+            if let Some(df) = desired.get(&tp) {
+                match (
+                    std::str::from_utf8(&before_bytes).ok(),
+                    std::str::from_utf8(&df.bytes).ok(),
+                ) {
+                    (Some(from), Some(to)) => {
+                        let from_name = format!("a/{rel_path}");
+                        let to_name = format!("b/{rel_path}");
+                        let diff = unified_diff(from, to, &from_name, &to_name);
+                        if diff.len() > UNIFIED_DIFF_MAX_BYTES {
+                            warnings.push(format!(
+                                "preview diff omitted for {} {} (over {} bytes)",
+                                c.target, rel_path, UNIFIED_DIFF_MAX_BYTES
+                            ));
+                        } else {
+                            unified = Some(diff);
+                        }
+                    }
+                    _ => {
+                        warnings.push(format!(
+                            "preview diff omitted for {} {} (binary or non-utf8)",
+                            c.target, rel_path
+                        ));
+                    }
+                }
+            }
+        }
+
+        out.push(PreviewDiffFile {
+            target: c.target.clone(),
+            root,
+            path: rel_path,
+            op: c.op.clone(),
+            before_hash,
+            after_hash,
+            unified,
+        });
+    }
+
+    Ok(out)
 }
 
 fn filter_managed(

--- a/tests/cli_preview.rs
+++ b/tests/cli_preview.rs
@@ -66,4 +66,5 @@ modules: []
     assert_eq!(v["command"], "preview");
     assert!(v["data"]["plan"]["summary"].is_object());
     assert!(v["data"]["diff"]["summary"].is_object());
+    assert!(v["data"]["diff"]["files"].is_array());
 }


### PR DESCRIPTION
Closes #36.

- Extend `agentpack preview --json --diff` to emit `data.diff.files[]` entries (target/root/path/op + hashes, optional unified diff).
- Add a size guard for unified diffs to avoid large JSON payloads.
- Keep existing `data.diff.summary`/`data.diff.changes` for compatibility.
- Update tests and add OpenSpec change `v0-4-preview-json-diff-files`.