### PR TITLE
feat(evolve): map aggregated instructions drift via markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project follows SemVer with the following clarifications (especially for au
 ### Changed
 - Deploy now requires explicit `--adopt` for `adopt_update` overwrites (stable `E_ADOPT_CONFIRM_REQUIRED`).
 - Overlay/store directory naming uses a bounded, filesystem-safe `module_fs_key` with legacy fallbacks.
+- Combined Codex instructions output (`AGENTS.md`) uses per-module section markers to enable `evolve propose` mapping for aggregated outputs.
 
 ### Fixed
 - Unifies atomic writes across all critical file writes.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -411,9 +411,18 @@ agentpack evolve propose [--module-id <id>] [--scope global|machine|project]
 - `--json` 模式下要求同时提供 `--yes`（缺少则 `E_CONFIRM_REQUIRED`）。
 - 要求 config repo 工作树干净；会创建分支并尝试提交（若 git identity 缺失导致提交失败，会提示并保留分支与改动）。
 - 当前实现是保守的（conservative），只会对“可安全映射回单个模块”的 drift 生成 proposal：
-  - 仅处理 `module_ids.len()==1` 的输出（多模块聚合输出会被跳过并提示）。
+  - 默认仅处理 `module_ids.len()==1` 的输出。
+  - 对聚合的 Codex `AGENTS.md`（由多个 `instructions` 模块合成）：当文件包含分段 marker 时，会尝试将 drift 映射回具体模块片段并生成 proposal（marker 缺失/不可解析时仍会跳过并提示 `multi_module_output`）。
   - 仅处理 deployed 文件“存在且内容不同”的 drift；对于 `missing` drift（文件不存在）会跳过并提示（建议通过 `deploy` 恢复）。
   - 推荐先用 `agentpack evolve propose --dry-run --json` 查看 candidates / skipped / warnings，再决定是否 `--yes` 创建 proposal 分支。
+
+聚合 instructions 的 marker 格式（v0.5+，示例）：
+
+```md
+<!-- agentpack:module=instructions:one -->
+# one
+<!-- /agentpack -->
+```
 
 ## 5. Target Adapter 细则
 

--- a/openspec/changes/add-instructions-markers/.openspec.yaml
+++ b/openspec/changes/add-instructions-markers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/add-instructions-markers/README.md
+++ b/openspec/changes/add-instructions-markers/README.md
@@ -1,0 +1,3 @@
+# add-instructions-markers
+
+Add module section markers to combined instructions outputs and enable evolve propose to map drift back to a specific module.

--- a/openspec/changes/add-instructions-markers/proposal.md
+++ b/openspec/changes/add-instructions-markers/proposal.md
@@ -1,0 +1,17 @@
+# Change: Add instructions section markers (enable evolve propose for aggregated AGENTS.md)
+
+## Why
+`agentpack` aggregates multiple `instructions` modules into a single deployed `AGENTS.md` (Codex target). Today, `agentpack evolve propose` intentionally refuses to generate proposals for multi-module outputs, which blocks the most common real-world workflow: editing a combined instructions file and wanting to map that drift back to the correct `instructions:<id>` module for review.
+
+## What Changes
+- Codex instructions aggregation writes stable per-module section markers in the combined `AGENTS.md` output.
+- `agentpack evolve propose` detects these markers and, when possible, maps drift in an aggregated `AGENTS.md` back to the specific `instructions` module section(s), producing proposeable candidates instead of `multi_module_output` skips.
+
+## Compatibility
+- This changes the deployed `AGENTS.md` content (comments are added). Existing deployments will appear drifted until re-deployed.
+- Behavior is additive for automation: JSON schema does not change; only `evolve propose` becomes more capable.
+
+## Impact
+- Affected specs: `agentpack`
+- Affected code: `src/engine.rs` (instructions aggregation), `src/cli/commands/evolve.rs` (proposal mapping)
+- Affected docs/tests: `docs/SPEC.md`, new CLI test for marker-based proposals

--- a/openspec/changes/add-instructions-markers/specs/agentpack/spec.md
+++ b/openspec/changes/add-instructions-markers/specs/agentpack/spec.md
@@ -1,0 +1,21 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Combined instructions outputs include per-module markers
+When multiple `instructions` modules contribute to a combined deployed `AGENTS.md`, the system SHALL include stable, per-module section markers so drift in the combined file can be mapped back to a specific module.
+
+#### Scenario: Combined AGENTS.md contains markers
+- **GIVEN** two `instructions` modules are enabled for the `codex` target
+- **WHEN** the system renders desired state for Codex agent instructions
+- **THEN** the combined `AGENTS.md` content contains a section marker per module id
+
+### Requirement: evolve propose can map marked instructions drift back to a module
+When a deployed combined `AGENTS.md` contains valid per-module section markers, `agentpack evolve propose` SHALL treat drifted sections as proposeable and generate overlay updates for the corresponding `instructions` module(s).
+
+#### Scenario: drifted marked section becomes a propose candidate
+- **GIVEN** a deployed combined `AGENTS.md` containing section markers for `instructions:one` and `instructions:two`
+- **AND** only the `instructions:one` section content is edited on disk
+- **WHEN** the user runs `agentpack evolve propose --dry-run --json`
+- **THEN** `data.candidates[]` contains an item with `module_id="instructions:one"`
+- **AND** the drift is not reported as `multi_module_output` skipped for that output

--- a/openspec/changes/add-instructions-markers/tasks.md
+++ b/openspec/changes/add-instructions-markers/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+- [x] Add stable section marker format for aggregated instructions outputs.
+- [x] Extend `evolve propose` to parse marker sections for `AGENTS.md` and propose per-module overlay updates.
+- [x] Keep conservative fallback: if markers are missing/unparseable, keep reporting `multi_module_output` as skipped.
+
+## 2. Tests
+- [x] Add a CLI test that:
+  - deploys combined `AGENTS.md` with markers
+  - edits only one marked module section
+  - asserts `evolve propose --dry-run --json` returns a candidate for that module (not `multi_module_output`)
+
+## 3. Docs
+- [x] Update `docs/SPEC.md` to document marker format and the evolve workflow for aggregated instructions.
+
+## 4. Validation
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] Run `cargo test --all --locked`.
+- [x] Run `openspec validate add-instructions-markers --strict --no-interactive`.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -218,11 +218,22 @@ impl Engine {
                 .iter()
                 .map(|(id, _)| id.clone())
                 .collect();
-            let combined = instructions_parts
-                .into_iter()
-                .map(|(_, text)| text)
-                .collect::<Vec<_>>()
-                .join("\n\n---\n\n");
+            let add_markers = instructions_parts.len() > 1;
+            let combined = if add_markers {
+                instructions_parts
+                    .into_iter()
+                    .map(|(module_id, text)| {
+                        crate::markers::format_module_section(&module_id, &text)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n\n---\n\n")
+            } else {
+                instructions_parts
+                    .into_iter()
+                    .map(|(_, text)| text)
+                    .collect::<Vec<_>>()
+                    .join("\n\n---\n\n")
+            };
             let bytes = combined.into_bytes();
 
             if write_agents_global {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod hash;
 pub mod ids;
 pub mod lockfile;
 pub mod machine;
+pub mod markers;
 pub mod output;
 pub mod overlay;
 pub mod paths;

--- a/src/markers.rs
+++ b/src/markers.rs
@@ -1,0 +1,81 @@
+use std::collections::BTreeMap;
+
+use anyhow::Context as _;
+
+pub const MODULE_SECTION_START_PREFIX: &str = "<!-- agentpack:module=";
+pub const MODULE_SECTION_END_MARKER: &str = "<!-- /agentpack -->";
+
+pub fn format_module_section(module_id: &str, content: &str) -> String {
+    let mut out = String::new();
+    out.push_str(MODULE_SECTION_START_PREFIX);
+    out.push_str(module_id);
+    out.push_str(" -->\n");
+    out.push_str(content);
+    if !content.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(MODULE_SECTION_END_MARKER);
+    out
+}
+
+pub fn parse_module_sections(text: &str) -> anyhow::Result<BTreeMap<String, String>> {
+    fn parse_start_marker(line: &str) -> Option<String> {
+        let trimmed = line.trim();
+        if !trimmed.starts_with(MODULE_SECTION_START_PREFIX) {
+            return None;
+        }
+        if !trimmed.ends_with("-->") {
+            return None;
+        }
+
+        let raw = trimmed
+            .strip_prefix(MODULE_SECTION_START_PREFIX)?
+            .strip_suffix("-->")?
+            .trim();
+        if raw.is_empty() {
+            return None;
+        }
+        Some(raw.to_string())
+    }
+
+    let mut sections = BTreeMap::<String, String>::new();
+    let mut current: Option<(String, String)> = None;
+
+    for line in text.split_inclusive('\n') {
+        if let Some((_module_id, buf)) = current.as_mut() {
+            if line.trim() == MODULE_SECTION_END_MARKER {
+                let Some((module_id, buf)) = current.take() else {
+                    continue;
+                };
+                anyhow::ensure!(
+                    !sections.contains_key(&module_id),
+                    "duplicate module section: {module_id}"
+                );
+                sections.insert(module_id, buf);
+                continue;
+            }
+
+            if parse_start_marker(line).is_some() {
+                anyhow::bail!("nested module section marker");
+            }
+
+            buf.push_str(line);
+            continue;
+        }
+
+        if let Some(module_id) = parse_start_marker(line) {
+            current = Some((module_id, String::new()));
+        }
+    }
+
+    if let Some((module_id, _)) = current {
+        anyhow::bail!("unterminated module section for {module_id}");
+    }
+
+    Ok(sections)
+}
+
+pub fn parse_module_sections_from_bytes(bytes: &[u8]) -> anyhow::Result<BTreeMap<String, String>> {
+    let text = std::str::from_utf8(bytes).context("decode as utf-8")?;
+    parse_module_sections(text)
+}

--- a/tests/cli_evolve_propose_marked_instructions.rs
+++ b/tests/cli_evolve_propose_marked_instructions.rs
@@ -1,0 +1,120 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn evolve_propose_can_map_marked_instructions_sections_to_modules() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let repo_dir = tmp.path().join("repo");
+    let i1 = repo_dir.join("modules/instructions/one");
+    let i2 = repo_dir.join("modules/instructions/two");
+    std::fs::create_dir_all(&i1).expect("create instructions module 1");
+    std::fs::create_dir_all(&i2).expect("create instructions module 2");
+    std::fs::write(i1.join("AGENTS.md"), "# one\n").expect("write AGENTS 1");
+    std::fs::write(i2.join("AGENTS.md"), "# two\n").expect("write AGENTS 2");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["instructions:one","instructions:two"]
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: true
+      write_agents_repo_root: false
+      write_user_prompts: false
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: "instructions:one"
+    type: instructions
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/instructions/one"
+  - id: "instructions:two"
+    type: instructions
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/instructions/two"
+"#,
+        codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest).expect("write manifest");
+
+    let deploy = agentpack_in(
+        tmp.path(),
+        &["--target", "codex", "deploy", "--apply", "--json", "--yes"],
+    );
+    assert!(deploy.status.success());
+
+    let agents_path = codex_home.join("AGENTS.md");
+    let mut agents = std::fs::read_to_string(&agents_path).expect("read AGENTS.md");
+    assert!(agents.contains("<!-- agentpack:module=instructions:one -->"));
+    assert!(agents.contains("<!-- agentpack:module=instructions:two -->"));
+    assert!(agents.contains("<!-- /agentpack -->"));
+
+    agents = agents.replace("# one", "# one edited");
+    std::fs::write(&agents_path, agents).expect("write drifted AGENTS.md");
+
+    let out = agentpack_in(
+        tmp.path(),
+        &[
+            "--target",
+            "codex",
+            "evolve",
+            "propose",
+            "--dry-run",
+            "--json",
+        ],
+    );
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "evolve.propose");
+    assert_eq!(v["data"]["reason"], "dry_run");
+
+    let candidates = v["data"]["candidates"]
+        .as_array()
+        .expect("candidates array");
+    assert!(
+        candidates
+            .iter()
+            .any(|c| c["module_id"] == "instructions:one")
+    );
+
+    let skipped = v["data"]["skipped"].as_array().expect("skipped array");
+    assert!(!skipped.iter().any(|s| s["reason"] == "multi_module_output"));
+}


### PR DESCRIPTION
Closes #109.

What
- Codex combined instructions output (`AGENTS.md`) now wraps each module section with stable markers when multiple instructions modules are present.
- `agentpack evolve propose` can parse these markers and propose per-module overlay updates for drifted sections (falls back to `multi_module_output` when markers are missing/unparseable).

Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate add-instructions-markers --strict --no-interactive`