### PR TITLE
feat(v0.5): module_fs_key for overlays and store

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -201,9 +201,13 @@ Schema（v1，示例）：
 ### 3.1 覆盖层级与优先级
 最终合成顺序（低 -> 高）：
 1) upstream module（repo 本地目录或 cache 中）
-2) global overlay（repo/overlays/<module_id>/...）
-3) machine overlay（repo/overlays/machines/<machine_id>/<module_id>/...）
-4) project overlay（repo/projects/<project_id>/overlays/<module_id>/...）
+2) global overlay（repo/overlays/<module_fs_key>/...）
+3) machine overlay（repo/overlays/machines/<machine_id>/<module_fs_key>/...）
+4) project overlay（repo/projects/<project_id>/overlays/<module_fs_key>/...）
+
+其中：
+- `module_fs_key` 是从 `module_id` 派生的、跨平台安全的目录名（会做字符规整，并附带短 hash 以避免碰撞）。
+- CLI 与 manifest 中仍使用原始 `module_id`；`module_fs_key` 仅用于磁盘寻址。
 
 ### 3.2 overlay 表达形式（v0.2）
 采用“文件覆盖”模型：
@@ -218,9 +222,9 @@ agentpack overlay edit <module_id> [--scope global|machine|project] 会：
 - 保存后 deploy 生效
 
 scope → 路径映射：
-- global: `repo/overlays/<module_id>/...`
-- machine: `repo/overlays/machines/<machine_id>/<module_id>/...`
-- project: `repo/projects/<project_id>/overlays/<module_id>/...`
+- global: `repo/overlays/<module_fs_key>/...`
+- machine: `repo/overlays/machines/<machine_id>/<module_fs_key>/...`
+- project: `repo/projects/<project_id>/overlays/<module_fs_key>/...`
 
 兼容性：
 - `--project` 仍保留但已 deprecated（等价 `--scope project`）。

--- a/docs/versions/v0.4/expert_review_result.md
+++ b/docs/versions/v0.4/expert_review_result.md
@@ -1,0 +1,162 @@
+我把仓库按“AI-native 工程 / Rust 工程质量 / 自进化 agent 闭环”三个视角，把核心链路（`engine -> desired_state -> plan/diff -> apply(snapshot/rollback) -> status/drift -> record/score -> evolve propose`）以及关键模块（`overlay/store/lockfile/target_manifest`）通读了一遍，也扫了测试与 `docs/SPEC.md` / `openspec` 的契约设计。下面是评审结论和我会优先改的点（含具体落点到文件/函数级别）。我没有在当前环境里编译运行（你仓库要求 Rust 1.87 + edition 2024），以下结论来自静态阅读实现与测试用例。
+
+第一印象与总体评价
+这个仓库的“产品形态”非常清晰：你不是在做一个 dotfiles 管理器，而是在做一个面向 AI 工具链（Codex/Claude Code）的本地资产控制平面。manifest/lockfile/overlays/snapshots/target manifest 的组合，能把“可审计（repo）/可复现（cache）/可回滚（state）”三层分得很干净，且在 CLI 层把 `--json` 当成 API 合同来维护，这是 AI-native 工程里很难得的“对机器友好 + 对人安全”的平衡。Codex 会读取 `AGENTS.md` 的发现链条、Skill 的标准化、Claude slash command 对 `allowed-tools` 的约束，你都把它们产品化成可部署资产，并通过 `bootstrap` 把“AI 会用 agentpack”闭环补上了。([OpenAI Developers][1])
+
+你在文档里强调“不要依赖 symlink，统一 copy/render”也非常务实：Codex 侧确实存在 prompts/skills 对 symlink 不生效的反馈（包括 Windows 上 junction/symlink 不被识别的 case），Claude 生态也有类似的 `.claude`/发现链条相关问题。你用复制生成真实文件，属于“工具发现稳定性优先”的正确取舍。([GitHub][2])
+
+亮点（做得很对，建议保持并继续强化）
+
+1. `--json` 的“可机器依赖性”做得像 API：`help --json` / `schema --json` / 统一 envelope / 明确的 `E_CONFIRM_REQUIRED`，对 agent 自动化非常关键。未来你要接 MCP/Agents SDK 也更顺。([OpenAI Developers][3])
+2. “安全删除”的设计很硬：通过每个 target root 的 `.agentpack.manifest.json` 记录托管文件，删除只删托管集合，`status` 也能基于 manifest 做 drift/extra/missing 分类，这比很多“粗暴覆盖”工具靠谱太多。
+3. snapshots/rollback 思路正确：snapshot 保存“部署时写入内容”，rollback 不依赖“当前磁盘状态还完整”，这点对真实环境非常重要（你 changelog 里也强调了）。
+4. overlay 4 层优先级 + drift warnings 是正确方向：你用 baseline manifest + upstream hash 提醒“上游变了，你的 overlay 可能需要 review”，这是维护可持续性关键。
+5. 验证规则落地到了 `validate`：Claude command frontmatter / allowed-tools / Bash 约束校验，属于“把安全规则写进编译器”的做法。Claude slash command 的约束本来就要求在使用 bash 相关能力时声明 allowlist，你在工具侧强校验是非常 AI-native 的防呆。([Claude Code][4])
+
+我会优先改的“硬问题”（P0：不改迟早踩坑）
+
+P0-1：module_id 直接当目录名，会引入跨平台问题 + 路径逃逸风险（overlay、store 都受影响）
+现状：多处用 `join(&module.id)` 把 module_id 直接落到文件系统路径里（overlay 目录、source layer 检测等）。你虽然有 `sanitize_module_id()`，但主要用于 store/cache 路径和少数地方，overlay 相关并没有统一走安全映射。
+问题有两类：
+A) Windows 文件名非法字符：你的默认 module id 形态是 `type:name`，包含 `:`。Windows 不允许 `:` 出现在文件/目录名里（除盘符后的那个）。这意味着 `agentpack overlay edit instructions:base` 在 Windows 上会直接创建目录失败（而 CI 虽然跑 Windows，但目前测试基本没覆盖 `:` 这种真实 id）。
+B) 路径逃逸/碰撞：只要 module_id 里出现 `/`、`..`、反斜杠等，你的 `PathBuf::join()` 就可能产生目录穿越式的“逃逸”路径；真实世界里这类问题经常以安全 advisories 的形式出现。即便这是本地工具，配置 repo 也可能来自多人协作/同步，应该把“module_id 是数据，不是路径”作为硬约束。([OWASP Foundation][5])
+
+建议改法（我认为这是最优先、也最值得一次性做对的改动）：
+
+1. 定义一个“稳定、跨平台、安全、无碰撞”的 module filesystem key，并全局替换所有“把 module_id 当路径”的地方：
+
+* 形态建议：`<sanitized>--<short_hash>`
+
+  * `sanitized` 只保留 `[A-Za-z0-9_-]`，其余替换 `_`（你已有）
+  * `short_hash` 用 `sha256(module_id)` 取前 8~12 位，保证不同 module_id 即使 sanitize 后相同也不会撞
+
+2. 在 overlay 目录里写一个很小的 metadata（比如 `.agentpack/module_id` 或 `.agentpack/meta.json`），人类可读地保留原始 id；CLI 输出仍然显示原始 module_id，但内部寻址用 fs_key。
+3. 做迁移兼容：加载 overlay 时，先尝试旧路径（raw id），找不到再用新 fs_key；或提供一次性 `agentpack migrate` 把旧目录迁移到新命名。
+4. store/cache 同理：`Store::git_checkout_dir()` 目前也用 sanitize（无 hash），也存在碰撞可能。建议一并升级到同一个 fs_key 规则，避免两个不同 id 写进同一 cache 目录造成“内容串台”。
+
+你要的是“控制平面”，那就必须保证“标识符 → 存储寻址”这一层是严谨的，否则越多人/越多机越容易出奇怪事故。
+
+P0-2：apply 的 Update 路径破坏了原子性（而且其实可以更简单）
+`apply_plan()` 里对 `Op::Update` 你做了：先 `remove_file(path)`，再 `write_atomic(path, bytes)`。这会产生一个真实的窗口期：文件被删了但新文件还没落地；如果在这个窗口期进程崩溃/掉电，用户会得到“文件消失”。
+而你使用的 `tempfile::NamedTempFile::persist()` 本身就支持把临时文件持久化到目标路径，并在目标已存在时进行原子替换（文档明确写了会 replace）。所以那句 `remove_file` 不仅多余，还降低了安全性。([Docs.rs][6])
+
+建议：
+
+1. 删除 `Op::Update` 分支里的 `remove_file`，让 `persist` 自己覆盖即可。
+2. 把“写 json 文件”的地方也统一用同一个 atomic write helper：
+
+* `Manifest::save()`（现在 `std::fs::write`）
+* `Lockfile::save()`（现在 `std::fs::write`）
+* `TargetManifest::save()`（现在 `std::fs::write`）
+  这样可以避免中途写了一半导致 config/lock/manifest 损坏。
+
+P0-3：目标路径冲突（两个模块生成同一输出）现在会静默覆盖
+在 `Engine::render_*` 里，你对 `DesiredState` 是直接 `desired.insert(TargetPath, DesiredFile)`；如果两个模块最终映射到同一路径（比如两个 prompt 同名、两个 command 同名、skills 目录结构撞车），后写入的会悄悄覆盖先写入的。
+这对“可审计/可复现”是硬伤：你会得到一个看似成功的 plan/deploy，但实际输出由“manifest 顺序”隐式决定，而且 `evolve propose`/`explain` 也会因此产生歧义。
+
+建议：
+
+1. 把 `insert_file` 做成“可检测冲突”的 API：
+
+* 若 key 不存在：插入
+* 若 key 已存在：
+
+  * 如果 bytes 相同：合并 `module_ids`（dedupe）
+  * 如果 bytes 不同：直接报错（或至少 plan 给出冲突项并拒绝 apply，除非用户显式 `--force-conflicts`）
+
+2. 在 `validate` 或 `plan` 阶段输出一个明确的冲突诊断（哪个 module_id 与哪个 module_id 争同一路径）。
+
+这会显著提升系统的确定性，也让“自进化/解释”更可靠。
+
+第二优先级的优化（P1：会明显提升可维护性和 agent 体验）
+
+P1-1：把“对 agent 友好的错误码体系”扩展到更多常见失败
+目前 JSON 模式下，只有 `E_CONFIRM_REQUIRED` 是强语义错误码，其他基本都落到 `E_UNEXPECTED`。对 agent 来说，错误码比 message 更可控。
+建议至少把这些变成稳定 code：
+
+* `E_MANIFEST_INVALID`（yaml/字段校验失败）
+* `E_LOCKFILE_MISSING`（fetch/update 需要 lockfile）
+* `E_TARGET_UNSUPPORTED` / `E_TARGET_NOT_CONFIGURED`
+* `E_GIT_NOT_FOUND` / `E_GIT_FAILED`（remote/sync 失败）
+* `E_DIR_NOT_WRITABLE`（doctor 检测）
+  这样你未来把 agentpack 接入自动化代理时，策略可以做到“遇到某类错误自动 fallback/引导”，而不是靠字符串匹配。
+
+P1-2：首次接管已有文件时给出“接管/覆盖”告警（更 AI-native 的安全边界）
+`compute_plan()` 对 Create/Update 的判断只看“目标路径是否存在以及内容是否不同”，并不区分“之前是否由 agentpack 管理”。这意味着第一次 deploy 时，如果用户目录里恰好已有同名文件，你会把它当 Update 覆盖掉（虽然有备份和可 rollback，但对用户心理预期依然偏危险）。
+建议：在没有 target manifest 的情况下，对“将覆盖一个非托管但存在的文件”给出 warning，甚至把 op 标成 `adopt_update`，要求用户显式确认（尤其在 `--json --yes` 的自动化场景里更需要显式信号）。
+
+P1-3：`cli.rs` 体积过大，建议拆分 command handlers（长期维护成本会急剧上升）
+`src/cli.rs` 已经 3000+ 行，并且很多 helper（例如 `expand_tilde`、overlay path 计算、manifest/roots 读取等）在多个模块重复。Rust 编译期也会受影响。
+建议结构：
+
+* `cli/mod.rs`：clap 定义 + run() + envelope 输出
+* `cli/commands/{init,add,lock,fetch,plan,diff,deploy,status,doctor,overlay,evolve,...}.rs`
+* `cli/util.rs`：expand_tilde、git repo root、confirm、路径标准化等
+  这样你以后加 target/adapters、加新命令（比如 registry/gc/tui）会轻松很多。
+
+P1-4：event log 更健壮、可扩展（为“自进化”打基础）
+`events.jsonl` 现在是整文件读入、逐行解析；如果某一行损坏（截断/并发写入插入半行），`score` 会整体失败。
+建议：
+
+* 读 events 时“跳过坏行 + warnings”而不是 hard fail（至少在 score 里）。
+* 增加可选字段：`command_id`、`targets`、`duration_ms`、`snapshot_id`、`git_rev`，并保持向后兼容（只增字段）。
+* 考虑 `deploy --apply` 成功后自动 `record` 一条（可通过 flag `--record` 控制），让闭环默认更顺滑。
+
+P1-5：`evolve propose` 的覆盖面可以更“闭环”
+现在 `evolve propose` 只挑 `module_ids.len()==1` 的文件，并且只处理“文件存在且内容不同”的 drift：
+
+* “missing（被删）”不会进入候选
+* “instructions 聚合生成的 AGENTS.md”因为 module_ids > 1 被跳过
+  这是合理的保守策略，但会限制“真正的自进化”。
+
+建议的增强方向：
+
+1. 给聚合文件加分段 marker（如 `<!-- agentpack:module=... -->`），这样你可以把 drift 精确映射回某个 instructions 模块片段，从而允许 evolve propose 针对 instructions 生效（这是 agent 维护规则库时最常见的需求）。
+2. 对 missing drift：提供两个策略
+
+* `--propose-restore`：把 desired 写回（相当于建议 redeploy，而不是写 overlay）
+* 或者生成一个“tombstone overlay”（如果你未来支持 overlay 删除语义）
+
+第三优先级的优化（P2：体验、性能、生态扩展）
+
+P2-1：overlay 目前是“整树 copy”，可以考虑稀疏 overlay / patch overlay
+`overlay edit` 会把 upstream 整棵树复制到 overlay，长远会带来：overlay repo 变大、合并困难、上游更新时冲突多。你已经在 backlog 里写了 3-way merge / patch overlays，这是正确方向。短期也可以做一个“sparse init”：只创建 `.agentpack/baseline.json`，不复制文件；用户只放改动文件。
+
+P2-2：lockfile 对 local_path 的“绝对路径”会影响跨机一致性
+`lockfile` 里对 local_path resolved_source 目前是 absolute path，这会让 lockfile 在不同机器/不同 AGENTPACK_HOME 下 diff 很大，也不利于把 config repo 当单一真源同步。
+建议：
+
+* local_path 的 resolved_source 保留 repo-relative（相对 `repo/`），并把“repo 根定位”当运行时参数；或
+* 对 local_path 不写 resolved_source.path，只写 hash + file_manifest 即可。
+
+P2-3：输出路径字符串的标准化（特别是 Windows）
+JSON 输出里 path/root 有些用 `display()`，Windows 会是反斜杠；有些地方又手动 replace 成 `/`。建议统一一个策略：
+
+* JSON 里给一个 `path`（posix 风格，用 `/`）+ `os_path`（原生）二者之一；或者
+* 统一 JSON 全部输出 `/`，human 输出用 native。
+  这对 agent 解析稳定性很有帮助。
+
+你现在这个设计为什么“AI-native”是对的（顺便帮你确认产品决策）
+
+1. 把 AGENTS.md、Skills、Claude commands 当“可部署资产”，而不是散落的文档/脚本，是正确的 AI-first 抽象；Codex 确实会在工作前读取 `AGENTS.md`，skills 也被官方定义成可复用能力单元。([OpenAI Developers][1])
+2. 你坚持 copy/render 而不是 symlink，本质是“对工具 discoverability 的适配层”：现实里 Codex 对 symlink 的行为确实会导致 prompts/skills 不被加载，尤其在 Windows 场景更明显。([GitHub][2])
+3. Claude slash command 把 `allowed-tools` 当能力边界，你在 `validate` 里做静态校验，是“把运行时安全约束前移到构建时”的典型 AI-native 工程实践。([Claude Code][4])
+
+如果只选 5 个“立刻动手就能显著变强”的改动（按性价比排序）
+
+1. 统一 module_id → fs_key（带 hash，避免 Windows 非法字符 + 碰撞 + 路径逃逸），覆盖 overlay + store + 任何 join(module_id) 的地方。
+2. 修复 Update 的原子写：去掉 `remove_file`，并让 manifest/lockfile/target manifest 都走 atomic write helper。([Docs.rs][6])
+3. DesiredState 插入做冲突检测：同路径不同内容直接报错（或强 warning + 拒绝 apply）。
+4. 扩展 JSON 错误码体系（把“常见用户错误”从 E_UNEXPECTED 里解耦出来）。
+5. 给首次覆盖非托管文件加 adopt/override 警告（尤其对 `--json --yes` 自动化安全很关键）。
+
+如果你愿意继续把“自进化”做成你这个项目的护城河，我会建议你把 evolve 系列目标定成一句话：
+“把 drift 从‘现场状态’可靠、可审计地回流到 ‘可 review 的 source（modules/overlays）’，并且能明确回答：改动来自谁、为什么改、影响哪些 target、能否一键回滚。”
+你现在已经完成了 70%（branch+commit+module mapping 的骨架已经在），剩下 30% 就是我上面提的：冲突检测、聚合文件可回溯、事件与效果度量更健壮。
+
+[1]: https://developers.openai.com/codex/guides/agents-md/?utm_source=chatgpt.com "Custom instructions with AGENTS.md"
+[2]: https://github.com/openai/codex/issues/4383?utm_source=chatgpt.com "Codex CLI ignores symlinks in ~/.codex/prompts · Issue ..."
+[3]: https://developers.openai.com/codex/guides/agents-sdk/?utm_source=chatgpt.com "Use Codex with the Agents SDK"
+[4]: https://code.claude.com/docs/en/slash-commands?utm_source=chatgpt.com "Slash commands - Claude Code Docs"
+[5]: https://owasp.org/www-community/attacks/Path_Traversal?utm_source=chatgpt.com "Path Traversal"
+[6]: https://docs.rs/tempfile/latest/tempfile/struct.NamedTempFile.html?utm_source=chatgpt.com "NamedTempFile in tempfile - Rust"

--- a/openspec/changes/v0-5-module-fs-key/.openspec.yaml
+++ b/openspec/changes/v0-5-module-fs-key/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/v0-5-module-fs-key/README.md
+++ b/openspec/changes/v0-5-module-fs-key/README.md
@@ -1,0 +1,3 @@
+# v0-5-module-fs-key
+
+Use a Windows-safe module_fs_key for overlays and store paths, with legacy fallback.

--- a/openspec/changes/v0-5-module-fs-key/proposal.md
+++ b/openspec/changes/v0-5-module-fs-key/proposal.md
@@ -1,0 +1,14 @@
+# Change: module_fs_key for overlays and store paths (v0.5)
+
+## Why
+`module_id` is a logical identifier and must not be used directly as a filesystem path component. In practice it breaks on Windows (e.g. `instructions:base` contains `:`) and can introduce path traversal / collision risks.
+
+## What Changes
+- Introduce a stable `module_fs_key` derived from `module_id` (sanitized + short hash).
+- Use `module_fs_key` for overlay directories (global/machine/project) and for store git checkout directories.
+- Keep CLI/manifest/user-facing identifiers as `module_id` (no UX change).
+- Backwards compatibility: if legacy paths exist (pre-v0.5), prefer them; otherwise create/use the new canonical paths.
+
+## Impact
+- Affected specs: `agentpack`, `agentpack-cli`
+- Affected code: overlay path resolution, overlay edit/evolve propose writes, git store layout

--- a/openspec/changes/v0-5-module-fs-key/specs/agentpack-cli/spec.md
+++ b/openspec/changes/v0-5-module-fs-key/specs/agentpack-cli/spec.md
@@ -1,0 +1,11 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: overlay path outputs a filesystem-safe directory
+The system SHALL make `agentpack overlay path <module_id>` return an overlay directory that is filesystem-safe on the current platform.
+
+#### Scenario: overlay path is Windows-safe
+- **GIVEN** a module id `instructions:base`
+- **WHEN** the user runs `agentpack overlay path instructions:base --scope global --json`
+- **THEN** `data.overlay_dir` does not contain a path segment with `:` on Windows

--- a/openspec/changes/v0-5-module-fs-key/specs/agentpack/spec.md
+++ b/openspec/changes/v0-5-module-fs-key/specs/agentpack/spec.md
@@ -1,0 +1,19 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: module_id is mapped to a filesystem-safe key
+The system SHALL derive a stable, filesystem-safe `module_fs_key` from `module_id` and SHALL use `module_fs_key` when creating filesystem paths for module-scoped storage (e.g., overlays and cache/store directories).
+
+#### Scenario: Windows-safe overlay directory
+- **GIVEN** a module id `instructions:base`
+- **WHEN** the system computes the overlay directory for that module
+- **THEN** the directory path does not require using `:` as a path component
+
+### Requirement: Legacy overlay and store paths remain usable
+The system SHALL preserve backwards compatibility by preferring legacy (pre-v0.5) overlay and store paths when they already exist on disk.
+
+#### Scenario: existing legacy overlay is used
+- **GIVEN** a legacy overlay directory exists for a module id
+- **WHEN** the system renders the module
+- **THEN** it applies the legacy overlay directory

--- a/openspec/changes/v0-5-module-fs-key/tasks.md
+++ b/openspec/changes/v0-5-module-fs-key/tasks.md
@@ -1,0 +1,15 @@
+## 1. Specs
+- [x] Add requirements for module_fs_key (cross-platform safe) and legacy fallback behavior.
+
+## 2. Implementation
+- [x] Add `module_fs_key` helper and use it for overlays and store paths.
+- [x] Keep legacy path fallback for existing overlays/checkouts.
+- [x] Update docs/SPEC.md overlay path descriptions.
+
+## 3. Tests
+- [x] Add tests asserting overlay paths are Windows-safe for ids like `instructions:base`.
+- [x] Add tests for store path stability / no collisions (module_fs_key includes hash).
+
+## 4. Validation
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test`.
+- [x] Run `openspec validate v0-5-module-fs-key --strict --no-interactive`.

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,0 +1,75 @@
+use crate::hash::sha256_hex;
+
+pub fn is_safe_legacy_path_component(value: &str) -> bool {
+    if value.is_empty() || value == "." || value == ".." {
+        return false;
+    }
+    if value.contains('/') || value.contains('\\') {
+        return false;
+    }
+
+    if cfg!(windows)
+        && (value.contains(':')
+            || value.contains('*')
+            || value.contains('?')
+            || value.contains('"')
+            || value.contains('<')
+            || value.contains('>')
+            || value.contains('|'))
+    {
+        return false;
+    }
+
+    true
+}
+
+pub fn sanitize_fs_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| match c {
+            _ if c.is_ascii_alphanumeric() || c == '-' || c == '_' => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+pub fn module_fs_key(module_id: &str) -> String {
+    let sanitized = sanitize_fs_component(module_id);
+    let hash = sha256_hex(module_id.as_bytes());
+    format!("{sanitized}--{}", &hash[..10])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_fs_key_is_stable_and_collision_resistant() {
+        let a = module_fs_key("a:b");
+        let b = module_fs_key("a/b");
+        assert_ne!(a, b);
+        assert!(a.contains("--"));
+        assert!(b.contains("--"));
+    }
+
+    #[test]
+    fn module_fs_key_sanitizes_for_filesystems() {
+        let key = module_fs_key("instructions:base");
+        assert!(key.starts_with("instructions_base--"));
+        assert!(!key.contains(':'));
+        assert!(!key.contains('/'));
+        assert!(!key.contains('\\'));
+    }
+
+    #[test]
+    fn legacy_component_safety_matches_platform_constraints() {
+        if cfg!(windows) {
+            assert!(!is_safe_legacy_path_component("instructions:base"));
+        } else {
+            assert!(is_safe_legacy_path_component("instructions:base"));
+        }
+        assert!(!is_safe_legacy_path_component(""));
+        assert!(!is_safe_legacy_path_component(".."));
+        assert!(!is_safe_legacy_path_component("a/b"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod events;
 pub mod fs;
 pub mod git;
 pub mod hash;
+pub mod ids;
 pub mod lockfile;
 pub mod machine;
 pub mod output;

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -55,6 +55,9 @@ pub fn ensure_overlay_skeleton(
     if !overlay_baseline_path(overlay_dir).exists() {
         write_overlay_baseline(&upstream_root, overlay_dir)?;
     }
+    if !overlay_module_id_path(overlay_dir).exists() {
+        write_overlay_module_id(module_id, overlay_dir)?;
+    }
 
     Ok(OverlaySkeleton {
         dir: overlay_dir.to_path_buf(),
@@ -216,6 +219,23 @@ pub fn overlay_drift_warnings(
 
 fn overlay_baseline_path(overlay_dir: &Path) -> PathBuf {
     overlay_dir.join(".agentpack").join("baseline.json")
+}
+
+fn overlay_module_id_path(overlay_dir: &Path) -> PathBuf {
+    overlay_dir.join(".agentpack").join("module_id")
+}
+
+fn write_overlay_module_id(module_id: &str, overlay_dir: &Path) -> anyhow::Result<()> {
+    let meta_dir = overlay_dir.join(".agentpack");
+    std::fs::create_dir_all(&meta_dir).context("create overlay metadata dir")?;
+
+    let path = overlay_module_id_path(overlay_dir);
+    let mut content = module_id.to_string();
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+    std::fs::write(&path, content).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
 }
 
 fn write_overlay_baseline(upstream_root: &Path, overlay_dir: &Path) -> anyhow::Result<()> {

--- a/tests/cli_overlay_fs_key.rs
+++ b/tests/cli_overlay_fs_key.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn overlay_path_is_filesystem_safe_for_colon_module_ids() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let init = agentpack_in(tmp.path(), &["init"]);
+    assert!(init.status.success());
+
+    let out = agentpack_in(
+        tmp.path(),
+        &[
+            "overlay",
+            "path",
+            "instructions:base",
+            "--scope",
+            "global",
+            "--json",
+        ],
+    );
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    let overlay_dir = v["data"]["overlay_dir"].as_str().expect("overlay_dir");
+    let name = std::path::Path::new(overlay_dir)
+        .file_name()
+        .expect("file name")
+        .to_string_lossy();
+    assert!(name.starts_with("instructions_base--"));
+    assert!(!name.contains(':'));
+}

--- a/tests/cli_overlay_path.rs
+++ b/tests/cli_overlay_path.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use agentpack::ids::module_fs_key;
 use sha2::Digest as _;
 
 fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
@@ -55,6 +56,7 @@ fn overlay_path_resolves_global_machine_and_project_scopes() {
 
     let module_id = "skill_test";
     let repo_dir = home.join("repo");
+    let fs_key = module_fs_key(module_id);
 
     let global = agentpack_in(
         home,
@@ -68,7 +70,7 @@ fn overlay_path_resolves_global_machine_and_project_scopes() {
         .expect("overlay_dir");
     assert_eq!(
         PathBuf::from(global_dir),
-        repo_dir.join("overlays").join(module_id)
+        repo_dir.join("overlays").join(&fs_key)
     );
 
     let machine = agentpack_in(
@@ -86,7 +88,7 @@ fn overlay_path_resolves_global_machine_and_project_scopes() {
         repo_dir
             .join("overlays/machines")
             .join(&machine_id)
-            .join(module_id)
+            .join(&fs_key)
     );
 
     let project = agentpack_in(
@@ -106,6 +108,6 @@ fn overlay_path_resolves_global_machine_and_project_scopes() {
             .join("projects")
             .join(project_id)
             .join("overlays")
-            .join(module_id)
+            .join(&fs_key)
     );
 }

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -173,10 +173,11 @@ fn resolve_upstream_module_root_auto_fetches_missing_git_checkout() -> anyhow::R
     assert!(root.join("SKILL.md").is_file());
 
     // Ensure the checkout was created under cache.
+    let fs_key = agentpack::ids::module_fs_key("skill:test");
     assert!(
         home.cache_dir
             .join("git")
-            .join("skill_test")
+            .join(fs_key)
             .join(&commit)
             .exists()
     );

--- a/tests/store_module_fs_key.rs
+++ b/tests/store_module_fs_key.rs
@@ -1,0 +1,53 @@
+use std::path::PathBuf;
+
+use agentpack::config::GitSource;
+use agentpack::paths::AgentpackHome;
+use agentpack::store::{Store, sanitize_module_id};
+
+#[test]
+fn store_checkout_dir_uses_fs_key_and_falls_back_to_legacy_if_present() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let root = tmp.path().to_path_buf();
+
+    let home = AgentpackHome {
+        repo_dir: root.join("repo"),
+        state_dir: root.join("state"),
+        cache_dir: root.join("cache"),
+        snapshots_dir: root.join("state").join("snapshots"),
+        logs_dir: root.join("state").join("logs"),
+        root: root.clone(),
+    };
+
+    let store = Store::new(&home);
+    let module_id = "instructions:base";
+    let commit = "deadbeef";
+
+    let canonical = store.git_checkout_dir(module_id, commit);
+    let dir_name = canonical
+        .parent()
+        .and_then(|p| p.file_name())
+        .expect("dir name")
+        .to_string_lossy()
+        .to_string();
+    assert!(dir_name.starts_with("instructions_base--"));
+
+    // Create legacy checkout directory and ensure ensure_git_checkout returns it (without cloning).
+    let legacy_dir: PathBuf = home
+        .cache_dir
+        .join("git")
+        .join(sanitize_module_id(module_id))
+        .join(commit);
+    std::fs::create_dir_all(&legacy_dir)?;
+
+    let src = GitSource {
+        url: "https://example.invalid/repo.git".to_string(),
+        ref_name: "main".to_string(),
+        subdir: String::new(),
+        shallow: true,
+    };
+
+    let used = store.ensure_git_checkout(module_id, &src, commit)?;
+    assert_eq!(used, legacy_dir);
+
+    Ok(())
+}


### PR DESCRIPTION
Implements P0-1 from `docs/versions/v0.4/expert_review_result.md` (issue #55).

- Adds `module_fs_key` (sanitized + short hash) for filesystem paths.
- Uses it for overlay dirs and store git checkout dirs.
- Back-compat: if legacy paths exist, prefer them.
- Updates `docs/SPEC.md` overlay path mapping.
- Adds tests for Windows-safe overlay paths and legacy store fallback.

Refs #55.
