### PR TITLE
feat(lockfile): make local_path repo-relative

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -168,6 +168,7 @@ modules:
 要求：
 - lockfile 变更必须可 diff（JSON 字段顺序固定，数组排序稳定）
 - install/fetch 只能使用 lockfile 的 resolved_version
+- 对于 local_path modules：`resolved_source.local_path.path` 必须记录 repo-relative 路径（不落绝对路径），并使用 `/` 作为分隔符，确保跨机器 diff 稳定。
 
 ### 2.3 <target root>/.agentpack.manifest.json（target manifest）
 

--- a/openspec/changes/update-lockfile-local-path/.openspec.yaml
+++ b/openspec/changes/update-lockfile-local-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/update-lockfile-local-path/README.md
+++ b/openspec/changes/update-lockfile-local-path/README.md
@@ -1,0 +1,3 @@
+# update-lockfile-local-path
+
+P2-2: Make lockfile local_path repo-relative

--- a/openspec/changes/update-lockfile-local-path/proposal.md
+++ b/openspec/changes/update-lockfile-local-path/proposal.md
@@ -1,0 +1,13 @@
+# Change: Make lockfile local_path repo-relative
+
+## Why
+`agentpack.lock.json` currently records absolute paths for `local_path` modules. This causes noisy diffs across machines and makes the lockfile harder to review, sync, and audit.
+
+## What Changes
+- When generating `agentpack.lock.json`, local-path modules record `resolved_source.local_path.path` as a repo-relative path (stable across machines), instead of an absolute path.
+- Update `docs/SPEC.md` to document the lockfile convention.
+
+## Impact
+- Affected specs: `agentpack` (lockfile contract)
+- Affected code: `src/lockfile.rs`
+- Affected tests: add coverage to ensure local paths are stored repo-relative

--- a/openspec/changes/update-lockfile-local-path/specs/agentpack/spec.md
+++ b/openspec/changes/update-lockfile-local-path/specs/agentpack/spec.md
@@ -1,0 +1,11 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Lockfile local paths are repo-relative
+When generating `agentpack.lock.json`, the system SHALL record `resolved_source.local_path.path` as a stable, repo-relative path so the lockfile remains portable across machines.
+
+#### Scenario: Lockfile local_path is stable across machines
+- **GIVEN** a module uses a `local_path` source inside the agentpack repo
+- **WHEN** the user runs `agentpack lock`
+- **THEN** the lockfile stores `resolved_source.local_path.path` without embedding an absolute machine path

--- a/openspec/changes/update-lockfile-local-path/tasks.md
+++ b/openspec/changes/update-lockfile-local-path/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+- [x] Update lockfile generation so `resolved_source.local_path.path` is repo-relative (not absolute).
+- [x] Preserve existing lockfile parsing behavior (existing lockfiles still load).
+
+## 2. Tests
+- [x] Add a test that verifies a local module’s `resolved_source.local_path.path` does not contain an absolute path.
+
+## 3. Docs
+- [x] Update `docs/SPEC.md` lockfile section to document repo-relative local paths.
+
+## 4. Validation
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] Run `cargo test --all --locked`.
+- [x] Run `openspec validate update-lockfile-local-path --strict --no-interactive`.

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -121,11 +121,10 @@ pub fn generate_lockfile(
                     .as_ref()
                     .context("missing local_path")?;
                 let abs = repo_root.join(&lp.path);
+                let rel = lp.path.replace('\\', "/");
                 (
                     ResolvedSource {
-                        local_path: Some(ResolvedLocalPathSource {
-                            path: abs.to_string_lossy().to_string(),
-                        }),
+                        local_path: Some(ResolvedLocalPathSource { path: rel }),
                         git: None,
                     },
                     "local".to_string(),

--- a/tests/lockfile_local_path.rs
+++ b/tests/lockfile_local_path.rs
@@ -1,0 +1,84 @@
+use std::collections::BTreeMap;
+
+use agentpack::config::{LocalPathSource, Manifest, Module, ModuleType, Profile, Source};
+use agentpack::lockfile::generate_lockfile;
+use agentpack::paths::{AgentpackHome, RepoPaths};
+use agentpack::store::Store;
+
+#[test]
+fn lockfile_stores_local_path_repo_relative() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let repo_dir = tmp.path().join("repo");
+    std::fs::create_dir_all(repo_dir.join("modules/prompts")).expect("create dirs");
+    std::fs::write(repo_dir.join("modules/prompts/test.md"), "hello\n").expect("write file");
+
+    let mut profiles = BTreeMap::new();
+    profiles.insert(
+        "default".to_string(),
+        Profile {
+            include_tags: Vec::new(),
+            include_modules: Vec::new(),
+            exclude_modules: Vec::new(),
+        },
+    );
+
+    let manifest = Manifest {
+        version: 1,
+        profiles,
+        targets: BTreeMap::new(),
+        modules: vec![Module {
+            id: "prompt:test".to_string(),
+            module_type: ModuleType::Prompt,
+            enabled: true,
+            tags: Vec::new(),
+            targets: Vec::new(),
+            source: Source {
+                local_path: Some(LocalPathSource {
+                    path: "modules/prompts/test.md".to_string(),
+                }),
+                git: None,
+            },
+            metadata: BTreeMap::new(),
+        }],
+    };
+
+    let repo = RepoPaths {
+        repo_dir: repo_dir.clone(),
+        manifest_path: repo_dir.join("agentpack.yaml"),
+        lockfile_path: repo_dir.join("agentpack.lock.json"),
+    };
+
+    let home_root = tmp.path().join("home");
+    let state_dir = home_root.join("state");
+    let home = AgentpackHome {
+        root: home_root.clone(),
+        repo_dir: home_root.join("repo"),
+        state_dir: state_dir.clone(),
+        cache_dir: home_root.join("cache"),
+        snapshots_dir: state_dir.join("snapshots"),
+        logs_dir: state_dir.join("logs"),
+    };
+    let store = Store::new(&home);
+
+    let lock = generate_lockfile(&repo, &manifest, &store)?;
+    assert_eq!(lock.modules.len(), 1);
+
+    let stored = lock.modules[0]
+        .resolved_source
+        .local_path
+        .as_ref()
+        .expect("local_path populated")
+        .path
+        .as_str();
+    assert_eq!(stored, "modules/prompts/test.md");
+    assert!(!stored.contains('\\'), "stored path should be POSIX style");
+
+    let tmp_str = tmp.path().to_string_lossy();
+    assert!(
+        !stored.contains(tmp_str.as_ref()),
+        "stored path should not embed the machine absolute path"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #103.

## Summary
- Generate `agentpack.lock.json` with repo-relative `resolved_source.local_path.path` for local modules (no absolute machine paths).
- Add test coverage and document in `docs/SPEC.md`.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate update-lockfile-local-path --strict --no-interactive`
