### PR TITLE
feat(json): stable error codes for common failures

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -20,6 +20,18 @@
 
 所有命令默认 human 输出；加 `--json` 输出机器可读 JSON（envelope 包含 `schema_version`、`warnings`、`errors`）。
 
+### 0.1 `--json` 稳定错误码（稳定对外契约）
+
+当 `--json` 启用时，常见/可行动的失败必须返回稳定错误码（`errors[0].code`）：
+- `E_CONFIRM_REQUIRED`：在 `--json` 下，写入类命令缺少 `--yes`。
+- `E_CONFIG_MISSING`：缺少 `repo/agentpack.yaml`。
+- `E_CONFIG_INVALID`：`agentpack.yaml` 语法或语义不合法（如缺少 default profile / 重复 module id / source 配置不合法）。
+- `E_CONFIG_UNSUPPORTED_VERSION`：`agentpack.yaml` 的 `version` 不被支持。
+- `E_LOCKFILE_MISSING`：缺少 `repo/agentpack.lock.json`（但当前命令需要它，如 fetch）。
+- `E_LOCKFILE_INVALID`：`agentpack.lock.json` JSON 不合法。
+- `E_TARGET_UNSUPPORTED`：不支持的 target（manifest targets 或 CLI `--target` 选择）。
+- `E_DESIRED_STATE_CONFLICT`：多个模块对同一 `(target,path)` 产出不同内容（拒绝静默覆盖）。
+
 ## 1. 核心概念与数据模型
 
 ### 1.1 Module

--- a/openspec/changes/v0-5-json-error-codes/.openspec.yaml
+++ b/openspec/changes/v0-5-json-error-codes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/v0-5-json-error-codes/README.md
+++ b/openspec/changes/v0-5-json-error-codes/README.md
@@ -1,0 +1,3 @@
+# v0-5-json-error-codes
+
+Add stable JSON error codes for common user-facing failures (config, lockfile, target selection).

--- a/openspec/changes/v0-5-json-error-codes/proposal.md
+++ b/openspec/changes/v0-5-json-error-codes/proposal.md
@@ -1,0 +1,16 @@
+# Change: Structured JSON error codes for common failures (v0.5)
+
+## Why
+In `--json` mode, automation needs stable, machine-readable error codes beyond `E_CONFIRM_REQUIRED` and the generic fallback `E_UNEXPECTED`.
+
+## What Changes
+- Introduce additional stable error codes for common user-facing failures:
+  - config missing/invalid/unsupported version
+  - lockfile missing/invalid
+  - unsupported `--target`
+- Ensure these failures return the appropriate code in `--json` mode.
+
+## Impact
+- Affected specs: `agentpack`
+- Affected code: config/lockfile loading, CLI error mapping
+- Affected docs/tests: `docs/SPEC.md`, CLI tests

--- a/openspec/changes/v0-5-json-error-codes/specs/agentpack/spec.md
+++ b/openspec/changes/v0-5-json-error-codes/specs/agentpack/spec.md
@@ -1,0 +1,19 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: JSON mode uses stable error codes for common failures
+In `--json` mode, user-facing failures that are common and actionable MUST return stable error codes (not just `E_UNEXPECTED`) so automation can branch reliably.
+
+At minimum, the following scenarios MUST return stable codes:
+- Missing config manifest: `E_CONFIG_MISSING`
+- Invalid config manifest: `E_CONFIG_INVALID`
+- Unsupported config version: `E_CONFIG_UNSUPPORTED_VERSION`
+- Missing lockfile when required: `E_LOCKFILE_MISSING`
+- Invalid lockfile JSON: `E_LOCKFILE_INVALID`
+- Unsupported `--target`: `E_TARGET_UNSUPPORTED`
+
+#### Scenario: missing config yields stable error code
+- **GIVEN** `agentpack.yaml` is missing
+- **WHEN** the user runs `agentpack plan --json`
+- **THEN** `errors[0].code` equals `E_CONFIG_MISSING`

--- a/openspec/changes/v0-5-json-error-codes/tasks.md
+++ b/openspec/changes/v0-5-json-error-codes/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+- [x] Map common failures to stable `UserError` codes.
+- [x] Ensure CLI JSON output uses those codes.
+
+## 2. Tests
+- [x] Add CLI tests for config/lockfile/target error codes.
+
+## 3. Docs
+- [x] Update `docs/SPEC.md` with the stable error codes list and examples.
+
+## 4. Validation
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test`.
+- [x] Run `openspec validate v0-5-json-error-codes --strict --no-interactive`.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -13,6 +13,7 @@ use crate::project::ProjectContext;
 use crate::store::{Store, sanitize_module_id};
 use crate::target_adapters::adapter_for;
 use crate::targets::{TargetRoot, dedup_roots};
+use crate::user_error::UserError;
 use crate::validate::validate_materialized_module;
 
 #[derive(Debug)]
@@ -96,7 +97,16 @@ impl Engine {
             "all" => Ok(known),
             "codex" => Ok(vec!["codex".to_string()]),
             "claude_code" => Ok(vec!["claude_code".to_string()]),
-            other => anyhow::bail!("unsupported --target: {other}"),
+            other => Err(anyhow::Error::new(
+                UserError::new(
+                    "E_TARGET_UNSUPPORTED",
+                    format!("unsupported --target: {other}"),
+                )
+                .with_details(serde_json::json!({
+                    "target": other,
+                    "allowed": ["all","codex","claude_code"],
+                })),
+            )),
         }
     }
 

--- a/tests/cli_error_codes.rs
+++ b/tests/cli_error_codes.rs
@@ -1,0 +1,113 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn json_error_code_config_missing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    std::fs::remove_file(tmp.path().join("repo").join("agentpack.yaml")).expect("remove manifest");
+
+    let out = agentpack_in(tmp.path(), &["plan", "--json"]);
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["errors"][0]["code"], "E_CONFIG_MISSING");
+}
+
+#[test]
+fn json_error_code_config_invalid_yaml() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    std::fs::write(
+        tmp.path().join("repo").join("agentpack.yaml"),
+        "version: [\n",
+    )
+    .expect("write invalid manifest");
+
+    let out = agentpack_in(tmp.path(), &["plan", "--json"]);
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["errors"][0]["code"], "E_CONFIG_INVALID");
+}
+
+#[test]
+fn json_error_code_config_unsupported_version() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let manifest = r#"version: 2
+
+profiles:
+  default:
+    include_tags: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options: {}
+
+modules: []
+"#;
+    std::fs::write(tmp.path().join("repo").join("agentpack.yaml"), manifest)
+        .expect("write manifest");
+
+    let out = agentpack_in(tmp.path(), &["plan", "--json"]);
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["errors"][0]["code"], "E_CONFIG_UNSUPPORTED_VERSION");
+}
+
+#[test]
+fn json_error_code_lockfile_missing_for_fetch() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let out = agentpack_in(tmp.path(), &["fetch", "--json", "--yes"]);
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["errors"][0]["code"], "E_LOCKFILE_MISSING");
+}
+
+#[test]
+fn json_error_code_lockfile_invalid_for_fetch() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    std::fs::write(
+        tmp.path().join("repo").join("agentpack.lock.json"),
+        "{not json",
+    )
+    .expect("write invalid lockfile");
+
+    let out = agentpack_in(tmp.path(), &["fetch", "--json", "--yes"]);
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["errors"][0]["code"], "E_LOCKFILE_INVALID");
+}
+
+#[test]
+fn json_error_code_target_unsupported() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let out = agentpack_in(tmp.path(), &["--target", "nope", "plan", "--json"]);
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["errors"][0]["code"], "E_TARGET_UNSUPPORTED");
+}


### PR DESCRIPTION
Fixes #58.

Adds stable `--json` error codes for common user-facing failures:
- `E_CONFIG_MISSING` / `E_CONFIG_INVALID` / `E_CONFIG_UNSUPPORTED_VERSION`
- `E_LOCKFILE_MISSING` / `E_LOCKFILE_INVALID`
- `E_TARGET_UNSUPPORTED`

Also updates `docs/SPEC.md` to document the stable codes and adds CLI tests.
