### PR TITLE
fix(score): tolerate malformed events.jsonl

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -201,12 +201,16 @@ Schema（v1，示例）：
   "schema_version": 1,
   "recorded_at": "2026-01-11T00:00:00Z",
   "machine_id": "my-macbook",
+  "module_id": "command:ap-plan",
+  "success": true,
   "event": { "module_id": "command:ap-plan", "success": true }
 }
 ```
 
 约定：
 - `event` 为自由 JSON；`score` 仅解析 `module_id|moduleId` 与 `success|ok`。
+- 顶层 `module_id` 与 `success` 为可选字段（兼容历史日志）；`score` 会优先使用它们。
+- `score` 必须容忍坏行（如截断/非 JSON）：跳过并输出 warning，而不是整个失败。
 
 ## 3. Overlays
 

--- a/openspec/changes/v0-5-events-log-robustness/.openspec.yaml
+++ b/openspec/changes/v0-5-events-log-robustness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/v0-5-events-log-robustness/README.md
+++ b/openspec/changes/v0-5-events-log-robustness/README.md
@@ -1,0 +1,3 @@
+# v0-5-events-log-robustness
+
+Make `events.jsonl` parsing robust (skip malformed lines with warnings) and add optional top-level fields for faster scoring.

--- a/openspec/changes/v0-5-events-log-robustness/proposal.md
+++ b/openspec/changes/v0-5-events-log-robustness/proposal.md
@@ -1,0 +1,17 @@
+# Change: events.jsonl robustness + optional richer fields (v0.5)
+
+## Why
+`agentpack score` should not fail entirely if `events.jsonl` contains malformed/partial lines (e.g., truncated writes, manual edits). For automation and long-running usage, best-effort parsing with warnings is safer.
+
+## What Changes
+- Parse `events.jsonl` line-by-line; skip malformed/unsupported lines with warnings.
+- Keep backwards compatibility: schema_version remains `1`; only add optional top-level fields.
+- Add optional derived fields to `RecordedEvent`:
+  - `module_id` (if derivable)
+  - `success` (if derivable)
+- Prefer these optional fields in scoring, falling back to extracting from `event`.
+
+## Impact
+- Affected specs: `agentpack`
+- Affected code: `src/events.rs`, `agentpack score`, `agentpack record`
+- Affected tests: add coverage for robustness and warnings

--- a/openspec/changes/v0-5-events-log-robustness/specs/agentpack/spec.md
+++ b/openspec/changes/v0-5-events-log-robustness/specs/agentpack/spec.md
@@ -1,0 +1,12 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: score tolerates malformed events.jsonl lines
+`agentpack score` MUST tolerate malformed/partial lines in `events.jsonl` by skipping bad lines and emitting warnings, instead of failing the whole command.
+
+#### Scenario: malformed line is skipped
+- **GIVEN** `events.jsonl` contains both valid and invalid JSON lines
+- **WHEN** the user runs `agentpack score --json`
+- **THEN** the command exits successfully with `ok=true`
+- **AND** `warnings` includes an entry referencing the skipped line

--- a/openspec/changes/v0-5-events-log-robustness/tasks.md
+++ b/openspec/changes/v0-5-events-log-robustness/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+- [x] Make reading `events.jsonl` tolerant of malformed/partial lines.
+- [x] Add optional top-level `module_id` and `success` fields while keeping schema_version=1.
+- [x] Surface parse warnings from `agentpack score` (human + `--json` warnings).
+
+## 2. Tests
+- [x] Add a CLI test asserting `score --json` succeeds with malformed lines and emits warnings.
+
+## 3. Validation
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test`.
+- [x] Run `openspec validate v0-5-events-log-robustness --strict --no-interactive`.

--- a/tests/cli_score_events_robustness.rs
+++ b/tests/cli_score_events_robustness.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn score_json_skips_malformed_lines_with_warnings() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let logs_dir = tmp.path().join("state").join("logs");
+    std::fs::create_dir_all(&logs_dir).expect("create logs dir");
+
+    let events_path = logs_dir.join("events.jsonl");
+    let good = serde_json::json!({
+        "schema_version": 1,
+        "recorded_at": "2026-01-11T00:00:00Z",
+        "machine_id": "m1",
+        "event": { "module_id": "skill:test", "success": false }
+    });
+
+    let unsupported = serde_json::json!({
+        "schema_version": 999,
+        "recorded_at": "2026-01-11T00:00:01Z",
+        "machine_id": "m1",
+        "event": { "module_id": "skill:ignored", "success": true }
+    });
+
+    let content = format!(
+        "{}\nnot-json\n{}\n",
+        serde_json::to_string(&good).unwrap(),
+        serde_json::to_string(&unsupported).unwrap()
+    );
+    std::fs::write(&events_path, content).expect("write events.jsonl");
+
+    let out = agentpack_in(tmp.path(), &["score", "--json"]);
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], true);
+    assert!(v["warnings"].is_array());
+    assert!(v["warnings"].as_array().unwrap().len() >= 2);
+
+    let modules = v["data"]["modules"].as_array().expect("modules array");
+    let item = modules
+        .iter()
+        .find(|m| m["module_id"] == "skill:test")
+        .expect("skill:test present");
+    assert_eq!(item["failures"], 1);
+    assert_eq!(item["total"], 1);
+}


### PR DESCRIPTION
Fixes #59.

What changed
- Parse `events.jsonl` line-by-line and skip malformed/unsupported lines with warnings.
- Add optional top-level fields (`module_id`, `success`) to recorded events (schema_version stays 1).
- `agentpack score` surfaces warnings (stderr in human mode; `warnings[]` in `--json`).

Tests
- `tests/cli_score_events_robustness.rs`
