### PR TITLE
feat(overlay): add sparse mode for overlay edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project follows SemVer with the following clarifications (especially for au
 - `--json` contract docs: `docs/JSON_API.md` and `docs/ERROR_CODES.md`.
 - GitHub Issue Forms (`.github/ISSUE_TEMPLATE/*.yml`).
 - `agentpack evolve restore` to restore missing desired outputs (create-only).
+- `agentpack overlay edit --sparse` to create overlays without copying full upstream trees, plus `--materialize` as an opt-in escape hatch.
 
 ### Changed
 - Deploy now requires explicit `--adopt` for `adopt_update` overwrites (stable `E_ADOPT_CONFIRM_REQUIRED`).

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -241,10 +241,14 @@ Schema（v1，示例）：
 - （future）可加入 patch/diff 模型（如 3-way merge），但当前实现未支持
 
 ### 3.3 overlay 编辑命令（见 CLI）
-agentpack overlay edit <module_id> [--scope global|machine|project] 会：
-- 若不存在 overlay：复制 upstream module 的完整文件树到 overlay 目录（scope 对应路径见下）
+agentpack overlay edit <module_id> [--scope global|machine|project] [--sparse|--materialize] 会：
+- 若不存在 overlay：默认复制 upstream module 的完整文件树到 overlay 目录（scope 对应路径见下）
 - 打开编辑器（$EDITOR）
 - 保存后 deploy 生效
+
+可选参数（v0.5+）：
+- `--sparse`：创建“稀疏 overlay”：只创建 overlay 元数据（baseline/module_id），不复制 upstream 文件；用户只放改动文件。
+- `--materialize`：将 upstream 文件“补齐”到 overlay 目录（只拷贝缺失文件，不覆盖已有 overlay edits），便于浏览/编辑。
 
 scope → 路径映射：
 - global: `repo/overlays/<module_fs_key>/...`

--- a/openspec/changes/add-sparse-overlay-mode/.openspec.yaml
+++ b/openspec/changes/add-sparse-overlay-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/add-sparse-overlay-mode/README.md
+++ b/openspec/changes/add-sparse-overlay-mode/README.md
@@ -1,0 +1,3 @@
+# add-sparse-overlay-mode
+
+Add a sparse overlay mode for overlay edit to avoid full upstream copies.

--- a/openspec/changes/add-sparse-overlay-mode/proposal.md
+++ b/openspec/changes/add-sparse-overlay-mode/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add sparse overlay mode for `overlay edit`
+
+## Why
+`agentpack overlay edit` currently creates an overlay by copying the entire upstream module tree into the overlay directory. This is convenient for browsing, but it makes config repos grow linearly with upstream size and increases sync/merge cost.
+
+Sparse overlays keep the overlay directory small by storing only modified files, while still composing correctly at deploy time (upstream + overlays).
+
+## What Changes
+- Add `--sparse` to `agentpack overlay edit` to create an overlay skeleton with metadata (baseline + module_id) but without copying upstream files.
+- Add `--materialize` to explicitly populate upstream files into an overlay directory without overwriting existing overlay edits (escape hatch for editing convenience).
+
+## Impact
+- Affected specs: `agentpack-cli`
+- Affected code: `src/cli/args.rs`, `src/cli/commands/overlay.rs`, `src/overlay.rs`, `src/fs.rs`
+- Affected docs/tests: `docs/SPEC.md`, core overlay tests

--- a/openspec/changes/add-sparse-overlay-mode/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-sparse-overlay-mode/specs/agentpack-cli/spec.md
@@ -1,0 +1,23 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: overlay edit supports sparse overlays
+The system SHALL support creating a sparse overlay via `agentpack overlay edit --sparse`, which creates the overlay directory and required metadata without copying the entire upstream tree.
+
+#### Scenario: overlay edit --sparse creates metadata only
+- **GIVEN** a module `<moduleId>` exists and resolves to an upstream root
+- **WHEN** the user runs `agentpack overlay edit <moduleId> --scope global --sparse`
+- **THEN** the overlay directory exists
+- **AND** it contains `.agentpack/baseline.json`
+- **AND** it contains `.agentpack/module_id`
+- **AND** it does not contain copied upstream files by default
+
+### Requirement: overlay edit supports materializing upstream files
+The system SHALL support materializing upstream files into an overlay directory via `agentpack overlay edit --materialize` without overwriting existing overlay edits.
+
+#### Scenario: overlay edit --materialize does not overwrite edits
+- **GIVEN** an overlay directory exists with an edited file
+- **WHEN** the user runs `agentpack overlay edit <moduleId> --materialize`
+- **THEN** upstream files missing from the overlay are copied in
+- **AND** existing overlay files are not overwritten

--- a/openspec/changes/add-sparse-overlay-mode/tasks.md
+++ b/openspec/changes/add-sparse-overlay-mode/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+- [x] Add `--sparse` and `--materialize` flags to `agentpack overlay edit` (mutually exclusive).
+- [x] Implement sparse overlay skeleton creation (baseline + module_id, no copy).
+- [x] Implement materialize behavior (copy missing upstream files only; never overwrite overlay edits).
+
+## 2. Tests
+- [x] Add tests for sparse overlay skeleton (no copied files, metadata exists).
+- [x] Add tests for materialize behavior (copies missing files, preserves existing edits).
+
+## 3. Docs
+- [x] Update `docs/SPEC.md` overlay section to document sparse/materialize.
+
+## 4. Validation
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] Run `cargo test --all --locked`.
+- [x] Run `openspec validate add-sparse-overlay-mode --strict --no-interactive`.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -225,6 +225,14 @@ pub enum OverlayCommands {
         /// Use project overlay (DEPRECATED: use --scope project)
         #[arg(long)]
         project: bool,
+
+        /// Create a sparse overlay (do not copy upstream files)
+        #[arg(long, conflicts_with = "materialize")]
+        sparse: bool,
+
+        /// Populate upstream files into the overlay without overwriting existing edits
+        #[arg(long, conflicts_with = "sparse")]
+        materialize: bool,
     },
 
     /// Print the resolved overlay directory for a module and scope

--- a/src/cli/commands/overlay.rs
+++ b/src/cli/commands/overlay.rs
@@ -2,7 +2,9 @@ use anyhow::Context as _;
 
 use crate::engine::Engine;
 use crate::output::{JsonEnvelope, print_json};
-use crate::overlay::ensure_overlay_skeleton;
+use crate::overlay::{
+    ensure_overlay_skeleton, ensure_overlay_skeleton_sparse, materialize_overlay_from_upstream,
+};
 
 use super::super::args::{OverlayCommands, OverlayScope};
 use super::Ctx;
@@ -13,6 +15,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &OverlayCommands) -> anyhow::Result<()
             module_id,
             scope,
             project,
+            sparse,
+            materialize,
         } => {
             super::super::util::require_yes_for_json_mutation(ctx.cli, "overlay edit")?;
             let engine = Engine::load(ctx.cli.repo.as_deref(), ctx.cli.machine.as_deref())?;
@@ -33,14 +37,38 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &OverlayCommands) -> anyhow::Result<()
             let overlay_dir =
                 super::super::util::overlay_dir_for_scope(&engine, module_id_str, effective_scope);
 
-            let skeleton = ensure_overlay_skeleton(
-                &engine.home,
-                &engine.repo,
-                &engine.manifest,
-                module_id_str,
-                &overlay_dir,
-            )
-            .context("ensure overlay")?;
+            let skeleton = if *sparse || *materialize {
+                ensure_overlay_skeleton_sparse(
+                    &engine.home,
+                    &engine.repo,
+                    &engine.manifest,
+                    module_id_str,
+                    &overlay_dir,
+                )
+                .context("ensure overlay")?
+            } else {
+                ensure_overlay_skeleton(
+                    &engine.home,
+                    &engine.repo,
+                    &engine.manifest,
+                    module_id_str,
+                    &overlay_dir,
+                )
+                .context("ensure overlay")?
+            };
+
+            let mut did_materialize = false;
+            if *materialize {
+                materialize_overlay_from_upstream(
+                    &engine.home,
+                    &engine.repo,
+                    &engine.manifest,
+                    module_id_str,
+                    &overlay_dir,
+                )
+                .context("materialize overlay")?;
+                did_materialize = true;
+            }
 
             if let Ok(editor) = std::env::var("EDITOR") {
                 if !editor.trim().is_empty() {
@@ -61,6 +89,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &OverlayCommands) -> anyhow::Result<()
                         "overlay_dir": skeleton.dir.clone(),
                         "overlay_dir_posix": crate::paths::path_to_posix_string(&skeleton.dir),
                         "created": skeleton.created,
+                        "sparse": sparse,
+                        "materialized": did_materialize,
                         "project": effective_scope == OverlayScope::Project,
                         "machine_id": if matches!(effective_scope, OverlayScope::Machine) { Some(engine.machine_id.clone()) } else { None },
                         "project_id": if matches!(effective_scope, OverlayScope::Project) { Some(engine.project.project_id.clone()) } else { None },
@@ -78,6 +108,12 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &OverlayCommands) -> anyhow::Result<()
                     "Overlay already exists at"
                 };
                 println!("{status} {}", skeleton.dir.display());
+                if *sparse {
+                    println!("Note: created sparse overlay (no upstream files copied)");
+                }
+                if did_materialize {
+                    println!("Note: materialized upstream files into overlay (missing-only)");
+                }
             }
         }
         OverlayCommands::Path { module_id, scope } => {


### PR DESCRIPTION
Closes #115.

What
- Adds `--sparse` and `--materialize` (mutually exclusive) to `agentpack overlay edit`.
  - `--sparse`: creates overlay metadata only (baseline + module_id), without copying upstream files.
  - `--materialize`: copies missing upstream files into the overlay without overwriting existing edits.

Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate add-sparse-overlay-mode --strict --no-interactive`