### PR TITLE
feat(evolve): report skipped drift in propose

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -395,6 +395,10 @@ agentpack evolve propose [--module-id <id>] [--scope global|machine|project]
 补充：
 - `--json` 模式下要求同时提供 `--yes`（缺少则 `E_CONFIRM_REQUIRED`）。
 - 要求 config repo 工作树干净；会创建分支并尝试提交（若 git identity 缺失导致提交失败，会提示并保留分支与改动）。
+- 当前实现是保守的（conservative），只会对“可安全映射回单个模块”的 drift 生成 proposal：
+  - 仅处理 `module_ids.len()==1` 的输出（多模块聚合输出会被跳过并提示）。
+  - 仅处理 deployed 文件“存在且内容不同”的 drift；对于 `missing` drift（文件不存在）会跳过并提示（建议通过 `deploy` 恢复）。
+  - 推荐先用 `agentpack evolve propose --dry-run --json` 查看 candidates / skipped / warnings，再决定是否 `--yes` 创建 proposal 分支。
 
 ## 5. Target Adapter 细则
 

--- a/openspec/changes/v0-5-evolve-propose-coverage/.openspec.yaml
+++ b/openspec/changes/v0-5-evolve-propose-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/v0-5-evolve-propose-coverage/README.md
+++ b/openspec/changes/v0-5-evolve-propose-coverage/README.md
@@ -1,0 +1,3 @@
+# v0-5-evolve-propose-coverage
+
+Clarify and expand `evolve propose` coverage: report skipped drift (missing + multi-module outputs) instead of silently returning no drift.

--- a/openspec/changes/v0-5-evolve-propose-coverage/proposal.md
+++ b/openspec/changes/v0-5-evolve-propose-coverage/proposal.md
@@ -1,0 +1,14 @@
+# Change: evolve propose coverage (missing drift + aggregated outputs) (v0.5)
+
+## Why
+`evolve propose` is intentionally conservative, but previously it could look like "no drift" even when drift existed that it couldn't safely propose (e.g., missing files or multi-module aggregated outputs like combined instructions).
+
+## What Changes
+- `evolve propose` detects drift even for non-proposeable cases and reports them as `skipped` items with reasons.
+- `--json` output includes a `summary` and `skipped` list; human output prints skipped items.
+- Documentation clarifies the conservative behavior and recommends `--dry-run` first.
+
+## Impact
+- Affected specs: `agentpack`
+- Affected code: `src/cli.rs` (`evolve_propose`)
+- Affected docs/templates/tests: `docs/SPEC.md`, `templates/claude/commands/ap-evolve.md`, new CLI tests

--- a/openspec/changes/v0-5-evolve-propose-coverage/specs/agentpack/spec.md
+++ b/openspec/changes/v0-5-evolve-propose-coverage/specs/agentpack/spec.md
@@ -1,0 +1,13 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: evolve propose reports skipped drift
+When drift exists but cannot be safely mapped back to a single module (e.g., multi-module aggregated outputs) or when the deployed file is missing, `agentpack evolve propose` MUST report the drift as skipped instead of claiming there is no drift.
+
+#### Scenario: missing drift is reported as skipped
+- **GIVEN** an expected managed output is missing on disk
+- **WHEN** the user runs `agentpack evolve propose --dry-run --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.reason` equals `no_proposeable_drift`
+- **AND** `data.skipped[]` contains an item with `reason=missing`

--- a/openspec/changes/v0-5-evolve-propose-coverage/tasks.md
+++ b/openspec/changes/v0-5-evolve-propose-coverage/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+- [x] Report skipped drift reasons for missing and multi-module outputs.
+- [x] Update operator template to recommend `--dry-run` first.
+
+## 2. Tests
+- [x] Add a CLI test that asserts `--dry-run --json` reports skipped drift instead of `no_drift`.
+
+## 3. Docs
+- [x] Update `docs/SPEC.md` to document conservative behavior and next steps.
+
+## 4. Validation
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test`.
+- [x] Run `openspec validate v0-5-evolve-propose-coverage --strict --no-interactive`.

--- a/templates/claude/commands/ap-evolve.md
+++ b/templates/claude/commands/ap-evolve.md
@@ -2,10 +2,11 @@
 description: "Propose overlay updates from drift (evolve propose)"
 agentpack_version: "{{AGENTPACK_VERSION}}"
 allowed-tools:
+  - Bash("agentpack evolve propose --dry-run --json")
   - Bash("agentpack evolve propose --yes --json")
 ---
 
 Capture drifted deployed files into overlays and create a proposal branch.
 
 !bash
-agentpack evolve propose --yes --json
+agentpack evolve propose --dry-run --json

--- a/tests/cli_evolve_propose_skipped.rs
+++ b/tests/cli_evolve_propose_skipped.rs
@@ -1,0 +1,120 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn evolve_propose_reports_skipped_missing_and_multi_module_drift() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let repo_dir = tmp.path().join("repo");
+    let i1 = repo_dir.join("modules/instructions/one");
+    let i2 = repo_dir.join("modules/instructions/two");
+    std::fs::create_dir_all(&i1).expect("create instructions module 1");
+    std::fs::create_dir_all(&i2).expect("create instructions module 2");
+    std::fs::write(i1.join("AGENTS.md"), "# one\n").expect("write AGENTS 1");
+    std::fs::write(i2.join("AGENTS.md"), "# two\n").expect("write AGENTS 2");
+
+    let p1 = repo_dir.join("modules/prompt/one");
+    std::fs::create_dir_all(&p1).expect("create prompt module dir");
+    std::fs::write(p1.join("prompt.md"), "# prompt\n").expect("write prompt");
+
+    // Create drift for aggregated instructions output (multi-module output).
+    std::fs::write(codex_home.join("AGENTS.md"), "drifted\n").expect("write drifted AGENTS");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["instructions:one","instructions:two","prompt:one"]
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: true
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: "instructions:one"
+    type: instructions
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/instructions/one"
+  - id: "instructions:two"
+    type: instructions
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/instructions/two"
+  - id: "prompt:one"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt/one"
+"#,
+        codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest).expect("write manifest");
+
+    // The prompt output is expected under codex_home/prompts/prompt.md, but we leave it missing.
+    let out = agentpack_in(
+        tmp.path(),
+        &[
+            "--target",
+            "codex",
+            "evolve",
+            "propose",
+            "--dry-run",
+            "--json",
+        ],
+    );
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "evolve.propose");
+    assert_eq!(v["data"]["created"], false);
+    assert_eq!(v["data"]["reason"], "no_proposeable_drift");
+
+    let summary = &v["data"]["summary"];
+    assert_eq!(summary["drifted_proposeable"], 0);
+    assert_eq!(summary["skipped_missing"], 1);
+    assert_eq!(summary["skipped_multi_module"], 1);
+
+    let skipped = v["data"]["skipped"].as_array().expect("skipped array");
+    assert_eq!(skipped.len(), 2);
+    assert!(skipped.iter().any(|s| s["reason"] == "missing"));
+    assert!(skipped.iter().any(|s| s["reason"] == "multi_module_output"));
+}


### PR DESCRIPTION
Fixes #60.

What changed
- `evolve propose` no longer silently reports `no_drift` when drift exists but isn't safely proposeable.
- Reports skipped drift items for:
  - missing deployed files (`reason=missing`)
  - multi-module aggregated outputs (`reason=multi_module_output`)
- `--json` includes `summary`, `skipped`, and `warnings`; human output prints skipped items.
- Operator template `ap-evolve.md` runs `--dry-run` first.

Tests
- `tests/cli_evolve_propose_skipped.rs`
