### PR TITLE
feat(overlay): add overlay rebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project follows SemVer with the following clarifications (especially for au
 - GitHub Issue Forms (`.github/ISSUE_TEMPLATE/*.yml`).
 - `agentpack evolve restore` to restore missing desired outputs (create-only).
 - `agentpack overlay edit --sparse` to create overlays without copying full upstream trees, plus `--materialize` as an opt-in escape hatch.
+- `agentpack overlay rebase` to 3-way merge overlays against upstream updates (optional `--sparsify`).
 
 ### Changed
 - Deploy now requires explicit `--adopt` for `adopt_update` overwrites (stable `E_ADOPT_CONFIRM_REQUIRED`).

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -58,3 +58,23 @@
 **含义**：多个模块对同一 `(target,path)` 产出不同内容，Agentpack 拒绝静默覆盖。
 **是否可重试**：取决于配置/overlay 调整。
 **建议动作**：调整 modules/overlays 使同一路径只由一个模块产出，或让冲突路径内容一致。
+
+### `E_OVERLAY_NOT_FOUND`
+**含义**：请求的 overlay 目录不存在（尚未创建 overlay）。
+**是否可重试**：是。
+**建议动作**：先执行 `agentpack overlay edit <module_id>` 创建 overlay（必要时选择 `--scope`）。
+
+### `E_OVERLAY_BASELINE_MISSING`
+**含义**：overlay 元数据缺失（`<overlay_dir>/.agentpack/baseline.json` 不存在），无法进行 rebase。
+**是否可重试**：是。
+**建议动作**：重新运行 `agentpack overlay edit <module_id>` 以补齐元数据。
+
+### `E_OVERLAY_BASELINE_UNSUPPORTED`
+**含义**：overlay baseline 缺少可定位的 merge base（例如 local_path 的 baseline 记录于非 git repo，或 baseline 版本过旧缺少 upstream identity），无法安全 rebase。
+**是否可重试**：取决于修复 baseline。
+**建议动作**：确保 repo 是 git 且 baseline 可追溯，然后重新创建 overlay baseline（重新 `overlay edit` 或重建 overlay）。
+
+### `E_OVERLAY_REBASE_CONFLICT`
+**含义**：`overlay rebase` 检测到无法自动合并的冲突（会输出冲突文件列表）。
+**是否可重试**：是（解决冲突后重试）。
+**建议动作**：打开 overlay 目录中带冲突标记的文件，手动解决后再次运行 `agentpack overlay rebase` 或直接 review/commit overlay 变更。

--- a/openspec/changes/add-overlay-rebase/.openspec.yaml
+++ b/openspec/changes/add-overlay-rebase/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-12

--- a/openspec/changes/add-overlay-rebase/README.md
+++ b/openspec/changes/add-overlay-rebase/README.md
@@ -1,0 +1,3 @@
+# add-overlay-rebase
+
+Add overlay rebase via 3-way merge

--- a/openspec/changes/add-overlay-rebase/proposal.md
+++ b/openspec/changes/add-overlay-rebase/proposal.md
@@ -1,0 +1,22 @@
+# Change: add-overlay-rebase
+
+## Why
+Sparse overlays reduce repo bloat, but they do not solve the day-2 problem: when upstream module content changes, existing overlays can drift and require manual merging.
+
+In particular, non-sparse overlays created by copying the upstream tree can unintentionally **pin** old upstream files (because overlay copies override upstream), making upstream upgrades painful.
+
+## What Changes
+- Add `agentpack overlay rebase <module_id>` to update an existing overlay against the current upstream using a 3-way merge, based on the overlay baseline metadata.
+- Extend overlay baseline metadata (`<overlay_dir>/.agentpack/baseline.json`) with upstream identity data so rebasing can locate the original baseline content.
+- Add stable `--json` error codes for common, actionable rebase failures (missing overlay/baseline, merge conflicts).
+
+## Impact
+- Affected specs: `agentpack-cli`
+- Affected code: `src/overlay.rs`, `src/cli/args.rs`, `src/cli/commands/overlay.rs`, `src/cli/commands/help.rs`, `src/cli/util.rs`
+- Tests: unit/integration tests for clean rebase and conflict reporting
+- Docs: `docs/SPEC.md`, `docs/ERROR_CODES.md`, `CHANGELOG.md`
+
+## Compatibility
+This change is additive:
+- New CLI subcommand and new `--json` fields are backwards compatible.
+- Overlay baseline metadata remains backwards compatible (existing `baseline.json` without upstream identity continues to support drift warnings; rebasing may require additional data).

--- a/openspec/changes/add-overlay-rebase/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-overlay-rebase/specs/agentpack-cli/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: overlay rebase updates overlays against upstream changes
+The system SHALL provide `agentpack overlay rebase <module_id>` to update an existing overlay against the current upstream module content.
+
+The command SHALL:
+- use `<overlay_dir>/.agentpack/baseline.json` as the merge base,
+- merge upstream changes into overlay edits using a 3-way merge, and
+- update overlay baseline metadata after a successful rebase.
+
+#### Scenario: rebase updates an unmodified file copy
+- **GIVEN** an overlay contains an unmodified copy of an upstream file (identical to the baseline)
+- **AND** the upstream file changes
+- **WHEN** the user runs `agentpack overlay rebase <moduleId> --scope global`
+- **THEN** the overlay file is updated so it no longer pins the old upstream content
+
+#### Scenario: rebase conflict yields stable error code
+- **GIVEN** an overlay edits a file that is also changed upstream since the baseline
+- **AND** the changes overlap and cannot be merged cleanly
+- **WHEN** the user runs `agentpack overlay rebase <moduleId> --json --yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_OVERLAY_REBASE_CONFLICT`

--- a/openspec/changes/add-overlay-rebase/tasks.md
+++ b/openspec/changes/add-overlay-rebase/tasks.md
@@ -1,0 +1,19 @@
+## 1. Spec
+- [x] Add OpenSpec delta for `agentpack-cli` describing `overlay rebase` behavior and conflict reporting.
+- [x] Run `openspec validate add-overlay-rebase --strict` and fix any issues.
+
+## 2. Implementation
+- [x] Extend overlay baseline metadata to include upstream identity (git commit/url/subdir or local repo revision) in a backwards-compatible way.
+- [x] Implement overlay rebase core logic (3-way merge + baseline update) with a deterministic conflict signal.
+- [x] Add `agentpack overlay rebase` CLI plumbing (+ `help --json` and mutating registry updates).
+- [x] Add tests for: unmodified-file rebase, clean merge, and conflict reporting.
+
+## 3. Docs
+- [x] Update `docs/SPEC.md` overlays section to document `overlay rebase`.
+- [x] Register new stable error codes in `docs/ERROR_CODES.md`.
+- [x] Update `CHANGELOG.md` (Unreleased).
+
+## 4. Validation
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo test --all --locked`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -235,6 +235,19 @@ pub enum OverlayCommands {
         materialize: bool,
     },
 
+    /// Rebase an overlay against the current upstream (3-way merge)
+    Rebase {
+        module_id: String,
+
+        /// Overlay scope to rebase (default: global)
+        #[arg(long, value_enum, default_value = "global")]
+        scope: OverlayScope,
+
+        /// Remove overlay files that end up identical to upstream after rebasing
+        #[arg(long)]
+        sparsify: bool,
+    },
+
     /// Print the resolved overlay directory for a module and scope
     Path {
         module_id: String,

--- a/src/cli/commands/help.rs
+++ b/src/cli/commands/help.rs
@@ -35,6 +35,7 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
             {"id":"rollback","path":["rollback"],"mutating":true},
             {"id":"bootstrap","path":["bootstrap"],"mutating":true},
             {"id":"overlay edit","path":["overlay","edit"],"mutating":true},
+            {"id":"overlay rebase","path":["overlay","rebase"],"mutating":true},
             {"id":"overlay path","path":["overlay","path"],"mutating":false}
         ]);
 

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -23,6 +23,7 @@ pub(crate) const MUTATING_COMMAND_IDS: &[&str] = &[
     "bootstrap",
     "doctor --fix",
     "overlay edit",
+    "overlay rebase",
     "remote set",
     "sync",
     "record",

--- a/tests/cli_guardrails.rs
+++ b/tests/cli_guardrails.rs
@@ -39,6 +39,10 @@ fn json_mode_requires_yes_for_mutating_commands() {
         ("record", &["record", "--json"]),
         ("overlay edit", &["overlay", "edit", "skill:test", "--json"]),
         (
+            "overlay rebase",
+            &["overlay", "rebase", "skill:test", "--json"],
+        ),
+        (
             "rollback",
             &["rollback", "--to", "snapshot-does-not-matter", "--json"],
         ),

--- a/tests/cli_overlay_rebase_conflicts.rs
+++ b/tests/cli_overlay_rebase_conflicts.rs
@@ -1,0 +1,114 @@
+use std::path::Path;
+use std::process::Command;
+
+use agentpack::config::{LocalPathSource, Manifest, Module, ModuleType, Source};
+use agentpack::ids::module_fs_key;
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .env("EDITOR", "")
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn git(cwd: &Path, args: &[&str]) -> anyhow::Result<String> {
+    let out = Command::new("git").current_dir(cwd).args(args).output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(String::from_utf8(out.stdout)?)
+}
+
+#[test]
+fn overlay_rebase_conflicts_return_stable_json_error_code() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path();
+
+    let project_dir = home.join("project");
+    std::fs::create_dir_all(&project_dir)?;
+
+    let init = agentpack_in(home, &project_dir, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+
+    // Put the config repo under git so local-path baselines can record a stable merge base.
+    let _ = git(&repo_dir, &["init"])?;
+    let _ = git(&repo_dir, &["config", "user.email", "test@example.com"])?;
+    let _ = git(&repo_dir, &["config", "user.name", "Test"])?;
+    let _ = git(&repo_dir, &["add", "."])?;
+    let _ = git(&repo_dir, &["commit", "-m", "init"])?;
+
+    // Add a local-path module.
+    let module_root = repo_dir.join("modules").join("skill_test");
+    std::fs::create_dir_all(&module_root)?;
+    std::fs::write(module_root.join("SKILL.md"), "line1\nline2\nline3\n")?;
+
+    let manifest_path = repo_dir.join("agentpack.yaml");
+    let mut manifest = Manifest::load(&manifest_path)?;
+    manifest.modules.push(Module {
+        id: "skill_test".to_string(),
+        module_type: ModuleType::Skill,
+        enabled: true,
+        tags: Vec::new(),
+        targets: Vec::new(),
+        source: Source {
+            local_path: Some(LocalPathSource {
+                path: "modules/skill_test".to_string(),
+            }),
+            git: None,
+        },
+        metadata: Default::default(),
+    });
+    manifest.save(&manifest_path)?;
+
+    let _ = git(&repo_dir, &["add", "."])?;
+    let _ = git(&repo_dir, &["commit", "-m", "add skill_test module"])?;
+
+    // Create overlay baseline.
+    let edit = agentpack_in(home, &project_dir, &["overlay", "edit", "skill_test"]);
+    assert!(edit.status.success());
+
+    let overlay_dir = repo_dir.join("overlays").join(module_fs_key("skill_test"));
+
+    // Simulate overlay edit and upstream edit on the same line to force conflict.
+    std::fs::write(overlay_dir.join("SKILL.md"), "line1\nline2-ours\nline3\n")?;
+    std::fs::write(module_root.join("SKILL.md"), "line1\nline2-theirs\nline3\n")?;
+
+    let _ = git(&repo_dir, &["add", "."])?;
+    let _ = git(&repo_dir, &["commit", "-m", "upstream change"])?;
+
+    let rebase = agentpack_in(
+        home,
+        &project_dir,
+        &[
+            "overlay",
+            "rebase",
+            "skill_test",
+            "--scope",
+            "global",
+            "--json",
+            "--yes",
+        ],
+    );
+    assert!(!rebase.status.success(), "rebase should fail on conflict");
+
+    let v = parse_stdout_json(&rebase);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_OVERLAY_REBASE_CONFLICT");
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #118.

Adds `agentpack overlay rebase` to 3-way merge overlay edits against upstream updates using `.agentpack/baseline.json` as the merge base.

Highlights:
- New subcommand: `agentpack overlay rebase <module_id> [--scope ...] [--sparsify]`
- Backwards-compatible baseline metadata now records upstream identity to locate merge bases
- Stable error codes: E_OVERLAY_NOT_FOUND / E_OVERLAY_BASELINE_MISSING / E_OVERLAY_BASELINE_UNSUPPORTED / E_OVERLAY_REBASE_CONFLICT
- Tests: CLI guardrails + conflict-case JSON error code

Validation:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
- openspec validate add-overlay-rebase --strict --no-interactive
