### PR TITLE
feat(cli): enrich help --json metadata

### DIFF
--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -56,3 +56,14 @@ Agentpack 的 `--json` 输出被视为可编排的 API：
 - 当 `data` 中包含文件系统路径字段（如 `path` / `root` / `repo` / `overlay_dir` / `lockfile` / `store` 等）时，agentpack 会额外输出对应的 `*_posix` 字段。
 - `*_posix` 使用 `/` 作为分隔符，便于跨平台解析；原字段保持原样（native），用于本机直接访问文件系统更方便。
 - 该约定是 additive change：`schema_version` 仍为 `1`。
+
+## 5. 自描述（供 automation/agent 学习与编排）
+
+为减少“靠 README 学命令”和避免 hardcode，agentpack 提供自描述接口：
+
+- `agentpack help --json`：输出命令清单与 guardrails 信息（例如哪些命令在 `--json` 下需要 `--yes`）。
+  - `data.global_args[]`：全局 flags/options（如 `--repo` / `--profile` / `--target` / `--json` / `--yes`）。
+  - `data.commands[]`：可用命令（含子命令）与参数摘要；每项至少包含 `id`、`path[]`、`mutating`、`supports_json`，并包含 `args[]`（非全局参数）。
+  - `data.mutating_commands[]`：稳定的“写入类命令 id”集合（用于 `--json` guardrails）。
+
+- `agentpack schema --json`：输出 JSON envelope 的结构与关键命令的最小 `data` 字段说明（适合生成/校验解析器）。

--- a/openspec/changes/update-help-json-metadata/.openspec.yaml
+++ b/openspec/changes/update-help-json-metadata/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-13

--- a/openspec/changes/update-help-json-metadata/README.md
+++ b/openspec/changes/update-help-json-metadata/README.md
@@ -1,0 +1,5 @@
+# update-help-json-metadata
+
+Enhance agentpack help --json command metadata
+
+This change strengthens the self-describing contract for `agentpack help --json` by adding structured command argument metadata and explicitly indicating which commands support `--json`.

--- a/openspec/changes/update-help-json-metadata/proposal.md
+++ b/openspec/changes/update-help-json-metadata/proposal.md
@@ -1,0 +1,18 @@
+# Change: Enhance `agentpack help --json` metadata
+
+## Why
+`agentpack help --json` is a stable, machine-consumable entrypoint for agents/scripts. Today it uses a partially hard-coded command list and does not expose command argument metadata or whether a command truly supports `--json` (e.g. `completions` currently errors in `--json` mode). This makes automation more fragile and increases maintenance drift risk.
+
+## What Changes
+- Enrich `agentpack help --json` output:
+  - Add `supports_json` to each `data.commands[]` item.
+  - Add `args[]` metadata to each `data.commands[]` item (command-specific args; global args excluded).
+  - Add a top-level `data.global_args[]` list for global flags/options.
+- Update `agentpack schema --json` to document the new self-description fields.
+- Update documentation to reflect the enriched self-description contract.
+
+## Impact
+- Affected specs: `openspec/specs/agentpack-cli/spec.md` (help/schema contract)
+- Affected docs: `docs/JSON_API.md` (self-description section)
+- Affected code: `src/cli/commands/help.rs`, `src/cli/commands/schema.rs`
+- Compatibility: additive only (no `schema_version` bump).

--- a/openspec/changes/update-help-json-metadata/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-help-json-metadata/specs/agentpack-cli/spec.md
@@ -1,0 +1,26 @@
+# agentpack-cli (delta)
+
+## MODIFIED Requirements
+
+### Requirement: help --json is self-describing
+The system SHALL provide `agentpack help --json` which emits machine-consumable documentation, including:
+- a `commands` list describing available commands/subcommands, and
+- `mutating_commands` listing mutating command IDs that require `--yes` in `--json` mode.
+
+Each item in `data.commands[]` SHALL include:
+- `id` (stable command id),
+- `path[]` (command path segments),
+- `mutating` (whether the base invocation mutates), and
+- `supports_json` (whether the command supports `--json` output).
+
+`data.commands[]` SHOULD include `args[]` describing command-specific arguments (excluding global args).
+
+The output SHOULD also include `global_args[]` describing global flags/options.
+
+#### Scenario: help --json returns command metadata
+- **WHEN** the user runs `agentpack help --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.commands` exists
+- **AND** `data.commands[0].supports_json` exists
+- **AND** `data.global_args` exists
+- **AND** `data.mutating_commands` exists

--- a/openspec/changes/update-help-json-metadata/tasks.md
+++ b/openspec/changes/update-help-json-metadata/tasks.md
@@ -1,0 +1,21 @@
+## 1. Spec
+- [x] Update OpenSpec delta for `agentpack-cli` to require `supports_json`, `args[]`, and `global_args[]` in `help --json`.
+
+## 2. Implementation
+- [x] Generate `help --json` command list from clap command structure (avoid hard-coded drift).
+- [x] Include per-command argument metadata (`args[]`) excluding global args and built-in `--help/--version`.
+- [x] Include `supports_json` per command (`completions=false`, others true).
+- [x] Add `global_args[]` describing global CLI args.
+- [x] Update `schema --json` to document help payload fields (additive).
+
+## 3. Tests
+- [x] Extend `tests/cli_help_schema.rs` to assert `supports_json` exists and `global_args` is present.
+
+## 4. Docs
+- [x] Update `docs/JSON_API.md` with a short section describing `help --json` / `schema` self-description payloads.
+
+## 5. Validation
+- [x] Run `cargo fmt --all`
+- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] Run `cargo test --all --locked`
+- [x] Run `openspec validate update-help-json-metadata --strict --no-interactive`

--- a/src/cli/commands/help.rs
+++ b/src/cli/commands/help.rs
@@ -1,47 +1,43 @@
-use clap::CommandFactory as _;
+use std::collections::BTreeSet;
+
+use clap::{ArgAction, Command, CommandFactory as _};
 
 use crate::output::{JsonEnvelope, print_json};
 
 use super::Ctx;
 
+#[derive(Debug, Clone, serde::Serialize)]
+struct HelpArg {
+    id: String,
+    kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    long: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    short: Option<String>,
+    required: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct HelpCommand {
+    id: String,
+    path: Vec<String>,
+    mutating: bool,
+    supports_json: bool,
+    args: Vec<HelpArg>,
+}
+
 pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     if ctx.cli.json {
-        let commands = serde_json::json!([
-            {"id":"init","path":["init"],"mutating":true},
-            {"id":"help","path":["help"],"mutating":false},
-            {"id":"schema","path":["schema"],"mutating":false},
-            {"id":"update","path":["update"],"mutating":true},
-            {"id":"add","path":["add"],"mutating":true},
-            {"id":"remove","path":["remove"],"mutating":true},
-            {"id":"lock","path":["lock"],"mutating":true},
-            {"id":"fetch","path":["fetch"],"mutating":true},
-            {"id":"preview","path":["preview"],"mutating":false},
-            {"id":"plan","path":["plan"],"mutating":false},
-            {"id":"diff","path":["diff"],"mutating":false},
-            {"id":"deploy","path":["deploy"],"mutating":false},
-            {"id":"status","path":["status"],"mutating":false},
-            {"id":"doctor","path":["doctor"],"mutating":false},
-            {"id":"doctor --fix","path":["doctor"],"mutating":true},
-            {"id":"remote set","path":["remote","set"],"mutating":true},
-            {"id":"sync","path":["sync"],"mutating":true},
-            {"id":"record","path":["record"],"mutating":true},
-            {"id":"score","path":["score"],"mutating":false},
-            {"id":"explain plan","path":["explain","plan"],"mutating":false},
-            {"id":"explain diff","path":["explain","diff"],"mutating":false},
-            {"id":"explain status","path":["explain","status"],"mutating":false},
-            {"id":"evolve propose","path":["evolve","propose"],"mutating":true},
-            {"id":"evolve restore","path":["evolve","restore"],"mutating":true},
-            {"id":"completions","path":["completions"],"mutating":false},
-            {"id":"rollback","path":["rollback"],"mutating":true},
-            {"id":"bootstrap","path":["bootstrap"],"mutating":true},
-            {"id":"overlay edit","path":["overlay","edit"],"mutating":true},
-            {"id":"overlay rebase","path":["overlay","rebase"],"mutating":true},
-            {"id":"overlay path","path":["overlay","path"],"mutating":false}
-        ]);
+        let cmd = super::super::args::Cli::command();
+        let global_args = help_global_args(&cmd);
+        let mut commands = help_leaf_commands(&cmd);
+        add_legacy_doctor_fix_variant(&mut commands);
+        commands.sort_by(|a, b| a.id.cmp(&b.id));
 
         let envelope = JsonEnvelope::ok(
             "help",
             serde_json::json!({
+                "global_args": global_args,
                 "commands": commands,
                 "mutating_commands": super::super::util::MUTATING_COMMAND_IDS,
                 "notes": [
@@ -59,4 +55,126 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn help_global_args(cmd: &Command) -> Vec<HelpArg> {
+    let mut out: Vec<HelpArg> = cmd
+        .get_arguments()
+        .filter_map(|arg| help_arg_from_clap(arg, None))
+        .collect();
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    out
+}
+
+fn help_leaf_commands(cmd: &Command) -> Vec<HelpCommand> {
+    let global_arg_ids = cmd
+        .get_arguments()
+        .filter_map(|arg| {
+            let id = arg.get_id().as_str();
+            (!is_builtin_clap_arg_id(id)).then_some(id.to_string())
+        })
+        .collect::<BTreeSet<String>>();
+
+    let mut out = Vec::new();
+    for sub in cmd.get_subcommands() {
+        collect_leaf_commands(sub, Vec::new(), &global_arg_ids, &mut out);
+    }
+    out
+}
+
+fn collect_leaf_commands(
+    cmd: &Command,
+    mut parent_path: Vec<String>,
+    global_arg_ids: &BTreeSet<String>,
+    out: &mut Vec<HelpCommand>,
+) {
+    let name = cmd.get_name().to_string();
+    parent_path.push(name);
+    let path = parent_path.clone();
+
+    if cmd.get_subcommands().count() == 0 {
+        let id = path.join(" ");
+        let mut args: Vec<HelpArg> = cmd
+            .get_arguments()
+            .filter_map(|arg| help_arg_from_clap(arg, Some(global_arg_ids)))
+            .collect();
+        args.sort_by(|a, b| (arg_kind_rank(&a.kind), &a.id).cmp(&(arg_kind_rank(&b.kind), &b.id)));
+
+        out.push(HelpCommand {
+            mutating: super::super::util::MUTATING_COMMAND_IDS.contains(&id.as_str()),
+            supports_json: supports_json_for_command(&id),
+            id,
+            path,
+            args,
+        });
+        return;
+    }
+
+    for sub in cmd.get_subcommands() {
+        collect_leaf_commands(sub, parent_path.clone(), global_arg_ids, out);
+    }
+}
+
+fn add_legacy_doctor_fix_variant(commands: &mut Vec<HelpCommand>) {
+    if commands.iter().any(|c| c.id == "doctor --fix") {
+        return;
+    }
+    let Some(doctor) = commands.iter().find(|c| c.id == "doctor").cloned() else {
+        return;
+    };
+
+    let mut fix = doctor;
+    fix.id = "doctor --fix".to_string();
+    fix.mutating = true;
+    commands.push(fix);
+}
+
+fn supports_json_for_command(command_id: &str) -> bool {
+    command_id != "completions"
+}
+
+fn help_arg_from_clap(
+    arg: &clap::Arg,
+    global_arg_ids: Option<&BTreeSet<String>>,
+) -> Option<HelpArg> {
+    let id = arg.get_id().as_str();
+    if is_builtin_clap_arg_id(id) {
+        return None;
+    }
+    if global_arg_ids.is_some_and(|ids| ids.contains(id)) {
+        return None;
+    }
+
+    let kind = if arg.get_index().is_some() {
+        "positional"
+    } else {
+        match arg.get_action() {
+            ArgAction::SetTrue | ArgAction::SetFalse | ArgAction::Count => "flag",
+            _ => "option",
+        }
+    };
+
+    let short = arg.get_short().map(|c| c.to_string());
+    let long = arg.get_long().map(|s| s.to_string());
+
+    Some(HelpArg {
+        id: id.to_string(),
+        kind: kind.to_string(),
+        long,
+        short,
+        required: arg.is_required_set(),
+    })
+}
+
+fn is_builtin_clap_arg_id(id: &str) -> bool {
+    matches!(id, "help" | "version")
+}
+
+fn arg_kind_rank(kind: &str) -> u8 {
+    match kind {
+        "positional" => 0,
+        "option" => 1,
+        "flag" => 2,
+        _ => 3,
+    }
 }

--- a/src/cli/commands/schema.rs
+++ b/src/cli/commands/schema.rs
@@ -25,6 +25,7 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                     }
                 },
                 "commands": {
+                    "help": { "data_fields": ["global_args","commands","mutating_commands","notes"] },
                     "plan": { "data_fields": ["profile","targets","changes","summary"] },
                     "diff": { "data_fields": ["profile","targets","changes","summary"] },
                     "preview": { "data_fields": ["profile","targets","plan","diff?"] },

--- a/tests/cli_help_schema.rs
+++ b/tests/cli_help_schema.rs
@@ -23,8 +23,23 @@ fn help_json_is_self_describing() {
     let v = parse_stdout_json(&output);
     assert_eq!(v["ok"], true);
     assert_eq!(v["command"], "help");
+    assert!(v["data"]["global_args"].is_array());
     assert!(v["data"]["commands"].is_array());
     assert!(v["data"]["commands"].as_array().unwrap().len() > 5);
+    assert!(
+        v["data"]["commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c.get("supports_json").is_some())
+    );
+    assert!(
+        v["data"]["commands"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|c| c["id"] == "completions" && c["supports_json"] == false)
+    );
     assert!(v["data"]["mutating_commands"].is_array());
     assert!(
         v["data"]["mutating_commands"]


### PR DESCRIPTION
## Summary

- Generates `agentpack help --json` command list from clap, and enriches payload with:
  - `data.global_args[]`
  - `data.commands[].supports_json`
  - `data.commands[].args[]` (excluding global + built-in help/version)
- Updates `agentpack schema --json` to document the new help payload fields.
- Updates `docs/JSON_API.md` self-description section.
- Adds OpenSpec change `openspec/changes/update-help-json-metadata/`.

Closes #123

## Checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all --locked`
- [x] `openspec validate update-help-json-metadata --strict --no-interactive`
