### PR TITLE
fix(overlay): harden module_fs_key paths

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,5 +1,7 @@
 use crate::hash::sha256_hex;
 
+const MODULE_FS_KEY_PREFIX_MAX_LEN: usize = 64;
+
 pub fn is_safe_legacy_path_component(value: &str) -> bool {
     if value.is_empty() || value == "." || value == ".." {
         return false;
@@ -34,7 +36,22 @@ pub fn sanitize_fs_component(value: &str) -> String {
 }
 
 pub fn module_fs_key(module_id: &str) -> String {
-    let sanitized = sanitize_fs_component(module_id);
+    module_fs_key_with_max_prefix(module_id, MODULE_FS_KEY_PREFIX_MAX_LEN)
+}
+
+pub(crate) fn module_fs_key_unbounded(module_id: &str) -> String {
+    module_fs_key_with_max_prefix(module_id, usize::MAX)
+}
+
+fn module_fs_key_with_max_prefix(module_id: &str, max_prefix_len: usize) -> String {
+    let mut sanitized = sanitize_fs_component(module_id);
+    if sanitized.is_empty() {
+        sanitized = "module".to_string();
+    }
+    if sanitized.len() > max_prefix_len {
+        sanitized.truncate(max_prefix_len);
+    }
+
     let hash = sha256_hex(module_id.as_bytes());
     format!("{sanitized}--{}", &hash[..10])
 }
@@ -59,6 +76,23 @@ mod tests {
         assert!(!key.contains(':'));
         assert!(!key.contains('/'));
         assert!(!key.contains('\\'));
+    }
+
+    #[test]
+    fn module_fs_key_truncates_long_prefix_but_preserves_hash_suffix() {
+        let module_id = "a".repeat(300);
+        let key = module_fs_key(&module_id);
+        assert!(key.len() <= MODULE_FS_KEY_PREFIX_MAX_LEN + 2 + 10);
+
+        let hash = sha256_hex(module_id.as_bytes());
+        assert!(key.ends_with(&hash[..10]));
+    }
+
+    #[test]
+    fn module_fs_key_avoids_collisions_when_prefix_is_truncated() {
+        let a = format!("{}x", "a".repeat(300));
+        let b = format!("{}y", "a".repeat(300));
+        assert_ne!(module_fs_key(&a), module_fs_key(&b));
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -38,6 +38,16 @@ impl Store {
             .join(commit)
     }
 
+    fn git_checkout_dir_v2_legacy_fs_key(&self, module_id: &str, commit: &str) -> Option<PathBuf> {
+        let bounded = crate::ids::module_fs_key(module_id);
+        let unbounded = crate::ids::module_fs_key_unbounded(module_id);
+        if bounded == unbounded {
+            return None;
+        }
+
+        Some(self.root.join("git").join(unbounded).join(commit))
+    }
+
     fn git_checkout_dir_legacy(&self, module_id: &str, commit: &str) -> PathBuf {
         self.root
             .join("git")
@@ -55,6 +65,11 @@ impl Store {
         let dir = self.git_checkout_dir_v2(module_id, commit);
         if dir.exists() {
             return Ok(dir);
+        }
+        if let Some(legacy_fs_key) = self.git_checkout_dir_v2_legacy_fs_key(module_id, commit) {
+            if legacy_fs_key.exists() {
+                return Ok(legacy_fs_key);
+            }
         }
         let legacy = self.git_checkout_dir_legacy(module_id, commit);
         if legacy.exists() {

--- a/tests/cli_doctor_overlay_layout.rs
+++ b/tests/cli_doctor_overlay_layout.rs
@@ -1,0 +1,84 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn doctor_warns_when_legacy_and_canonical_overlay_dirs_coexist() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let init = agentpack_in(tmp.path(), &["init"]);
+    assert!(init.status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let module_id = "instructions-base";
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: []
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: false
+      write_user_prompts: false
+      write_user_skills: false
+      write_repo_skills: false
+      write_agents_repo_root: false
+
+modules:
+  - id: "{module_id}"
+    type: instructions
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/instructions/base"
+"#,
+        codex_home.display()
+    );
+    let manifest_path = tmp.path().join("repo").join("agentpack.yaml");
+    std::fs::write(&manifest_path, manifest).expect("write manifest");
+
+    let repo_dir = tmp.path().join("repo");
+    let canonical = repo_dir
+        .join("overlays")
+        .join(agentpack::ids::module_fs_key(module_id));
+    let legacy = repo_dir.join("overlays").join(module_id);
+    std::fs::create_dir_all(&canonical).expect("create canonical overlay dir");
+    std::fs::create_dir_all(&legacy).expect("create legacy overlay dir");
+
+    let out = agentpack_in(tmp.path(), &["--target", "codex", "doctor", "--json"]);
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    let warnings = v["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings.iter().any(|w| w
+            .as_str()
+            .unwrap_or_default()
+            .contains(&format!("overlay layout (global) module {module_id}"))),
+        "expected overlay layout warning"
+    );
+}


### PR DESCRIPTION
Closes #75.

- Bound `module_fs_key` prefix length to avoid path segment limits.
- Keep backward compatibility by falling back to the previous (unbounded) fs_key directories when present.
- `doctor` warns when multiple overlay dirs for the same module/scope coexist.
