### PR TITLE
chore(openspec): fix delta classification for v0.5 apply change

### DIFF
--- a/openspec/changes/v0-5-apply-atomic-update/specs/agentpack/spec.md
+++ b/openspec/changes/v0-5-apply-atomic-update/specs/agentpack/spec.md
@@ -1,6 +1,6 @@
 # agentpack (delta)
 
-## MODIFIED Requirements
+## ADDED Requirements
 
 ### Requirement: apply uses atomic writes for updates
 The system SHALL avoid unnecessary pre-deletes when writing updated outputs. On platforms where atomic replacement is supported by the underlying filesystem APIs, an update SHALL replace the destination atomically.


### PR DESCRIPTION
The v0-5-apply-atomic-update OpenSpec delta was marked as MODIFIED, but the requirement is new.

This switches it to ADDED so `openspec archive` can apply it cleanly.
