### PR TITLE
feat(deploy): require --adopt for unmanaged overwrites

### DIFF
--- a/openspec/changes/add-adopt-confirmation/.openspec.yaml
+++ b/openspec/changes/add-adopt-confirmation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/add-adopt-confirmation/README.md
+++ b/openspec/changes/add-adopt-confirmation/README.md
@@ -1,0 +1,3 @@
+# add-adopt-confirmation
+
+Require explicit confirmation before overwriting unmanaged existing target files (adopt_update guardrails).

--- a/openspec/changes/add-adopt-confirmation/proposal.md
+++ b/openspec/changes/add-adopt-confirmation/proposal.md
@@ -1,0 +1,21 @@
+# Change: Adopt confirmation for unmanaged overwrites
+
+## Why
+On a first deploy (no prior target manifest and no prior snapshot), Agentpack currently treats any existing file at a desired output path as a normal `update` and will overwrite it when applying. This can silently clobber user-owned, unmanaged files.
+
+## What Changes
+- Detect and classify “adopt updates”: updates that would overwrite an existing file that is **not known to be managed**.
+- Refuse to apply adopt updates unless the user explicitly opts in (separate from `--yes`).
+- In `--json` mode, return a stable error code for missing adopt confirmation so automation can branch reliably.
+- Expose adopt updates in plan/preview output (machine-readable) so callers can surface a clear prompt before apply.
+
+## Impact
+- Affected specs:
+  - `openspec/specs/agentpack/spec.md` (new requirement)
+  - `docs/SPEC.md` (CLI + `--json` contract update)
+- Affected code:
+  - `src/deploy.rs` (plan classification)
+  - `src/cli.rs` (deploy flag + enforcement)
+- Affected tests:
+  - golden snapshot updates under `tests/golden/`
+  - new CLI tests for `E_ADOPT_CONFIRM_REQUIRED`

--- a/openspec/changes/add-adopt-confirmation/specs/agentpack/spec.md
+++ b/openspec/changes/add-adopt-confirmation/specs/agentpack/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Adopt updates require explicit confirmation
+Agentpack MUST NOT overwrite an existing target file unless it is known to be managed **or** the user explicitly opts in to adopting that file.
+
+“Known to be managed” means the file path is present in at least one of:
+- the target manifest `.agentpack.manifest.json`, or
+- the latest deployment snapshot (when manifests are missing).
+
+#### Scenario: Unmanaged overwrite is refused by default
+- **GIVEN** a target file already exists at an output path
+- **AND** that file is not known to be managed
+- **AND** the desired content differs from the existing content
+- **WHEN** the user runs `agentpack deploy --apply`
+- **THEN** the command fails without writing
+- **AND** it reports how to re-run with explicit adopt confirmation
+
+#### Scenario: JSON mode returns stable error code for missing adopt confirmation
+- **GIVEN** an adopt update would be required
+- **WHEN** the user runs `agentpack deploy --apply --json --yes` without the explicit adopt flag
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_ADOPT_CONFIRM_REQUIRED`

--- a/openspec/changes/add-adopt-confirmation/tasks.md
+++ b/openspec/changes/add-adopt-confirmation/tasks.md
@@ -1,0 +1,19 @@
+## 1. Spec + Docs
+- [ ] Add OpenSpec delta requirement for adopt confirmation
+- [ ] Update `docs/SPEC.md` to document adopt behavior and error code
+
+## 2. Implementation
+- [ ] Extend plan output to mark adopt updates (machine-readable)
+- [ ] Add deploy flag to explicitly allow adopt updates (separate from `--yes`)
+- [ ] Refuse apply when adopt updates exist without explicit adopt flag
+- [ ] Add stable JSON error code `E_ADOPT_CONFIRM_REQUIRED`
+
+## 3. Tests
+- [ ] Update `tests/golden/plan_codex.json` for new plan fields
+- [ ] Add CLI test that deploy --json --yes refuses adopt without explicit adopt flag
+
+## 4. Validation
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] `cargo test --all --locked`
+- [ ] `openspec validate add-adopt-confirmation --strict --no-interactive`

--- a/tests/cli_deploy_adopt_confirmation.rs
+++ b/tests/cli_deploy_adopt_confirmation.rs
@@ -1,0 +1,95 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn deploy_json_refuses_adopt_updates_without_explicit_flag() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let init = agentpack_in(tmp.path(), &["init"]);
+    assert!(init.status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(codex_home.join("prompts")).expect("create prompts dir");
+
+    let repo_dir = tmp.path().join("repo");
+    let module_dir = repo_dir.join("modules/prompt_one");
+    std::fs::create_dir_all(&module_dir).expect("create module dir");
+    std::fs::write(module_dir.join("prompt.md"), "# new\n").expect("write prompt");
+
+    let existing_path = codex_home.join("prompts").join("prompt.md");
+    std::fs::write(&existing_path, "# old\n").expect("write existing prompt");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["prompt:one"]
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: false
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: "prompt:one"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt_one"
+"#,
+        codex_home.display()
+    );
+    let manifest_path = repo_dir.join("agentpack.yaml");
+    std::fs::write(&manifest_path, manifest).expect("write manifest");
+
+    let refused = agentpack_in(
+        tmp.path(),
+        &["--target", "codex", "deploy", "--apply", "--json", "--yes"],
+    );
+    assert!(!refused.status.success());
+    let v = parse_stdout_json(&refused);
+    assert_eq!(v["errors"][0]["code"], "E_ADOPT_CONFIRM_REQUIRED");
+    assert_eq!(
+        std::fs::read_to_string(&existing_path).expect("read existing prompt"),
+        "# old\n"
+    );
+
+    let allowed = agentpack_in(
+        tmp.path(),
+        &[
+            "--target", "codex", "deploy", "--apply", "--adopt", "--json", "--yes",
+        ],
+    );
+    assert!(allowed.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&existing_path).expect("read adopted prompt"),
+        "# new\n"
+    );
+}

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -468,6 +468,7 @@ fn plan_matches_golden_snapshot() -> anyhow::Result<()> {
                 "path": normalize(&c.path),
                 "before_sha256": c.before_sha256.as_deref(),
                 "after_sha256": c.after_sha256.as_deref(),
+                "update_kind": c.update_kind.as_ref(),
                 "reason": &c.reason,
             })
         })

--- a/tests/golden/plan_codex.json
+++ b/tests/golden/plan_codex.json
@@ -6,15 +6,17 @@
       "op": "create",
       "path": "<TMP>/a.txt",
       "reason": "file missing",
-      "target": "codex"
+      "target": "codex",
+      "update_kind": null
     },
     {
       "after_sha256": "6ae725813d3c3aaaa1bcd8b15c4707b4f5aa2a529ea089af5d350e14c21c4647",
       "before_sha256": "cba06b5736faf67e54b07b561eae94395e774c517a7d910a54369e1263ccfbd4",
       "op": "update",
       "path": "<TMP>/b.txt",
-      "reason": "content differs",
-      "target": "codex"
+      "reason": "would overwrite unmanaged existing file",
+      "target": "codex",
+      "update_kind": "adopt_update"
     }
   ],
   "summary": {


### PR DESCRIPTION
Closes #80.

Implements OpenSpec change `add-adopt-confirmation`:
- Plan output annotates update operations with `update_kind` (`managed_update` vs `adopt_update`).
- `deploy --apply` refuses to overwrite unmanaged existing files unless `--adopt` is provided.
- In `--json` mode, missing adopt confirmation returns stable error code `E_ADOPT_CONFIRM_REQUIRED` (even with `--yes`).

Also updates `docs/SPEC.md` and the plan golden snapshot.
