### PR TITLE
docs: refresh AI instructions and OpenSpec context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,10 @@ Keep this managed block so 'openspec update' can refresh the instructions.
 
 ## Specs & Contracts
 - `docs/SPEC.md` is the authoritative, implementation-level contract (CLI behavior, `--json` envelopes, file formats).
+- `docs/JSON_API.md` and `docs/ERROR_CODES.md` define the stable `--json` envelope rules and error codes for automation.
 - `openspec/specs/` is the OpenSpec “requirements slice”; changes go through `openspec/changes/<change-id>/...` and MUST stay consistent with `docs/SPEC.md`.
 - If you change stable output (especially `--json`), update `docs/SPEC.md`, OpenSpec deltas, and relevant snapshots under `tests/golden/`.
+  - If you add a new mutating command, update `src/cli/util.rs` (`MUTATING_COMMAND_IDS`), `agentpack help --json`, and guardrails tests (`tests/cli_guardrails.rs`).
 
 ## Build, Test, and Development Commands
 - `cargo fmt --all -- --check`: formatting (required).

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -7,16 +7,19 @@ Agentpack is an AI-first local “asset control plane” that manages and deploy
 - Codex custom prompts (`~/.codex/prompts`)
 - Claude Code slash commands (`.claude/commands`)
 
-As of v0.3, the focus is a reproducible, auditable workflow: `plan/preview -> diff -> apply -> validate -> snapshot -> rollback`, plus:
+As of v0.5, the focus is a reproducible, auditable workflow: `plan/preview -> diff -> apply -> validate -> snapshot -> rollback`, plus:
 - manifest-based safety (`.agentpack.manifest.json` in target roots)
 - multi-machine sync (`remote set` + `sync --rebase`)
 - machine overlays (`overlays/machines/<machineId>/...` + `--machine`)
-- observability + proposals (`record`/`score`/`explain`/`evolve propose`)
+- overlay authoring + rebase (`overlay edit`/`overlay rebase`, sparse/materialize)
+- observability + proposals (`record`/`score`/`explain`/`evolve propose`/`evolve restore`)
 - lower-friction composites (`update`, `preview`) and scripting helpers (`overlay path`)
-- `--json` write guardrails (`--yes` required, stable error code `E_CONFIRM_REQUIRED`)
+- stable machine-consumable JSON contracts (`help --json`, `schema`, stable error codes)
+- TargetAdapter conformance tests as the contribution gate
 
 ## Canonical Specs
 - `docs/SPEC.md` is the implementation-level contract (CLI behavior, `--json` envelope, file formats) and should match code + tests.
+- `docs/JSON_API.md` and `docs/ERROR_CODES.md` document the stable machine contract for `--json` and actionable error codes.
 - `openspec/specs/` is the OpenSpec “requirements slice” used for proposal-driven changes; it MUST stay consistent with `docs/SPEC.md`.
 - If `docs/SPEC.md` and `openspec/specs/` drift, reconcile them promptly (avoid leaving `TBD`/placeholder Purpose sections in archived specs).
 


### PR DESCRIPTION
## Summary

Refreshes AI/agent contributor docs to match current v0.5 realities:
- Updates `openspec/project.md` (v0.5 context, overlay rebase/sparse, evolve restore, self-describing JSON contract, conformance gate).
- Updates `AGENTS.md` to point to `docs/JSON_API.md` + `docs/ERROR_CODES.md` and adds a reminder to keep mutating command plumbing in sync.

Closes #121

## Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all --locked`
- [ ] `cargo deny check licenses bans sources` (not needed)
- [ ] Added/updated tests where needed (docs-only)
- [x] Updated docs (`docs/` / OpenSpec) where needed
