### PR TITLE
feat(score): report events.jsonl skip stats

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -214,6 +214,11 @@ Schema（v1，示例）：
 - `event` 为自由 JSON；`score` 仅解析 `module_id|moduleId` 与 `success|ok`。
 - 顶层 `module_id` 与 `success` 为可选字段（兼容历史日志）；`score` 会优先使用它们。
 - `score` 必须容忍坏行（如截断/非 JSON）：跳过并输出 warning，而不是整个失败。
+- 兼容性：
+  - 允许在顶层新增字段（旧版本 reader 忽略未知字段）。
+  - 遇到不支持的 `schema_version`：跳过该行并输出 warning（不中断整个命令）。
+  - `score --json` 会在 `data.read_stats` 中输出 skipped 行数与原因统计，便于诊断日志健康度。
+- 可选顶层字段（additive，v1）：`command_id`、`duration_ms`、`git_rev`、`snapshot_id`、`targets`。
 
 ## 3. Overlays
 

--- a/openspec/changes/update-events-audit-log/proposal.md
+++ b/openspec/changes/update-events-audit-log/proposal.md
@@ -1,0 +1,15 @@
+# Change: Update events.jsonl as an evolvable audit log
+
+## Why
+`state/logs/events.jsonl` is the foundation for “AI-first observability” (`record` → `score` → `explain` → `evolve`). It should remain usable and diagnosable even when logs contain partial corruption or mixed schema versions, and it should support additive metadata for richer reporting.
+
+## What Changes
+- Define and document `events.jsonl` schema_version compatibility rules (forward/backwards behavior).
+- Add optional top-level metadata fields to recorded events (additive, backwards-compatible).
+- Enhance `agentpack score` to report counts of skipped lines and skip reasons (in both human output and `--json` data).
+
+## Impact
+- Affected specs: `openspec/specs/agentpack/spec.md`
+- Affected docs: `docs/SPEC.md`
+- Affected code: `src/events.rs`, `src/cli.rs`
+- Affected tests: CLI integration tests for `score`

--- a/openspec/changes/update-events-audit-log/specs/agentpack/spec.md
+++ b/openspec/changes/update-events-audit-log/specs/agentpack/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: score tolerates malformed events.jsonl lines
+`agentpack score` MUST tolerate malformed/partial lines in `events.jsonl` by skipping bad lines and emitting warnings, instead of failing the whole command.
+
+Additionally, the system SHOULD provide a structured summary of how many lines were skipped and why (e.g. read errors, malformed JSON, unsupported schema_version) so operators and automation can diagnose log health.
+
+#### Scenario: malformed line is skipped
+- **GIVEN** `events.jsonl` contains both valid and invalid JSON lines
+- **WHEN** the user runs `agentpack score --json`
+- **THEN** the command exits successfully with `ok=true`
+- **AND** `warnings` includes an entry referencing the skipped line
+
+#### Scenario: score reports skipped counts
+- **GIVEN** `events.jsonl` contains malformed JSON lines and unsupported schema versions
+- **WHEN** the user runs `agentpack score --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.read_stats.skipped_total` is greater than 0
+- **AND** `data.read_stats.skipped_malformed_json` is greater than 0
+
+## ADDED Requirements
+
+### Requirement: events.jsonl is forward-compatible
+`events.jsonl` MUST be treated as an evolvable audit log:
+- Readers MUST ignore unknown top-level fields (additive changes).
+- Readers MUST skip unsupported `schema_version` entries and emit warnings (do not fail the whole command).
+
+#### Scenario: unknown fields are ignored
+- **GIVEN** an `events.jsonl` entry includes additional top-level fields that are not recognized by this version
+- **WHEN** the user runs `agentpack score --json`
+- **THEN** the entry is parsed successfully and does not cause a failure
+
+#### Scenario: unsupported schema_version is skipped
+- **GIVEN** an `events.jsonl` entry with `schema_version` not supported by this version
+- **WHEN** the user runs `agentpack score --json`
+- **THEN** the entry is skipped
+- **AND** a warning is emitted

--- a/openspec/changes/update-events-audit-log/tasks.md
+++ b/openspec/changes/update-events-audit-log/tasks.md
@@ -1,0 +1,21 @@
+## 1. Spec & Docs
+
+- [x] Update OpenSpec deltas for events/score behavior
+- [x] Update `docs/SPEC.md` for events.jsonl compatibility + optional fields
+
+## 2. Implementation
+
+- [x] Extend `RecordedEvent` with optional metadata fields
+- [x] Track structured read/skip stats when reading events.jsonl
+- [x] Surface skip stats in `agentpack score` (human + `--json`)
+
+## 3. Tests
+
+- [x] Add/extend tests for score skip stats and compatibility behavior
+
+## 4. Validation
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo test --all --locked`
+- [x] `openspec validate update-events-audit-log --strict --no-interactive`

--- a/src/events.rs
+++ b/src/events.rs
@@ -15,15 +15,37 @@ pub struct RecordedEvent {
     pub recorded_at: String,
     pub machine_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_rev: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub module_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub success: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub targets: Option<Vec<String>>,
     pub event: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ReadEventsStats {
+    pub lines_total: u64,
+    pub lines_empty: u64,
+    pub records_ok: u64,
+    pub skipped_total: u64,
+    pub skipped_io_errors: u64,
+    pub skipped_malformed_json: u64,
+    pub skipped_unsupported_schema_version: u64,
 }
 
 pub struct ReadEventsResult {
     pub events: Vec<RecordedEvent>,
     pub warnings: Vec<String>,
+    pub stats: ReadEventsStats,
 }
 
 pub fn read_stdin_event() -> anyhow::Result<serde_json::Value> {
@@ -56,6 +78,38 @@ pub fn event_success(event: &serde_json::Value) -> Option<bool> {
     })
 }
 
+fn event_string_field(event: &serde_json::Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|k| event.get(*k))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn event_u64_field(event: &serde_json::Value, keys: &[&str]) -> Option<u64> {
+    keys.iter()
+        .find_map(|k| event.get(*k))
+        .and_then(|v| v.as_u64())
+}
+
+fn event_targets_field(event: &serde_json::Value) -> Option<Vec<String>> {
+    if let Some(values) = event.get("targets").and_then(|v| v.as_array()) {
+        let mut out: Vec<String> = values
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+        out.sort();
+        out.dedup();
+        if !out.is_empty() {
+            return Some(out);
+        }
+    }
+
+    event
+        .get("target")
+        .and_then(|v| v.as_str())
+        .map(|s| vec![s.to_string()])
+}
+
 pub fn append_event(home: &AgentpackHome, recorded: &RecordedEvent) -> anyhow::Result<PathBuf> {
     std::fs::create_dir_all(&home.logs_dir).context("create logs dir")?;
     let path = home.logs_dir.join(EVENTS_LOG_FILENAME);
@@ -82,8 +136,13 @@ pub fn new_record(machine_id: String, event: serde_json::Value) -> anyhow::Resul
         schema_version: EVENTS_SCHEMA_VERSION,
         recorded_at,
         machine_id,
+        command_id: event_string_field(&event, &["command_id", "commandId"]),
+        duration_ms: event_u64_field(&event, &["duration_ms", "durationMs"]),
+        git_rev: event_string_field(&event, &["git_rev", "gitRev"]),
         module_id: event_module_id(&event),
+        snapshot_id: event_string_field(&event, &["snapshot_id", "snapshotId"]),
         success: event_success(&event),
+        targets: event_targets_field(&event),
         event,
     })
 }
@@ -98,20 +157,25 @@ pub fn read_events_with_warnings(home: &AgentpackHome) -> anyhow::Result<ReadEve
         return Ok(ReadEventsResult {
             events: Vec::new(),
             warnings: Vec::new(),
+            stats: ReadEventsStats::default(),
         });
     }
 
     let f = std::fs::File::open(&path).with_context(|| format!("open {}", path.display()))?;
     let mut events = Vec::new();
     let mut warnings = Vec::new();
+    let mut stats = ReadEventsStats::default();
 
     use std::io::BufRead as _;
     let reader = std::io::BufReader::new(f);
     for (i, line) in reader.lines().enumerate() {
         let line_no = i + 1;
+        stats.lines_total += 1;
         let line = match line {
             Ok(s) => s,
             Err(err) => {
+                stats.skipped_total += 1;
+                stats.skipped_io_errors += 1;
                 warnings.push(format!(
                     "events.jsonl: failed to read line {line_no}: {err}"
                 ));
@@ -121,12 +185,15 @@ pub fn read_events_with_warnings(home: &AgentpackHome) -> anyhow::Result<ReadEve
 
         let trimmed = line.trim();
         if trimmed.is_empty() {
+            stats.lines_empty += 1;
             continue;
         }
 
         let evt: RecordedEvent = match serde_json::from_str(trimmed) {
             Ok(v) => v,
             Err(err) => {
+                stats.skipped_total += 1;
+                stats.skipped_malformed_json += 1;
                 warnings.push(format!(
                     "events.jsonl: skipped malformed JSON at line {line_no}: {err}"
                 ));
@@ -135,6 +202,8 @@ pub fn read_events_with_warnings(home: &AgentpackHome) -> anyhow::Result<ReadEve
         };
 
         if evt.schema_version != EVENTS_SCHEMA_VERSION {
+            stats.skipped_total += 1;
+            stats.skipped_unsupported_schema_version += 1;
             warnings.push(format!(
                 "events.jsonl: skipped unsupported schema_version {} at line {line_no}",
                 evt.schema_version
@@ -142,8 +211,13 @@ pub fn read_events_with_warnings(home: &AgentpackHome) -> anyhow::Result<ReadEve
             continue;
         }
 
+        stats.records_ok += 1;
         events.push(evt);
     }
 
-    Ok(ReadEventsResult { events, warnings })
+    Ok(ReadEventsResult {
+        events,
+        warnings,
+        stats,
+    })
 }

--- a/tests/cli_score_events_robustness.rs
+++ b/tests/cli_score_events_robustness.rs
@@ -28,6 +28,7 @@ fn score_json_skips_malformed_lines_with_warnings() {
         "schema_version": 1,
         "recorded_at": "2026-01-11T00:00:00Z",
         "machine_id": "m1",
+        "future_field": 123,
         "event": { "module_id": "skill:test", "success": false }
     });
 
@@ -51,6 +52,13 @@ fn score_json_skips_malformed_lines_with_warnings() {
     assert_eq!(v["ok"], true);
     assert!(v["warnings"].is_array());
     assert!(v["warnings"].as_array().unwrap().len() >= 2);
+
+    assert_eq!(v["data"]["read_stats"]["skipped_total"], 2);
+    assert_eq!(v["data"]["read_stats"]["skipped_malformed_json"], 1);
+    assert_eq!(
+        v["data"]["read_stats"]["skipped_unsupported_schema_version"],
+        1
+    );
 
     let modules = v["data"]["modules"].as_array().expect("modules array");
     let item = modules


### PR DESCRIPTION
Closes #97.

OpenSpec:
- `openspec/changes/update-events-audit-log/`

Changes:
- `events.jsonl` supports additive metadata fields on recorded events.
- `agentpack score --json` now includes `data.read_stats` (skipped-line counts + reasons).
- Docs updated in `docs/SPEC.md`.

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate update-events-audit-log --strict --no-interactive`
