### PR TITLE
refactor(v0.4): TargetAdapter registry

### DIFF
--- a/openspec/changes/v0-4-target-adapter-registry/.openspec.yaml
+++ b/openspec/changes/v0-4-target-adapter-registry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/v0-4-target-adapter-registry/README.md
+++ b/openspec/changes/v0-4-target-adapter-registry/README.md
@@ -1,0 +1,3 @@
+# v0-4-target-adapter-registry
+
+v0.4: introduce TargetAdapter registry to centralize target rendering

--- a/openspec/changes/v0-4-target-adapter-registry/specs/agentpack/spec.md
+++ b/openspec/changes/v0-4-target-adapter-registry/specs/agentpack/spec.md
@@ -1,0 +1,11 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Target rendering is routed via a TargetAdapter registry
+The system SHALL centralize target-specific rendering and validation behind a `TargetAdapter` abstraction, so adding a new target does not require scattering conditional logic across the engine and CLI.
+
+#### Scenario: Known targets are resolved via registry
+- **GIVEN** the system supports the `codex` and `claude_code` targets
+- **WHEN** the engine renders desired state for a selected target
+- **THEN** the corresponding target adapter is used to compute target roots and desired output paths

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod project;
 pub mod source;
 pub mod state;
 pub mod store;
+pub mod target_adapters;
 pub mod target_manifest;
 pub mod targets;
 pub mod validate;

--- a/src/target_adapters.rs
+++ b/src/target_adapters.rs
@@ -1,0 +1,64 @@
+use crate::deploy::DesiredState;
+use crate::engine::Engine;
+use crate::targets::TargetRoot;
+
+pub trait TargetAdapter {
+    fn id(&self) -> &'static str;
+
+    fn render(
+        &self,
+        engine: &Engine,
+        modules: &[&crate::config::Module],
+        desired: &mut DesiredState,
+        warnings: &mut Vec<String>,
+        roots: &mut Vec<TargetRoot>,
+    ) -> anyhow::Result<()>;
+}
+
+struct CodexAdapter;
+struct ClaudeCodeAdapter;
+
+impl TargetAdapter for CodexAdapter {
+    fn id(&self) -> &'static str {
+        "codex"
+    }
+
+    fn render(
+        &self,
+        engine: &Engine,
+        modules: &[&crate::config::Module],
+        desired: &mut DesiredState,
+        warnings: &mut Vec<String>,
+        roots: &mut Vec<TargetRoot>,
+    ) -> anyhow::Result<()> {
+        engine.render_codex(modules, desired, warnings, roots)
+    }
+}
+
+impl TargetAdapter for ClaudeCodeAdapter {
+    fn id(&self) -> &'static str {
+        "claude_code"
+    }
+
+    fn render(
+        &self,
+        engine: &Engine,
+        modules: &[&crate::config::Module],
+        desired: &mut DesiredState,
+        warnings: &mut Vec<String>,
+        roots: &mut Vec<TargetRoot>,
+    ) -> anyhow::Result<()> {
+        engine.render_claude_code(modules, desired, warnings, roots)
+    }
+}
+
+pub fn adapter_for(target: &str) -> Option<&'static dyn TargetAdapter> {
+    static CODEX: CodexAdapter = CodexAdapter;
+    static CLAUDE: ClaudeCodeAdapter = ClaudeCodeAdapter;
+
+    match target {
+        "codex" => Some(&CODEX),
+        "claude_code" => Some(&CLAUDE),
+        _ => None,
+    }
+}


### PR DESCRIPTION
Closes #37.

- Introduce `TargetAdapter` + `adapter_for()` registry for routing target rendering.
- Wire `Engine::desired_state` to call adapters instead of hard-coded match.
- Keep existing codex/claude implementation, now accessed via adapters.
- Add OpenSpec change `v0-4-target-adapter-registry`.