### PR TITLE
fix(apply): atomic create/update writes

### DIFF
--- a/openspec/changes/v0-5-apply-atomic-update/.openspec.yaml
+++ b/openspec/changes/v0-5-apply-atomic-update/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/v0-5-apply-atomic-update/README.md
+++ b/openspec/changes/v0-5-apply-atomic-update/README.md
@@ -1,0 +1,3 @@
+# v0-5-apply-atomic-update
+
+Avoid pre-delete for updates; centralize best-effort replace in write_atomic.

--- a/openspec/changes/v0-5-apply-atomic-update/proposal.md
+++ b/openspec/changes/v0-5-apply-atomic-update/proposal.md
@@ -1,0 +1,12 @@
+# Change: Apply atomic update semantics (v0.5)
+
+## Why
+`apply` should use atomic replacement semantics where possible. The current implementation pre-deletes files before writing, creating an unnecessary window where outputs can be missing.
+
+## What Changes
+- Remove pre-delete in `apply` for create/update paths.
+- Centralize best-effort replace semantics in `write_atomic` (including a Windows fallback when destination exists).
+
+## Impact
+- Affected specs: `agentpack`
+- Affected code: `src/apply.rs`

--- a/openspec/changes/v0-5-apply-atomic-update/specs/agentpack/spec.md
+++ b/openspec/changes/v0-5-apply-atomic-update/specs/agentpack/spec.md
@@ -1,0 +1,11 @@
+# agentpack (delta)
+
+## MODIFIED Requirements
+
+### Requirement: apply uses atomic writes for updates
+The system SHALL avoid unnecessary pre-deletes when writing updated outputs. On platforms where atomic replacement is supported by the underlying filesystem APIs, an update SHALL replace the destination atomically.
+
+#### Scenario: update does not require deleting the destination first
+- **GIVEN** a deployed managed file exists
+- **WHEN** a subsequent deploy updates that file
+- **THEN** the system uses atomic replacement semantics where available

--- a/openspec/changes/v0-5-apply-atomic-update/tasks.md
+++ b/openspec/changes/v0-5-apply-atomic-update/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+- [x] Remove pre-delete for create/update in apply paths.
+- [x] Make `write_atomic` handle existing destinations (best-effort replace).
+
+## 2. Tests
+- [x] Ensure existing test suite passes (deploy/bootstrap/apply/rollback).
+
+## 3. Validation
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test`.
+- [x] Run `openspec validate v0-5-apply-atomic-update --strict --no-interactive`.


### PR DESCRIPTION
Fixes #56.

What changed
- Stop deleting destination files before create/update (avoids a delete window).
- Make `write_atomic()` attempt atomic replace via temp-file persist; on Windows, retry after removing an existing destination when needed.

Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate v0-5-apply-atomic-update --strict --no-interactive`
