### PR TITLE
feat(evolve): add restore for missing drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project follows SemVer with the following clarifications (especially for au
 - Release automation via cargo-dist (`.github/workflows/release.yml`) and docs (`docs/RELEASING.md`).
 - `--json` contract docs: `docs/JSON_API.md` and `docs/ERROR_CODES.md`.
 - GitHub Issue Forms (`.github/ISSUE_TEMPLATE/*.yml`).
+- `agentpack evolve restore` to restore missing desired outputs (create-only).
 
 ### Changed
 - Deploy now requires explicit `--adopt` for `adopt_update` overwrites (stable `E_ADOPT_CONFIRM_REQUIRED`).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -424,6 +424,14 @@ agentpack evolve propose [--module-id <id>] [--scope global|machine|project]
 <!-- /agentpack -->
 ```
 
+### 4.15 evolve restore
+agentpack evolve restore [--module-id <id>]
+- 将 `missing` 的 desired outputs 以“create-only”的方式恢复到磁盘（只创建缺失文件；不更新已存在文件；不删除任何文件）。
+
+补充：
+- `--json` 模式下若会写入，要求同时提供 `--yes`（缺少则 `E_CONFIRM_REQUIRED`）。
+- 支持 `--dry-run`：仅输出将要恢复的文件列表，不写入。
+
 ## 5. Target Adapter 细则
 
 ### 5.1 codex target

--- a/openspec/changes/add-evolve-restore/.openspec.yaml
+++ b/openspec/changes/add-evolve-restore/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/add-evolve-restore/README.md
+++ b/openspec/changes/add-evolve-restore/README.md
@@ -1,0 +1,3 @@
+# add-evolve-restore
+
+Add an evolve restore helper to repair missing drift by restoring desired outputs.

--- a/openspec/changes/add-evolve-restore/proposal.md
+++ b/openspec/changes/add-evolve-restore/proposal.md
@@ -1,0 +1,16 @@
+# Change: Add `evolve restore` for missing drift
+
+## Why
+`agentpack evolve propose` intentionally focuses on creating reviewable overlay changes. When drift is `missing` (a desired output file is absent on disk), the most common operator intent is to restore the desired state (i.e., write the expected content back), not to update source.
+
+Today, that requires running a full `deploy --apply`, which may also update other managed files. A targeted “restore missing only” helper reduces risk and makes recovery workflows more ergonomic for both humans and automation.
+
+## What Changes
+- Add a new subcommand: `agentpack evolve restore`.
+- Behavior: create-only restore of missing desired outputs (no updates, no deletes).
+- JSON guardrails: in `--json` mode, requires `--yes` (stable `E_CONFIRM_REQUIRED`).
+
+## Impact
+- Affected specs: `agentpack-cli`
+- Affected code: `src/cli/args.rs`, `src/cli/commands/evolve.rs`
+- Affected docs/tests: `docs/SPEC.md`, new CLI tests

--- a/openspec/changes/add-evolve-restore/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-evolve-restore/specs/agentpack-cli/spec.md
@@ -1,0 +1,20 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: evolve restore repairs missing desired outputs
+The system SHALL provide `agentpack evolve restore` to repair `missing` drift by restoring the desired outputs on disk.
+
+The command SHALL only create missing files:
+- It MUST NOT modify existing files (no updates).
+- It MUST NOT delete files.
+
+#### Scenario: evolve restore recreates a missing file
+- **GIVEN** a desired output path is missing on disk
+- **WHEN** the user runs `agentpack evolve restore --yes`
+- **THEN** the missing file is created with the desired content
+
+#### Scenario: evolve restore --json requires --yes
+- **WHEN** the user runs `agentpack evolve restore --json` without `--yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`

--- a/openspec/changes/add-evolve-restore/tasks.md
+++ b/openspec/changes/add-evolve-restore/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+- [x] Add `agentpack evolve restore` subcommand and wire it in CLI dispatch.
+- [x] Implement restore behavior: write only missing desired outputs (create-only).
+- [x] `--json` mode requires `--yes` (`E_CONFIRM_REQUIRED`) and outputs a stable summary.
+
+## 2. Tests
+- [x] Add a CLI test for `evolve restore --json` requiring `--yes`.
+- [x] Add a CLI test that verifies `evolve restore` recreates a missing desired output file.
+
+## 3. Docs
+- [x] Update `docs/SPEC.md` to document `evolve restore` behavior and safety properties.
+
+## 4. Validation
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] Run `cargo test --all --locked`.
+- [x] Run `openspec validate add-evolve-restore --strict --no-interactive`.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -285,6 +285,13 @@ pub enum EvolveCommands {
         #[arg(long)]
         branch: Option<String>,
     },
+
+    /// Restore missing desired outputs on disk (create-only; no updates/deletes)
+    Restore {
+        /// Only restore missing outputs attributable to a module id
+        #[arg(long)]
+        module_id: Option<String>,
+    },
 }
 
 impl Cli {

--- a/src/cli/commands/evolve.rs
+++ b/src/cli/commands/evolve.rs
@@ -23,6 +23,9 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &EvolveCommands) -> anyhow::Result<()>
             *scope,
             branch.as_deref(),
         ),
+        EvolveCommands::Restore { module_id } => {
+            evolve_restore(ctx.cli, &engine, module_id.as_deref())
+        }
     }
 }
 
@@ -479,6 +482,148 @@ fn evolve_propose(
         }
         if !committed {
             println!("Note: commit failed; changes are left on the proposal branch.");
+        }
+    }
+
+    Ok(())
+}
+
+fn evolve_restore(
+    cli: &super::super::args::Cli,
+    engine: &Engine,
+    module_filter: Option<&str>,
+) -> anyhow::Result<()> {
+    #[derive(Debug, Clone, serde::Serialize)]
+    struct RestoreItem {
+        target: String,
+        path: String,
+        path_posix: String,
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        module_ids: Vec<String>,
+    }
+
+    #[derive(Default, serde::Serialize)]
+    struct RestoreSummary {
+        missing: u64,
+        restored: u64,
+        skipped_existing: u64,
+        skipped_read_error: u64,
+    }
+
+    let render = engine.desired_state(&cli.profile, &cli.target)?;
+    let desired = render.desired;
+
+    let mut warnings = render.warnings;
+    let mut summary = RestoreSummary::default();
+    let mut missing: Vec<(TargetPath, Vec<u8>, Vec<String>)> = Vec::new();
+
+    for (tp, desired_file) in &desired {
+        if let Some(filter) = module_filter {
+            if !desired_file.module_ids.iter().any(|id| id == filter) {
+                continue;
+            }
+        }
+
+        match std::fs::metadata(&tp.path) {
+            Ok(_) => {
+                summary.skipped_existing += 1;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                summary.missing += 1;
+                missing.push((
+                    tp.clone(),
+                    desired_file.bytes.clone(),
+                    desired_file.module_ids.clone(),
+                ));
+            }
+            Err(err) => {
+                summary.skipped_read_error += 1;
+                warnings.push(format!(
+                    "evolve.restore: skipped {} {}: failed to stat path: {err}",
+                    tp.target,
+                    tp.path.display()
+                ));
+            }
+        }
+    }
+
+    if missing.is_empty() {
+        if cli.json {
+            let mut envelope = JsonEnvelope::ok(
+                "evolve.restore",
+                serde_json::json!({
+                    "restored": [],
+                    "summary": summary,
+                    "reason": "no_missing",
+                }),
+            );
+            envelope.warnings = warnings;
+            print_json(&envelope)?;
+        } else {
+            for w in warnings {
+                eprintln!("Warning: {w}");
+            }
+            println!("No missing desired outputs to restore");
+        }
+        return Ok(());
+    }
+
+    if cli.json && !cli.yes && !cli.dry_run {
+        return Err(UserError::confirm_required("evolve restore"));
+    }
+    if !cli.json
+        && !cli.yes
+        && !cli.dry_run
+        && !super::super::util::confirm("Restore missing desired outputs?")?
+    {
+        println!("Aborted");
+        return Ok(());
+    }
+
+    let mut restored: Vec<RestoreItem> = Vec::new();
+    for (tp, bytes, module_ids) in missing {
+        if !cli.dry_run {
+            crate::fs::write_atomic(&tp.path, &bytes)
+                .with_context(|| format!("write {}", tp.path.display()))?;
+            summary.restored += 1;
+        }
+
+        restored.push(RestoreItem {
+            target: tp.target.clone(),
+            path: tp.path.to_string_lossy().to_string(),
+            path_posix: crate::paths::path_to_posix_string(&tp.path),
+            module_ids,
+        });
+    }
+
+    restored.sort_by(|a, b| {
+        (a.target.as_str(), a.path.as_str()).cmp(&(b.target.as_str(), b.path.as_str()))
+    });
+
+    if cli.json {
+        let reason = if cli.dry_run { "dry_run" } else { "restored" };
+
+        let mut envelope = JsonEnvelope::ok(
+            "evolve.restore",
+            serde_json::json!({
+                "restored": restored,
+                "summary": summary,
+                "reason": reason,
+            }),
+        );
+        envelope.warnings = warnings;
+        print_json(&envelope)?;
+    } else {
+        for w in warnings {
+            eprintln!("Warning: {w}");
+        }
+        if cli.dry_run {
+            println!("Would restore missing desired outputs (dry-run):");
+        } else {
+            println!("Restored missing desired outputs:");
+        }
+        for item in restored {
+            println!("- {} {}", item.target, item.path);
         }
     }
 

--- a/src/cli/commands/help.rs
+++ b/src/cli/commands/help.rs
@@ -30,6 +30,7 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
             {"id":"explain diff","path":["explain","diff"],"mutating":false},
             {"id":"explain status","path":["explain","status"],"mutating":false},
             {"id":"evolve propose","path":["evolve","propose"],"mutating":true},
+            {"id":"evolve restore","path":["evolve","restore"],"mutating":true},
             {"id":"completions","path":["completions"],"mutating":false},
             {"id":"rollback","path":["rollback"],"mutating":true},
             {"id":"bootstrap","path":["bootstrap"],"mutating":true},

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -27,6 +27,7 @@ pub(crate) const MUTATING_COMMAND_IDS: &[&str] = &[
     "sync",
     "record",
     "evolve propose",
+    "evolve restore",
 ];
 
 pub(crate) fn require_yes_for_json_mutation(

--- a/tests/cli_evolve_restore.rs
+++ b/tests/cli_evolve_restore.rs
@@ -1,0 +1,108 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn write_codex_prompt_manifest(repo_dir: &Path, codex_home: &Path) {
+    let module_dir = repo_dir.join("modules/prompt/one");
+    std::fs::create_dir_all(&module_dir).expect("create prompt module dir");
+    std::fs::write(module_dir.join("prompt.md"), "# prompt\n").expect("write prompt");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["prompt:one"]
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: false
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: "prompt:one"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt/one"
+"#,
+        codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest).expect("write manifest");
+}
+
+#[test]
+fn evolve_restore_json_requires_yes_when_it_would_write() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let repo_dir = tmp.path().join("repo");
+    write_codex_prompt_manifest(&repo_dir, &codex_home);
+
+    let out = agentpack_in(
+        tmp.path(),
+        &["--target", "codex", "evolve", "restore", "--json"],
+    );
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+}
+
+#[test]
+fn evolve_restore_restores_missing_desired_outputs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let repo_dir = tmp.path().join("repo");
+    write_codex_prompt_manifest(&repo_dir, &codex_home);
+
+    let prompt_path = codex_home.join("prompts").join("prompt.md");
+    assert!(!prompt_path.exists());
+
+    let out = agentpack_in(
+        tmp.path(),
+        &["--target", "codex", "evolve", "restore", "--json", "--yes"],
+    );
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "evolve.restore");
+
+    assert!(prompt_path.is_file());
+    assert_eq!(
+        std::fs::read_to_string(&prompt_path).expect("read prompt"),
+        "# prompt\n"
+    );
+}


### PR DESCRIPTION
Closes #112.

What
- Adds `agentpack evolve restore` to restore missing desired outputs on disk (create-only; no updates/deletes).
- In `--json` mode, requires `--yes` when it would write (stable `E_CONFIRM_REQUIRED`).

Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate add-evolve-restore --strict --no-interactive`