### PR TITLE
ci: add cargo-deny checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,22 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  deny:
+    name: Dependency policy (cargo-deny)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.87.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny@0.18.3 --locked
+
+      - name: cargo deny
+        run: cargo deny check licenses bans sources

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,34 @@
+[graph]
+all-features = true
+
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  "Unlicense",
+  "Zlib",
+]
+
+[licenses.private]
+ignore = false
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/SECURITY_CHECKS.md
+++ b/docs/SECURITY_CHECKS.md
@@ -1,0 +1,36 @@
+# SECURITY_CHECKS.md
+
+本仓库在 CI 中默认启用两类依赖/安全检查：
+
+## 1) RustSec 漏洞扫描（advisories）
+
+- CI: `.github/workflows/ci.yml` 的 `Security audit` job（`rustsec/audit-check`）
+- 本地（可选）：安装后运行 `cargo audit`
+  - 安装：`cargo install cargo-audit --locked`
+
+失败处理建议：
+- **优先**升级/替换依赖以消除漏洞。
+- 若必须临时忽略（不推荐）：需要在 PR/Issue 中写明原因、影响范围、以及移除 ignore 的计划。
+
+## 2) cargo-deny 依赖策略检查（licenses / bans / sources）
+
+- CI: `.github/workflows/ci.yml` 的 `Dependency policy (cargo-deny)` job
+- 配置：`deny.toml`
+- 当前 CI 运行的 checks：
+  - `licenses`：许可证允许列表与例外
+  - `bans`：重复依赖版本与通配版本约束（`*`）
+  - `sources`：依赖来源（仅允许 crates.io；禁止未知 registry/git）
+
+本地运行：
+- `cargo install cargo-deny@0.18.3 --locked`
+- `cargo deny check licenses bans sources`
+
+失败处理建议：
+- **licenses**：
+  - 新增的许可证若可接受：将 SPDX 标识加入 `deny.toml` 的 `licenses.allow`
+  - 若仅某个 crate 需要例外：使用 `licenses.exceptions`（并写清楚 reason/issue）
+- **sources**：
+  - 尽量避免 git 依赖；若确实必要，显式加入 `sources.allow-git`（并写清楚 reason/issue）
+- **bans**：
+  - `wildcards`（`*`）被拒绝：将依赖版本固定到明确的 semver 约束
+  - `multiple-versions` 当前为 warning：可逐步通过 `cargo update -p <crate>` / 依赖升级来收敛


### PR DESCRIPTION
Closes #87.

Adds:
- `deny.toml` cargo-deny policy (licenses/bans/sources; advisories handled by existing RustSec audit job)
- CI job `Dependency policy (cargo-deny)` running `cargo deny check licenses bans sources`
- `docs/SECURITY_CHECKS.md` documenting security/dependency checks and exception process

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `cargo deny check licenses bans sources`
