### PR TITLE
docs: add JSON API and error codes registry

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,0 +1,60 @@
+# ERROR_CODES.md
+
+> Current as of **v0.4** (2026-01-12). `docs/SPEC.md` remains the authoritative contract.
+
+本文件定义 `--json` 模式下对外稳定的错误码注册表（`errors[0].code`）。
+
+约定：
+- `ok=false` 时进程退出码非 0。
+- `errors[0].code` 用于自动化分支；`errors[0].message` 主要用于人类阅读（可能随版本优化）。
+- `warnings` 不用于强逻辑分支（字符串不保证稳定）。
+
+## 稳定错误码
+
+### `E_CONFIRM_REQUIRED`
+**含义**：在 `--json` 模式下，命令会产生写入（文件系统或 git），但缺少 `--yes`。
+**典型场景**：`deploy --apply --json` / `init --json` / `sync --json` 等。
+**是否可重试**：是。
+**建议动作**：确认这是预期写入后，补上 `--yes`；或移除 `--json` 走人类交互流程。
+
+### `E_ADOPT_CONFIRM_REQUIRED`
+**含义**：`deploy --apply` 将覆盖一个“非托管但已存在”的文件（adopt_update），但未显式提供 `--adopt`。
+**是否可重试**：是。
+**建议动作**：
+- 先 `plan/preview` 确认变更影响；
+- 若确实要接管该文件（覆盖写入），重新执行并加 `--adopt`。
+
+### `E_CONFIG_MISSING`
+**含义**：缺少 `repo/agentpack.yaml`。
+**是否可重试**：是。
+**建议动作**：运行 `agentpack init` 创建 repo skeleton，或指定正确的 `--repo`。
+
+### `E_CONFIG_INVALID`
+**含义**：`agentpack.yaml` 语法或语义不合法。
+**是否可重试**：取决于修复配置。
+**建议动作**：根据 `details`/报错信息修复 YAML（例如缺少 default profile / module id 重复 / source 配置不合法）。
+
+### `E_CONFIG_UNSUPPORTED_VERSION`
+**含义**：`agentpack.yaml` 的 `version` 不被支持。
+**是否可重试**：取决于修复配置或升级/降级工具版本。
+**建议动作**：将 `version` 调整为支持的版本（当前为 `1`），或升级 agentpack。
+
+### `E_LOCKFILE_MISSING`
+**含义**：缺少 `repo/agentpack.lock.json`，但当前命令需要它（例如 `fetch`）。
+**是否可重试**：是。
+**建议动作**：运行 `agentpack update`（或 `agentpack lock`）生成 lockfile。
+
+### `E_LOCKFILE_INVALID`
+**含义**：`agentpack.lock.json` JSON 不合法或无法解析。
+**是否可重试**：取决于修复/重建 lockfile。
+**建议动作**：修复 JSON 或删除后重新 `agentpack update` 生成。
+
+### `E_TARGET_UNSUPPORTED`
+**含义**：`--target` 指定了不支持的 target。
+**是否可重试**：是。
+**建议动作**：改用允许值（`all`/`codex`/`claude_code`），或修复 manifest targets 配置。
+
+### `E_DESIRED_STATE_CONFLICT`
+**含义**：多个模块对同一 `(target,path)` 产出不同内容，Agentpack 拒绝静默覆盖。
+**是否可重试**：取决于配置/overlay 调整。
+**建议动作**：调整 modules/overlays 使同一路径只由一个模块产出，或让冲突路径内容一致。

--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -1,0 +1,51 @@
+# JSON_API.md
+
+> Current as of **v0.4** (2026-01-12). `docs/SPEC.md` remains the authoritative contract.
+
+## 1. 稳定性承诺（原则）
+
+Agentpack 的 `--json` 输出被视为可编排的 API：
+- **stdout 永远是合法 JSON**（即使失败也返回 envelope，`ok=false`）。
+- `schema_version` 表示 envelope 的结构版本；当前为 `1`。
+- `warnings` 面向人类诊断（允许变动），**不要**依赖字符串匹配做关键分支。
+- 对常见且可行动的失败，`errors[0].code` 提供稳定错误码（见 `docs/ERROR_CODES.md`）。
+
+兼容性（schema_version=1）：
+- **允许新增字段**（additive change）作为向后兼容演进。
+- **不允许删除/重命名字段** 或改变字段语义而不升级 `schema_version`（breaking change）。
+
+## 2. Envelope 结构（schema_version=1）
+
+所有 `--json` 输出都包含：
+- `schema_version`: number
+- `ok`: boolean
+- `command`: string
+- `version`: string（agentpack 版本号）
+- `data`: object（成功返回的 payload；失败时为默认空值）
+- `warnings`: string[]
+- `errors`: {code, message, details?}[]
+
+示例（失败）：
+```json
+{
+  "schema_version": 1,
+  "ok": false,
+  "command": "deploy",
+  "version": "0.4.0",
+  "data": {},
+  "warnings": [],
+  "errors": [
+    {
+      "code": "E_CONFIRM_REQUIRED",
+      "message": "refusing to run 'deploy --apply' in --json mode without --yes",
+      "details": {"command": "deploy --apply"}
+    }
+  ]
+}
+```
+
+## 3. 版本化与演进建议
+
+- 自动化逻辑应以 `schema_version` + `errors[0].code` 为主。
+- 对 `data` 的解析建议采用“可选字段 + 默认值”的方式，容忍未来新增字段。
+- 对 `warnings` 仅做展示或日志记录，不建议做强逻辑分支。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -33,6 +33,8 @@
 - `E_TARGET_UNSUPPORTED`：不支持的 target（manifest targets 或 CLI `--target` 选择）。
 - `E_DESIRED_STATE_CONFLICT`：多个模块对同一 `(target,path)` 产出不同内容（拒绝静默覆盖）。
 
+详见：`docs/ERROR_CODES.md`。
+
 ## 1. 核心概念与数据模型
 
 ### 1.1 Module
@@ -439,6 +441,8 @@ Paths：
 - （future）可支持 plugin mode（输出 .claude-plugin/plugin.json），但当前实现未支持
 
 ## 6. JSON 输出规范（v0.2）
+
+详见：`docs/JSON_API.md`。
 
 所有 --json 输出必须包含：
 - schema_version: number


### PR DESCRIPTION
Closes #83.

Adds:
- `docs/ERROR_CODES.md`: stable `--json` error code registry + guidance
- `docs/JSON_API.md`: `--json` envelope contract + evolution rules
- `docs/SPEC.md`: links to the above docs

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
