### PR TITLE
fix(engine): refuse conflicting desired outputs

### DIFF
--- a/openspec/changes/v0-5-desired-state-conflicts/.openspec.yaml
+++ b/openspec/changes/v0-5-desired-state-conflicts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/v0-5-desired-state-conflicts/README.md
+++ b/openspec/changes/v0-5-desired-state-conflicts/README.md
@@ -1,0 +1,3 @@
+# v0-5-desired-state-conflicts
+
+Detect and refuse conflicting desired outputs (same target+path, different content) instead of silently overwriting.

--- a/openspec/changes/v0-5-desired-state-conflicts/proposal.md
+++ b/openspec/changes/v0-5-desired-state-conflicts/proposal.md
@@ -1,0 +1,13 @@
+# Change: Detect DesiredState path conflicts (v0.5)
+
+## Why
+Multiple modules can currently write the same `(target, path)` with different bytes. Because `DesiredState` is a map, later inserts overwrite earlier ones silently, which is unsafe and hard to debug (especially for automation).
+
+## What Changes
+- Detect conflicts when building `DesiredState`: if a `(target, path)` is already present with different content, fail fast.
+- If the bytes are identical, merge module provenance (`module_ids`) instead of erroring.
+- In `--json` mode, return a stable error code `E_DESIRED_STATE_CONFLICT`.
+
+## Impact
+- Affected specs: `agentpack`
+- Affected code: engine/target rendering (desired state construction), CLI JSON errors

--- a/openspec/changes/v0-5-desired-state-conflicts/specs/agentpack/spec.md
+++ b/openspec/changes/v0-5-desired-state-conflicts/specs/agentpack/spec.md
@@ -1,0 +1,17 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: DesiredState path conflicts are refused
+If multiple modules attempt to produce different content for the same `(target, path)`, the system MUST fail fast instead of silently overwriting based on insertion order.
+
+If the bytes are identical, the system SHOULD merge module provenance so the output can still be attributed to all contributing modules.
+
+In `--json` mode, the system MUST return a stable error code `E_DESIRED_STATE_CONFLICT`.
+
+#### Scenario: conflict is detected before apply
+- **GIVEN** two modules render different bytes to the same output path
+- **WHEN** the user runs `agentpack plan --json` (or `preview/deploy`)
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_DESIRED_STATE_CONFLICT`

--- a/openspec/changes/v0-5-desired-state-conflicts/tasks.md
+++ b/openspec/changes/v0-5-desired-state-conflicts/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+- [x] Add conflict detection when inserting into DesiredState.
+- [x] Ensure `--json` surfaces a stable error code for conflicts.
+
+## 2. Tests
+- [x] Add a CLI test that reproduces a conflicting output and asserts the JSON error code.
+
+## 3. Validation
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test`.
+- [x] Run `openspec validate v0-5-desired-state-conflicts --strict --no-interactive`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod store;
 pub mod target_adapters;
 pub mod target_manifest;
 pub mod targets;
+pub mod user_error;
 pub mod validate;
 
 pub use cli::run;

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -1,0 +1,40 @@
+#[derive(Debug)]
+pub struct UserError {
+    pub code: String,
+    pub message: String,
+    pub details: Option<serde_json::Value>,
+}
+
+impl std::fmt::Display for UserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for UserError {}
+
+impl UserError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    pub fn with_details(mut self, details: serde_json::Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+
+    pub fn confirm_required(command: impl Into<String>) -> anyhow::Error {
+        let command = command.into();
+        anyhow::Error::new(
+            Self::new(
+                "E_CONFIRM_REQUIRED",
+                format!("refusing to run '{command}' in --json mode without --yes"),
+            )
+            .with_details(serde_json::json!({ "command": command })),
+        )
+    }
+}

--- a/tests/cli_desired_state_conflict.rs
+++ b/tests/cli_desired_state_conflict.rs
@@ -1,0 +1,86 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn plan_json_fails_with_stable_code_on_desired_state_conflict() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let init = agentpack_in(tmp.path(), &["init"]);
+    assert!(init.status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let repo_dir = tmp.path().join("repo");
+    let m1 = repo_dir.join("modules/prompt_one");
+    let m2 = repo_dir.join("modules/prompt_two");
+    std::fs::create_dir_all(&m1).expect("create module 1");
+    std::fs::create_dir_all(&m2).expect("create module 2");
+    std::fs::write(m1.join("prompt.md"), "# one\n").expect("write prompt 1");
+    std::fs::write(m2.join("prompt.md"), "# two\n").expect("write prompt 2");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["prompt:one","prompt:two"]
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+      write_agents_global: false
+      write_agents_repo_root: false
+
+modules:
+  - id: "prompt:one"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt_one"
+  - id: "prompt:two"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt_two"
+"#,
+        codex_home.display()
+    );
+    let manifest_path = repo_dir.join("agentpack.yaml");
+    std::fs::write(&manifest_path, manifest).expect("write manifest");
+
+    let plan = agentpack_in(tmp.path(), &["--target", "codex", "plan", "--json"]);
+    assert!(!plan.status.success());
+
+    let v = parse_stdout_json(&plan);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_DESIRED_STATE_CONFLICT");
+}

--- a/tests/deploy_insert_desired_file.rs
+++ b/tests/deploy_insert_desired_file.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use agentpack::deploy::{DesiredState, insert_desired_file};
+use agentpack::user_error::UserError;
+
+#[test]
+fn insert_desired_file_merges_module_ids_when_bytes_match() -> anyhow::Result<()> {
+    let mut desired = DesiredState::new();
+
+    insert_desired_file(
+        &mut desired,
+        "codex",
+        PathBuf::from("out.txt"),
+        b"same".to_vec(),
+        vec!["module:a".to_string()],
+    )?;
+
+    insert_desired_file(
+        &mut desired,
+        "codex",
+        PathBuf::from("out.txt"),
+        b"same".to_vec(),
+        vec!["module:b".to_string()],
+    )?;
+
+    assert_eq!(desired.len(), 1);
+    let file = desired.values().next().expect("one desired file");
+    assert_eq!(file.bytes, b"same".to_vec());
+    assert_eq!(
+        file.module_ids,
+        vec!["module:a".to_string(), "module:b".to_string()]
+    );
+
+    Ok(())
+}
+
+#[test]
+fn insert_desired_file_errors_on_conflicting_bytes() {
+    let mut desired = DesiredState::new();
+
+    insert_desired_file(
+        &mut desired,
+        "codex",
+        PathBuf::from("out.txt"),
+        b"one".to_vec(),
+        vec!["module:a".to_string()],
+    )
+    .expect("first insert ok");
+
+    let err = insert_desired_file(
+        &mut desired,
+        "codex",
+        PathBuf::from("out.txt"),
+        b"two".to_vec(),
+        vec!["module:b".to_string()],
+    )
+    .expect_err("second insert should conflict");
+
+    let user = err.downcast_ref::<UserError>().expect("error is UserError");
+    assert_eq!(user.code, "E_DESIRED_STATE_CONFLICT");
+    assert!(user.message.contains("conflicting desired outputs"));
+    assert!(user.details.is_some());
+}


### PR DESCRIPTION
Fixes #57.

What changed
- Detect DesiredState conflicts: if two modules render different bytes to the same (target,path), fail fast instead of silently overwriting.
- If bytes match, merge module provenance (module_ids).
- Unify user-facing JSON errors via `UserError` and surface `E_DESIRED_STATE_CONFLICT`.

Tests
- `cargo test --all --locked`
