### PR TITLE
test(v0.4): conformance suite + rollback snapshot restore

### DIFF
--- a/docs/TARGET_CONFORMANCE.md
+++ b/docs/TARGET_CONFORMANCE.md
@@ -1,0 +1,15 @@
+# TARGET_CONFORMANCE.md
+
+Conformance tests are the quality bar for targets.
+
+## Required semantics
+1. Delete protection: plan/apply only delete manifest-managed paths.
+2. Manifest: apply writes per-root `.agentpack.manifest.json`.
+3. Drift: status distinguishes `missing`/`modified`/`extra` (extras are not auto-deleted).
+4. Rollback: restores create/update/delete effects.
+5. JSON contract: envelope fields and key error codes remain stable.
+
+## Recommended harness approach
+- Use temp directories as fake target roots.
+- Run the real pipeline (`deploy --apply`, `status`, `rollback`) against those roots.
+- Keep tests hermetic: avoid writing to real `~/.codex` or `~/.claude`.

--- a/docs/TARGET_SDK.md
+++ b/docs/TARGET_SDK.md
@@ -1,0 +1,15 @@
+# TARGET_SDK.md
+
+Goal: make adding a new target predictable and reviewable.
+
+## New target checklist
+1. Pick a stable target id (e.g., `cursor`).
+2. Define managed roots (each root MUST write `.agentpack.manifest.json`).
+3. Define mapping rules (modules → output paths under roots).
+4. Define minimal validation (structure/frontmatter requirements).
+5. Pass conformance tests (see `docs/TARGET_CONFORMANCE.md`).
+
+## Footguns to avoid
+- Never delete unmanaged files (only delete manifest-managed paths).
+- Don’t rely on symlinks (default is copy/render).
+- Keep target-specific behavior documented and tested.

--- a/openspec/changes/v0-4-conformance-tests/.openspec.yaml
+++ b/openspec/changes/v0-4-conformance-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-11

--- a/openspec/changes/v0-4-conformance-tests/README.md
+++ b/openspec/changes/v0-4-conformance-tests/README.md
@@ -1,0 +1,3 @@
+# v0-4-conformance-tests
+
+v0.4: add target conformance tests harness and docs

--- a/openspec/changes/v0-4-conformance-tests/specs/agentpack/spec.md
+++ b/openspec/changes/v0-4-conformance-tests/specs/agentpack/spec.md
@@ -1,0 +1,15 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Target conformance tests cover critical safety semantics
+The repository SHALL include conformance tests that validate critical cross-target safety semantics, including:
+- delete protection (only manifest-managed paths can be deleted)
+- per-root manifest write/read
+- drift classification (missing/modified/extra)
+- rollback restoring previous outputs
+
+#### Scenario: conformance tests exist for built-in targets
+- **GIVEN** built-in targets `codex` and `claude_code`
+- **WHEN** the test suite is run
+- **THEN** conformance tests execute these semantics for both targets

--- a/tests/conformance_targets.rs
+++ b/tests/conformance_targets.rs
@@ -1,0 +1,395 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn git_in(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run git")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn write_module(repo_dir: &Path, rel_dir: &str, filename: &str, content: &str) -> PathBuf {
+    let dir = repo_dir.join(rel_dir);
+    std::fs::create_dir_all(&dir).expect("create module dir");
+    let path = dir.join(filename);
+    std::fs::write(&path, content).expect("write module file");
+    path
+}
+
+fn write_manifest(repo_dir: &Path, codex_home: &Path) {
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{codex_home}'
+      write_agents_global: true
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+  claude_code:
+    mode: files
+    scope: project
+    options:
+      write_repo_commands: true
+      write_user_commands: false
+
+modules:
+  - id: instructions:base
+    type: instructions
+    source:
+      local_path:
+        path: modules/instructions/base
+    enabled: true
+    tags: ["base"]
+    targets: ["codex"]
+  - id: prompt:hello
+    type: prompt
+    source:
+      local_path:
+        path: modules/prompts/hello
+    enabled: true
+    tags: ["base"]
+    targets: ["codex"]
+  - id: command:hello
+    type: command
+    source:
+      local_path:
+        path: modules/claude-commands/hello
+    enabled: true
+    tags: ["base"]
+    targets: ["claude_code"]
+"#,
+        codex_home = codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest).expect("write manifest");
+}
+
+fn list_all_files(root: &Path) -> Vec<String> {
+    fn walk(dir: &Path, out: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let path = e.path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else {
+                out.push(path.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    out.sort();
+    out
+}
+
+#[test]
+fn conformance_codex_smoke() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+    let workspace = tmp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    assert!(git_in(&workspace, &["init"]).status.success());
+
+    let init = agentpack_in(home, &workspace, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    let codex_home = workspace.join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+    write_manifest(&repo_dir, &codex_home);
+
+    write_module(
+        &repo_dir,
+        "modules/instructions/base",
+        "AGENTS.md",
+        "# Base instructions\n",
+    );
+    write_module(
+        &repo_dir,
+        "modules/prompts/hello",
+        "hello.md",
+        "Hello prompt v1\n",
+    );
+
+    // First deployment: manifests exist.
+    let deploy1 = agentpack_in(
+        home,
+        &workspace,
+        &["--target", "codex", "deploy", "--apply", "--yes", "--json"],
+    );
+    assert!(deploy1.status.success());
+    let deploy1_json = parse_stdout_json(&deploy1);
+    let snapshot1 = deploy1_json["data"]["snapshot_id"]
+        .as_str()
+        .expect("snapshot_id")
+        .to_string();
+
+    assert!(codex_home.join(".agentpack.manifest.json").exists());
+    assert!(
+        codex_home
+            .join("prompts")
+            .join(".agentpack.manifest.json")
+            .exists()
+    );
+
+    // Drift classification: modified + extra.
+    let changes = deploy1_json["data"]["changes"]
+        .as_array()
+        .expect("changes array");
+    let deployed_prompt = changes
+        .iter()
+        .filter_map(|c| c["path"].as_str())
+        .map(PathBuf::from)
+        .find(|p| p.file_name().and_then(|s| s.to_str()) == Some("hello.md"))
+        .expect("deployed prompt path");
+    assert!(
+        deployed_prompt.exists(),
+        "deployed prompt missing at {}; files={:?}",
+        deployed_prompt.display(),
+        list_all_files(&codex_home)
+    );
+    let v1 = std::fs::read_to_string(&deployed_prompt).expect("read deployed prompt");
+
+    let unmanaged = codex_home.join("prompts").join("unmanaged.txt");
+    std::fs::write(&unmanaged, "unmanaged\n").expect("write unmanaged");
+    std::fs::write(&deployed_prompt, "local drift\n").expect("write drift");
+
+    let status = agentpack_in(home, &workspace, &["--target", "codex", "status", "--json"]);
+    assert!(status.status.success());
+    let status_json = parse_stdout_json(&status);
+    let drift = status_json["data"]["drift"]
+        .as_array()
+        .expect("drift array");
+    assert!(drift.iter().any(|d| d["kind"] == "modified"));
+    assert!(drift.iter().any(|d| d["kind"] == "extra"));
+
+    // Safe apply: should not delete unmanaged files.
+    let deploy_fix = agentpack_in(
+        home,
+        &workspace,
+        &["--target", "codex", "deploy", "--apply", "--yes", "--json"],
+    );
+    assert!(deploy_fix.status.success());
+    assert!(unmanaged.exists());
+
+    // Rollback: change desired outputs via module edit, deploy again, then rollback.
+    write_module(
+        &repo_dir,
+        "modules/prompts/hello",
+        "hello.md",
+        "Hello prompt v2\n",
+    );
+    let deploy2 = agentpack_in(
+        home,
+        &workspace,
+        &["--target", "codex", "deploy", "--apply", "--yes", "--json"],
+    );
+    assert!(deploy2.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&deployed_prompt).expect("read deployed prompt"),
+        "Hello prompt v2\n"
+    );
+
+    let rollback = agentpack_in(
+        home,
+        &workspace,
+        &[
+            "--target",
+            "codex",
+            "rollback",
+            "--to",
+            snapshot1.as_str(),
+            "--yes",
+            "--json",
+        ],
+    );
+    assert!(rollback.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&deployed_prompt).expect("read deployed prompt"),
+        v1
+    );
+    assert!(unmanaged.exists());
+}
+
+#[test]
+fn conformance_claude_code_smoke() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+    let workspace = tmp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    assert!(git_in(&workspace, &["init"]).status.success());
+
+    let init = agentpack_in(home, &workspace, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    let codex_home = workspace.join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+    write_manifest(&repo_dir, &codex_home);
+
+    write_module(
+        &repo_dir,
+        "modules/claude-commands/hello",
+        "hello.md",
+        r#"---
+description: "Hello command"
+allowed-tools:
+  - Bash("echo hi")
+---
+
+Hello v1
+"#,
+    );
+
+    let deploy1 = agentpack_in(
+        home,
+        &workspace,
+        &[
+            "--target",
+            "claude_code",
+            "deploy",
+            "--apply",
+            "--yes",
+            "--json",
+        ],
+    );
+    assert!(deploy1.status.success());
+    let deploy1_json = parse_stdout_json(&deploy1);
+    let snapshot1 = deploy1_json["data"]["snapshot_id"]
+        .as_str()
+        .expect("snapshot_id")
+        .to_string();
+
+    let commands_dir = workspace.join(".claude").join("commands");
+    assert!(commands_dir.join(".agentpack.manifest.json").exists());
+
+    let changes = deploy1_json["data"]["changes"]
+        .as_array()
+        .expect("changes array");
+    let deployed_cmd = changes
+        .iter()
+        .filter_map(|c| c["path"].as_str())
+        .map(PathBuf::from)
+        .find(|p| p.file_name().and_then(|s| s.to_str()) == Some("hello.md"))
+        .expect("deployed command path");
+    let commands_dir = workspace.join(".claude").join("commands");
+    assert!(
+        deployed_cmd.exists(),
+        "deployed command missing at {}; files={:?}",
+        deployed_cmd.display(),
+        list_all_files(&commands_dir)
+    );
+    let v1 = std::fs::read_to_string(&deployed_cmd).expect("read deployed command");
+
+    let unmanaged = commands_dir.join("unmanaged.txt");
+    std::fs::write(&unmanaged, "unmanaged\n").expect("write unmanaged");
+    std::fs::write(&deployed_cmd, "local drift\n").expect("write drift");
+
+    let status = agentpack_in(
+        home,
+        &workspace,
+        &["--target", "claude_code", "status", "--json"],
+    );
+    assert!(status.status.success());
+    let status_json = parse_stdout_json(&status);
+    let drift = status_json["data"]["drift"]
+        .as_array()
+        .expect("drift array");
+    assert!(drift.iter().any(|d| d["kind"] == "modified"));
+    assert!(drift.iter().any(|d| d["kind"] == "extra"));
+
+    let deploy_fix = agentpack_in(
+        home,
+        &workspace,
+        &[
+            "--target",
+            "claude_code",
+            "deploy",
+            "--apply",
+            "--yes",
+            "--json",
+        ],
+    );
+    assert!(deploy_fix.status.success());
+    assert!(unmanaged.exists());
+
+    write_module(
+        &repo_dir,
+        "modules/claude-commands/hello",
+        "hello.md",
+        r#"---
+description: "Hello command"
+allowed-tools:
+  - Bash("echo hi")
+---
+
+Hello v2
+"#,
+    );
+    let deploy2 = agentpack_in(
+        home,
+        &workspace,
+        &[
+            "--target",
+            "claude_code",
+            "deploy",
+            "--apply",
+            "--yes",
+            "--json",
+        ],
+    );
+    assert!(deploy2.status.success());
+    assert!(
+        std::fs::read_to_string(&deployed_cmd)
+            .expect("read deployed command")
+            .contains("Hello v2")
+    );
+
+    let rollback = agentpack_in(
+        home,
+        &workspace,
+        &[
+            "--target",
+            "claude_code",
+            "rollback",
+            "--to",
+            snapshot1.as_str(),
+            "--yes",
+            "--json",
+        ],
+    );
+    assert!(rollback.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&deployed_cmd).expect("read deployed command"),
+        v1
+    );
+    assert!(unmanaged.exists());
+}


### PR DESCRIPTION
Implements v0.4 epic #38 (target conformance).

- Adds hermetic conformance integration tests for the built-in targets: codex and claude_code.
- Fixes rollback to restore the target snapshot outputs even if later drift/deploys occurred (stores per-snapshot state for managed outputs and manifests).
- Adds docs/TARGET_SDK.md and docs/TARGET_CONFORMANCE.md.
- Adds OpenSpec delta: openspec/changes/v0-4-conformance-tests/.

Closes #38.
