### PR TITLE
fix(cli): improve desired state conflict error

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -321,6 +321,9 @@ agentpack preview [--diff]
 ### 4.5 plan / diff
 agentpack plan
 - 输出将要写入哪些 target、哪些文件、何种操作（create/update/delete）
+- 若多个模块对同一 `(target,path)` 产出：
+  - 同路径同内容：合并 module_ids（用于 provenance/解释）
+  - 同路径不同内容：报错并返回 `E_DESIRED_STATE_CONFLICT`（默认阻止 apply）
 agentpack diff
 - 输出逐文件 diff（text），JSON 模式输出 diff 摘要 + 文件 hash 变更
 - 对 update 操作：JSON 会额外输出 `update_kind`（`managed_update` / `adopt_update`）。

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -359,13 +359,84 @@ pub fn run() -> std::process::ExitCode {
                     }],
                 );
                 let _ = print_json(&envelope);
-            } else {
+            } else if !print_user_error_human(&err) {
                 eprintln!("{err:#}");
             }
 
             std::process::ExitCode::from(1)
         }
     }
+}
+
+fn print_user_error_human(err: &anyhow::Error) -> bool {
+    let Some(user_err) = err.chain().find_map(|e| e.downcast_ref::<UserError>()) else {
+        return false;
+    };
+
+    if user_err.code != "E_DESIRED_STATE_CONFLICT" {
+        return false;
+    }
+
+    eprintln!("error[{}]: {}", user_err.code, user_err.message);
+
+    let Some(details) = user_err.details.as_ref() else {
+        return true;
+    };
+
+    let target = details
+        .get("target")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>");
+    let path = details
+        .get("path")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>");
+    let existing_sha = details.pointer("/existing/sha256").and_then(|v| v.as_str());
+    let new_sha = details.pointer("/new/sha256").and_then(|v| v.as_str());
+    let existing_modules = summarize_json_string_array(details.pointer("/existing/module_ids"), 4);
+    let new_modules = summarize_json_string_array(details.pointer("/new/module_ids"), 4);
+
+    eprintln!("  target: {target}");
+    eprintln!("  path: {path}");
+    if let Some(sha) = existing_sha {
+        eprintln!("  existing sha256: {sha}");
+    }
+    eprintln!("  existing modules: {existing_modules}");
+    if let Some(sha) = new_sha {
+        eprintln!("  new sha256: {sha}");
+    }
+    eprintln!("  new modules: {new_modules}");
+    eprintln!(
+        "hint: ensure only one module owns each target/path, or make the contents identical."
+    );
+
+    true
+}
+
+fn summarize_json_string_array(value: Option<&serde_json::Value>, max: usize) -> String {
+    let mut unique = std::collections::BTreeSet::new();
+    if let Some(values) = value.and_then(|v| v.as_array()) {
+        for v in values {
+            if let Some(s) = v.as_str() {
+                unique.insert(s.to_string());
+            }
+        }
+    }
+
+    if unique.is_empty() {
+        return "<none>".to_string();
+    }
+
+    let total = unique.len();
+    let shown: Vec<String> = unique.into_iter().take(max).collect();
+    let remaining = total.saturating_sub(shown.len());
+
+    let mut out = shown.join(", ");
+    if remaining > 0 {
+        out.push_str(&format!(" ...({} more)", remaining));
+    }
+
+    out
 }
 
 fn require_yes_for_json_mutation(cli: &Cli, command_id: &'static str) -> anyhow::Result<()> {

--- a/tests/cli_desired_state_conflict.rs
+++ b/tests/cli_desired_state_conflict.rs
@@ -84,3 +84,81 @@ modules:
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_DESIRED_STATE_CONFLICT");
 }
+
+#[test]
+fn plan_human_includes_conflict_path_and_module_ids() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let init = agentpack_in(tmp.path(), &["init"]);
+    assert!(init.status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let repo_dir = tmp.path().join("repo");
+    let m1 = repo_dir.join("modules/prompt_one");
+    let m2 = repo_dir.join("modules/prompt_two");
+    std::fs::create_dir_all(&m1).expect("create module 1");
+    std::fs::create_dir_all(&m2).expect("create module 2");
+    std::fs::write(m1.join("prompt.md"), "# one\n").expect("write prompt 1");
+    std::fs::write(m2.join("prompt.md"), "# two\n").expect("write prompt 2");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["prompt:one","prompt:two"]
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+      write_agents_global: false
+      write_agents_repo_root: false
+
+modules:
+  - id: "prompt:one"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt_one"
+  - id: "prompt:two"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt_two"
+"#,
+        codex_home.display()
+    );
+    let manifest_path = repo_dir.join("agentpack.yaml");
+    std::fs::write(&manifest_path, manifest).expect("write manifest");
+
+    let plan = agentpack_in(tmp.path(), &["--target", "codex", "plan"]);
+    assert!(!plan.status.success());
+
+    let stderr = String::from_utf8_lossy(&plan.stderr);
+    assert!(stderr.contains("E_DESIRED_STATE_CONFLICT"));
+    assert!(stderr.contains("prompt:one"));
+    assert!(stderr.contains("prompt:two"));
+
+    let expected_suffix = std::path::Path::new("codex_home")
+        .join("prompts")
+        .join("prompt.md")
+        .to_string_lossy()
+        .to_string();
+    assert!(stderr.contains(&expected_suffix));
+}


### PR DESCRIPTION
Closes #85.

Changes:
- Human mode prints a readable summary for `E_DESIRED_STATE_CONFLICT` (target/path + module id summaries).
- `docs/SPEC.md` documents conflict strategy (same bytes merges module_ids; different bytes fails).
- Adds a CLI integration test for the human output.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
