### PR TITLE
fix(fs): unify atomic writes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ use crate::config::{Manifest, Module, ModuleType, TargetScope};
 use crate::deploy::{TargetPath, load_managed_paths_from_snapshot, plan as compute_plan};
 use crate::diff::unified_diff;
 use crate::engine::Engine;
+use crate::fs::write_atomic;
 use crate::hash::sha256_hex;
 use crate::lockfile::{Lockfile, generate_lockfile, hash_tree};
 use crate::output::{JsonEnvelope, JsonError, print_json};
@@ -1312,7 +1313,7 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
                 }
                 contents.push_str(line);
                 contents.push('\n');
-                std::fs::write(&gitignore_path, contents)
+                write_atomic(&gitignore_path, contents.as_bytes())
                     .with_context(|| format!("write {}", gitignore_path.display()))?;
                 Ok(true)
             }
@@ -2963,7 +2964,7 @@ fn evolve_propose(
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("create {}", parent.display()))?;
         }
-        std::fs::write(&dst, actual).with_context(|| format!("write {}", dst.display()))?;
+        write_atomic(&dst, actual).with_context(|| format!("write {}", dst.display()))?;
         touched.push(
             dst.strip_prefix(&engine.repo.repo_dir)
                 .unwrap_or(&dst)

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use anyhow::Context as _;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
+use crate::fs::write_atomic;
 use crate::user_error::UserError;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ValueEnum)]
@@ -171,7 +172,7 @@ impl Manifest {
         if !out.ends_with('\n') {
             out.push('\n');
         }
-        std::fs::write(path, out).with_context(|| format!("write {}", path.display()))?;
+        write_atomic(path, out.as_bytes()).with_context(|| format!("write {}", path.display()))?;
         Ok(())
     }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -6,6 +6,7 @@ use sha2::Digest as _;
 use walkdir::WalkDir;
 
 use crate::config::{GitSource, LocalPathSource, Manifest, ModuleType, SourceKind};
+use crate::fs::write_atomic;
 use crate::paths::RepoPaths;
 use crate::store::Store;
 use crate::user_error::UserError;
@@ -94,7 +95,7 @@ impl Lockfile {
         if !out.ends_with('\n') {
             out.push('\n');
         }
-        std::fs::write(path, out).with_context(|| format!("write {}", path.display()))?;
+        write_atomic(path, out.as_bytes()).with_context(|| format!("write {}", path.display()))?;
         Ok(())
     }
 }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::GitSource;
 use crate::config::{Manifest, Module, SourceKind};
-use crate::fs::{copy_tree, list_files};
+use crate::fs::{copy_tree, list_files, write_atomic};
 use crate::lockfile::{FileEntry, Lockfile, hash_tree};
 use crate::paths::{AgentpackHome, RepoPaths};
 use crate::store::Store;
@@ -234,7 +234,7 @@ fn write_overlay_module_id(module_id: &str, overlay_dir: &Path) -> anyhow::Resul
     if !content.ends_with('\n') {
         content.push('\n');
     }
-    std::fs::write(&path, content).with_context(|| format!("write {}", path.display()))?;
+    write_atomic(&path, content.as_bytes()).with_context(|| format!("write {}", path.display()))?;
     Ok(())
 }
 
@@ -261,7 +261,7 @@ fn write_overlay_baseline(upstream_root: &Path, overlay_dir: &Path) -> anyhow::R
     if !out.ends_with('\n') {
         out.push('\n');
     }
-    std::fs::write(&baseline_path, out)
+    write_atomic(&baseline_path, out.as_bytes())
         .with_context(|| format!("write {}", baseline_path.display()))?;
     Ok(())
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -2,6 +2,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
 
+use crate::fs::write_atomic;
+
 #[derive(Debug, Clone)]
 pub struct AgentpackHome {
     pub root: PathBuf,
@@ -66,22 +68,24 @@ impl RepoPaths {
 
         let base_agents = base_instructions_dir.join("AGENTS.md");
         if !base_agents.exists() {
-            std::fs::write(&base_agents, default_base_agents_md())
+            write_atomic(&base_agents, default_base_agents_md().as_bytes())
                 .context("write base AGENTS.md")?;
         }
 
         let draft_prompt = prompts_dir.join("draftpr.md");
         if !draft_prompt.exists() {
-            std::fs::write(&draft_prompt, default_draft_prompt_md())
+            write_atomic(&draft_prompt, default_draft_prompt_md().as_bytes())
                 .context("write draft prompt")?;
         }
 
         let ap_plan = claude_commands_dir.join("ap-plan.md");
         if !ap_plan.exists() {
-            std::fs::write(&ap_plan, default_ap_plan_md()).context("write ap-plan command")?;
+            write_atomic(&ap_plan, default_ap_plan_md().as_bytes())
+                .context("write ap-plan command")?;
         }
         if !self.manifest_path.exists() {
-            std::fs::write(&self.manifest_path, default_manifest()).context("write manifest")?;
+            write_atomic(&self.manifest_path, default_manifest().as_bytes())
+                .context("write manifest")?;
         }
         Ok(())
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 
+use crate::fs::write_atomic;
 use crate::paths::AgentpackHome;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,7 +70,7 @@ impl DeploymentSnapshot {
         if !out.ends_with('\n') {
             out.push('\n');
         }
-        std::fs::write(path, out).with_context(|| format!("write {}", path.display()))?;
+        write_atomic(path, out.as_bytes()).with_context(|| format!("write {}", path.display()))?;
         Ok(())
     }
 }

--- a/src/target_manifest.rs
+++ b/src/target_manifest.rs
@@ -4,6 +4,7 @@ use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 
 use crate::deploy::{ManagedPaths, TargetPath};
+use crate::fs::write_atomic;
 use crate::targets::TargetRoot;
 
 pub const TARGET_MANIFEST_FILENAME: &str = ".agentpack.manifest.json";
@@ -57,7 +58,7 @@ impl TargetManifest {
         if !out.ends_with('\n') {
             out.push('\n');
         }
-        std::fs::write(path, out).with_context(|| format!("write {}", path.display()))?;
+        write_atomic(path, out.as_bytes()).with_context(|| format!("write {}", path.display()))?;
         Ok(())
     }
 }


### PR DESCRIPTION
Closes #76.

- Add `fs::write_atomic` helper and route key file writes through it.
- Remove ad-hoc atomic write implementation and avoid remove+rewrite windows.

Files touched: manifest, lockfile, target manifest, snapshot state, overlay metadata, doctor gitignore fix, evolve propose.
