### PR TITLE
docs(i18n): make English canonical and add zh-CN user docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Agentpack
 
+> Language: English | [Chinese (Simplified)](README.zh-CN.md)
+
 Agentpack is an AI-first local “asset control plane” for managing and deploying:
 - `AGENTS.md` / instructions
 - Agent Skills (`SKILL.md`)
 - Claude Code slash commands (`.claude/commands`)
 - Codex custom prompts (`~/.codex/prompts`)
 
-See docs in `docs/`:
-- `docs/README.md`
-- `docs/PRD.md`, `docs/ARCHITECTURE.md`, `docs/SPEC.md`, `docs/BACKLOG.md`
+## Documentation
+
+- Docs index: `docs/README.md` (English), `docs/zh-CN/README.md` (Chinese)
+- Start here: `docs/QUICKSTART.md`
+- Daily workflow: `docs/WORKFLOWS.md`
+- CLI reference: `docs/CLI.md`
 
 ## Installation
 
@@ -22,45 +27,16 @@ cargo install agentpack --locked
 
 GitHub Releases: https://github.com/liqiongyu/agentpack/releases
 
-## Usage (v0.5)
+## Quickstart (v0.5)
 
 ```bash
-# Create (or open) your config repo at $AGENTPACK_HOME/repo
 agentpack init
-
-# Optional: configure and sync your config repo across machines
-agentpack remote set https://github.com/you/agentpack-config.git
-agentpack sync --rebase
-
-# Self-check (machineId + target paths)
-agentpack doctor
-
-# Add modules to agentpack.yaml
-agentpack add instructions local:modules/instructions/base --id instructions:base --tags base
-agentpack add command local:modules/claude-commands/ap-plan.md --id command:ap-plan --tags base --targets claude_code
-
-# Lock and fetch (composite)
 agentpack update
-
-# Preview changes (composite: plan + optional diff)
-agentpack preview --profile default --diff
-agentpack deploy --profile default --apply --yes --json
-
-# Drift + rollback
-agentpack status --profile default
-agentpack rollback --to <snapshot_id>
-
-# AI-first operator assets
-agentpack bootstrap --target all --scope both
-
-# Observability + proposals (v0.2+ loop)
-agentpack record < event.json
-agentpack score
-agentpack explain plan
-agentpack evolve propose --scope global --yes
+agentpack preview --diff
+agentpack deploy --apply --yes
 ```
 
-For a fuller walkthrough, see `docs/README.md`.
+For a fuller walkthrough, see `docs/README.md`. For automation, see `docs/JSON_API.md`.
 
 ## Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,51 @@
+# Agentpack
+
+> Language: 简体中文 | [English](README.md)
+
+Agentpack 是一个 AI-first 的本地“资产控制平面（asset control plane）”，用于管理与部署：
+- `AGENTS.md` / instructions
+- Agent Skills（`SKILL.md`）
+- Claude Code slash commands（`.claude/commands`）
+- Codex custom prompts（`~/.codex/prompts`）
+
+## 文档
+
+- 文档入口：`docs/README.md`（英文）、`docs/zh-CN/README.md`（中文）
+- 推荐从：`docs/QUICKSTART.md` 开始
+- 日常工作流：`docs/WORKFLOWS.md`
+- CLI 参考：`docs/CLI.md`
+
+## 安装
+
+### Cargo
+
+```bash
+cargo install agentpack --locked
+```
+
+### 预编译二进制
+
+GitHub Releases: https://github.com/liqiongyu/agentpack/releases
+
+## 快速开始（v0.5）
+
+```bash
+agentpack init
+agentpack update
+agentpack preview --diff
+agentpack deploy --apply --yes
+```
+
+更完整的上手与阅读顺序见 `docs/README.md`；自动化用 `--json`（契约见 `docs/JSON_API.md`）。
+
+## 开发
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all --locked
+```
+
+## 贡献
+
+从 `AGENTS.md` 与 `CONTRIBUTING.md` 开始。

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4,26 +4,26 @@
 
 ## Status
 
-- v5 milestone: 完成一轮“可日用 + AI-first 闭环”的收敛（组合命令、overlay rebase、adopt 保护、evolve restore 等）。
-- 具体变更请看 `CHANGELOG.md`。
+- v0.5 milestone: a round of “daily-usable + AI-first loop” convergence (composite commands, overlay rebase, adopt protection, evolve restore, etc.).
+- For concrete shipped changes, see `CHANGELOG.md`.
 
-## Next（v0.6+ 候选）
+## Next (candidates for v0.6+)
 
 ### Targets & ecosystem
-- 新增 targets（Cursor / VS Code 等），要求：TargetAdapter + conformance tests 作为合并门槛。
-- 为每个新 target 提供：映射规则、examples、migration notes。
+- Add new targets (Cursor / VS Code, etc.), gated by: TargetAdapter + conformance tests.
+- For each new target: mapping rules, examples, migration notes.
 
 ### UX & ergonomics
-- 更强的 `status` 输出（可选 summary、按 root 分组、可建议动作）。
-- 更丰富但仍可脚本化的 warnings（尽量带可操作建议与命令）。
-- 考虑轻量 TUI（浏览 plan/diff/status/snapshots），但保持核心可在非交互模式运行。
+- Stronger `status` output (optional summary, grouped by root, actionable suggestions).
+- Richer but still script-friendly warnings (with actionable commands where possible).
+- Consider a lightweight TUI (browse plan/diff/status/snapshots) while keeping the core usable in non-interactive mode.
 
 ### Overlays & evolve
-- patch-based overlays（可选）：让少量文本改动更易 merge、冲突更可读。
-- evolve propose 覆盖面增强：更好的多模块聚合输出回溯（除了 AGENTS.md），并提升 skipped reasons 的结构化解释。
-- 为 evolve 输出更明确的“下一步命令”（适合 operator assets 引导）。
+- Patch-based overlays (optional): make small text edits easier to merge and conflicts more readable.
+- Expand evolve propose coverage: better attribution for multi-module aggregated outputs (beyond AGENTS.md) and more structured skipped reasons.
+- Provide clearer “next command” suggestions in evolve output (good for operator assets).
 
-### 工程化
-- CLI golden tests（JSON 输出/错误码的回归测试）。
-- 更强的 conformance harness（临时 roots、跨平台路径用例）。
-- 文档持续收敛（本轮已移除 `docs/versions/`，后续靠 git 历史承载迭代）。
+### Engineering
+- CLI golden tests (regression coverage for JSON output/error codes).
+- Stronger conformance harness (temp roots, cross-platform path cases).
+- Keep docs consolidated (legacy `docs/versions/` removed; rely on git history for iteration tracking).

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -1,57 +1,59 @@
-# Bootstrap（AI 自举 / Operator assets）
+# Bootstrap (AI operator assets)
 
-Bootstrap 的目标：把“会用 agentpack”这件事交给 AI 自己完成。
+> Language: English | [Chinese (Simplified)](zh-CN/BOOTSTRAP.md)
 
-执行一次 bootstrap 后：
-- Codex 会多一个 `agentpack-operator` skill，教它如何调用 `agentpack` CLI（优先 `--json`），以及推荐的工作流。
-- Claude Code 会多一组 `/ap-*` slash commands，封装常用的 `doctor/update/preview/plan/diff/deploy/status/explain/evolve` 操作，并使用最小化的 `allowed-tools`。
+Bootstrap’s goal is to make “how to use agentpack” self-serve for agents.
 
-## 1) 命令
+After running bootstrap once:
+- Codex gains an `agentpack-operator` skill that teaches how to call the `agentpack` CLI (preferring `--json`) and the recommended workflows.
+- Claude Code gains a set of `/ap-*` slash commands that wrap common operations (`doctor/update/preview/plan/diff/deploy/status/explain/evolve`) with minimal `allowed-tools`.
+
+## 1) Command
 
 `agentpack bootstrap [--scope user|project|both]`
 
-- `--scope` 默认 `both`：同时写 user 与 project 位置
-- 选择写哪些 target 用全局 `--target`：
+- `--scope` defaults to `both`: writes to both user and project locations
+- Choose which targets to write via the global `--target`:
   - `agentpack --target codex bootstrap`
   - `agentpack --target claude_code bootstrap`
 
-## 2) 写入位置
+## 2) Output locations
 
-- Codex：
-  - user：`~/.codex/skills/agentpack-operator/SKILL.md`
-  - project：`<project_root>/.codex/skills/agentpack-operator/SKILL.md`
+- Codex:
+  - user: `~/.codex/skills/agentpack-operator/SKILL.md`
+  - project: `<project_root>/.codex/skills/agentpack-operator/SKILL.md`
 
-- Claude Code：
-  - user：`~/.claude/commands/ap-*.md`
-  - project：`<project_root>/.claude/commands/ap-*.md`
+- Claude Code:
+  - user: `~/.claude/commands/ap-*.md`
+  - project: `<project_root>/.claude/commands/ap-*.md`
 
-这些文件也会被纳入 target manifest（`.agentpack.manifest.json`），因此：
-- 可以被 `status` 检测
-- 可以被 `rollback` 回滚
-- 删除只会删托管文件
+These files are also included in the per-root target manifest (`.agentpack.manifest.json`), which means:
+- `status` can detect them
+- `rollback` can revert them
+- deletes remove managed files only
 
-## 3) 版本标记与更新
+## 3) Version marker and updates
 
-Bootstrap 写入的模板会替换 `{{AGENTPACK_VERSION}}` 为当前 agentpack 版本号。
+Bootstrap templates replace `{{AGENTPACK_VERSION}}` with the current agentpack version.
 
-当你升级 agentpack 后，如果 `status` 提示 operator assets 过期：
-- 直接重新运行 `agentpack bootstrap` 即可更新。
+After upgrading agentpack, if `status` reports operator assets are outdated:
+- Re-run `agentpack bootstrap` to update them.
 
-## 4) dry-run 与 --json
+## 4) dry-run and `--json`
 
-- 预览（不写入）：`agentpack bootstrap --dry-run --json`
-- 应用（写入）：
-  - human：`agentpack bootstrap`（会交互确认）
-  - json：`agentpack --json bootstrap --yes`
+- Preview (no writes): `agentpack bootstrap --dry-run --json`
+- Apply (writes):
+  - human: `agentpack bootstrap` (interactive confirmation)
+  - json: `agentpack --json bootstrap --yes`
 
-说明：bootstrap 属于写入类命令；在 `--json` 下必须显式 `--yes`，否则返回 `E_CONFIRM_REQUIRED`。
+Note: bootstrap is mutating; in `--json` mode you must pass `--yes` or the command fails with `E_CONFIRM_REQUIRED`.
 
-## 5) 自定义 operator assets（可选）
+## 5) Custom operator assets (optional)
 
-Bootstrap 使用内置模板（随版本更新）：
+Bootstrap uses built-in templates (updated with releases):
 - `templates/codex/skills/agentpack-operator/SKILL.md`
 - `templates/claude/commands/ap-*.md`
 
-如果你希望完全自定义：
-- 你可以把这些内容做成普通 module（`skill`/`command`），由 manifest 管理；
-- 或者在 bootstrap 后用 overlays 覆盖模板写入的文件（更推荐作为“你自己的版本”沉淀进 config repo）。
+If you want full customization:
+- Package your own operator assets as normal modules (`skill`/`command`) managed via the manifest, or
+- Use overlays after bootstrap to override the written files (recommended if you want to store “your own variant” in the config repo).

--- a/docs/CODEX_WORKPLAN.md
+++ b/docs/CODEX_WORKPLAN.md
@@ -1,70 +1,70 @@
 # CODEX_WORKPLAN.md
 
-Agentpack 工程改进与开源工程化工作单（给 Codex CLI/自动化直接执行用）
+Agentpack engineering + OSS workplan (designed to be executable by Codex CLI / automation)
 
-> Current as of **v0.5.0** (2026-01-13). v0.5.0 已完成一轮关键正确性收敛（fs_key 长度上限、全链路 atomic write、adopt 保护、sparse overlay + rebase、CLI 拆分、overlay metadata/doctor 检查等）。本工作单聚焦“把它做成真正优秀的开源项目”的下一步。
+> Current as of **v0.5.0** (2026-01-13). v0.5.0 delivered a round of correctness hardening (fs_key prefix length cap, end-to-end atomic writes, adopt protection, sparse overlays + rebase, CLI split, overlay metadata + doctor checks, etc.). This workplan focuses on the next steps to make the project “truly great” as open source.
 
-使用方式建议：
-- 每个任务一个 PR（或一个 commit group），PR 描述包含：目的、验收条件、回归测试命令。
-- 每个 PR 至少跑：`cargo fmt`、`cargo clippy --all-targets -- -D warnings`、`cargo test`。
+Recommended usage:
+- One task per PR (or per commit group). PR description should include: intent, acceptance criteria, and regression test commands.
+- Each PR should run at least: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test`.
 
 ------------------------------------------------------------
-P0：回归测试与契约锁定（优先）
+P0: regression tests and contract lock-down (highest priority)
 ------------------------------------------------------------
 
-P0-1 JSON 契约 golden tests（强烈建议）
-- 目标：锁住 `schema_version=1` 的 envelope 字段与关键错误码（避免无意 breaking）。
-- 建议做法：
-  - 用临时目录创建“伪 AGENTPACK_HOME”与“伪 target roots”。
-  - 运行真实 CLI（或调用内部命令入口），对 `plan/preview(deep)/deploy --apply/status/rollback` 以及关键错误码场景做 snapshot/golden。
-  - 至少覆盖：
-    - `E_CONFIRM_REQUIRED`（--json 缺 --yes）
-    - `E_ADOPT_CONFIRM_REQUIRED`（adopt_update）
-    - `E_DESIRED_STATE_CONFLICT`（冲突）
-    - `E_OVERLAY_REBASE_CONFLICT`（冲突）
+P0-1 JSON contract golden tests (strongly recommended)
+- Goal: lock down the `schema_version=1` envelope fields and key error codes (avoid accidental breaking changes).
+- Suggested approach:
+  - Use temp dirs as a “fake AGENTPACK_HOME” and “fake target roots”.
+  - Run the real CLI (or call internal command entrypoints) and snapshot/golden `plan/preview(deep)/deploy --apply/status/rollback` plus key error scenarios.
+  - At minimum cover:
+    - `E_CONFIRM_REQUIRED` (`--json` without `--yes`)
+    - `E_ADOPT_CONFIRM_REQUIRED` (`adopt_update`)
+    - `E_DESIRED_STATE_CONFLICT` (conflicts)
+    - `E_OVERLAY_REBASE_CONFLICT` (merge conflicts)
 
 P0-2 Conformance harness
-- 目标：新增 target 前，必须能跑一套“语义一致性测试”。
-- 覆盖点（见 `TARGET_CONFORMANCE.md`）：
-  - delete protection（只删托管）
-  - manifest（每个 root 写 `.agentpack.manifest.json`）
-  - drift（missing/modified/extra）
-  - rollback（可恢复）
+- Goal: before adding a new target, you must be able to run a suite of “semantic consistency tests”.
+- Coverage (see `TARGET_CONFORMANCE.md`):
+  - delete protection (delete managed only)
+  - manifests (per-root `.agentpack.manifest.json`)
+  - drift (missing/modified/extra)
+  - rollback (restorable)
 
-P0-3 Windows 路径与权限用例
-- 目标：确保 Windows 下 overlay 与 deploy 不被路径字符/长度/权限轻易打爆。
-- 建议：
-  - 单测覆盖 `module_fs_key` 截断/稳定性已完成；补集成测试：overlay edit/rebase 生成的路径在 Windows runner 上可用。
-
-------------------------------------------------------------
-P1：产品体验（可日用）
-------------------------------------------------------------
-
-P1-1 status 输出增强（不破坏 JSON）
-- human 模式：按 root 分组、给下一步建议（例如“run bootstrap”/“run deploy --apply”）。
-- json 模式：可以 additive 增加 `summary`，但不要删除/重命名现有字段。
-
-P1-2 evolve propose 的可解释性
-- 把 skipped reasons 做成更结构化、可行动：
-  - missing → 推荐 `evolve restore` 或 `deploy --apply`
-  - multi_module_output → 建议补 marker 或拆分输出
-
-P1-3 docs/examples（用户更友好）
-- 本轮 docs 已收敛；后续建议补：
-  - 一个最小示例 repo（含 `agentpack.yaml` + 几个模块）
-  - “从 0 到多机器同步”的录屏/动图（可选）
+P0-3 Windows path and permission cases
+- Goal: ensure overlay/deploy won’t be easily broken by Windows path characters/length/permissions.
+- Suggestion:
+  - Unit tests already cover `module_fs_key` truncation/stability; add integration coverage that overlay edit/rebase output paths are usable on Windows runners.
 
 ------------------------------------------------------------
-OSS：开源工程化（需要 GitHub 配置的另见 docs）
+P1: product UX (daily-usable)
 ------------------------------------------------------------
 
-OSS-1 贡献者体验
-- `CONTRIBUTING.md`（根目录）+ issue/pr templates
+P1-1 Better status output (without breaking JSON)
+- Human mode: group by root and provide “next action” suggestions (e.g., “run bootstrap” / “run deploy --apply”).
+- JSON mode: additive fields like `summary` are OK; do not delete/rename existing fields.
+
+P1-2 Better explainability for evolve propose
+- Make skipped reasons more structured and actionable:
+  - missing → suggest `evolve restore` or `deploy --apply`
+  - multi_module_output → suggest adding markers or splitting outputs
+
+P1-3 Docs/examples (more user-friendly)
+- Docs are consolidated; next suggested additions:
+  - A minimal example repo (with `agentpack.yaml` + a few modules)
+  - A “0 → multi-machine sync” screencast/GIF (optional)
+
+------------------------------------------------------------
+OSS: open-source project ops (GitHub settings are handled separately)
+------------------------------------------------------------
+
+OSS-1 Contributor experience
+- `CONTRIBUTING.md` (root) + issue/PR templates
 - `CODE_OF_CONDUCT.md`
-- `SECURITY.md`（漏洞报告入口）
+- `SECURITY.md` (vulnerability reporting)
 - `LICENSE`
 
-OSS-2 发布与分发
-- 确认 `cargo-dist` release workflow 在三平台产物、校验和、签名（可选）上都稳定。
+OSS-2 Release and distribution
+- Ensure the `cargo-dist` release workflow is stable across three platforms (artifacts, checksums, optional signing).
 
-（GitHub 侧需要手工设置的事项，见 `GITHUB_SETUP.md`。）
+For GitHub-side manual setup items, see `GITHUB_SETUP.md`.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,16 +1,18 @@
-# 配置文件与模块（agentpack.yaml）
+# Config and modules (`agentpack.yaml`)
 
-Agentpack 的“单一真源”是 config repo 里的 `agentpack.yaml`。
+> Language: English | [Chinese (Simplified)](zh-CN/CONFIG.md)
 
-你也可以手改 YAML，但更推荐用 `agentpack add/remove` 来改（能自动校验、少踩坑）。
+Agentpack’s single source of truth is the config repo’s `agentpack.yaml`.
 
-## 文件位置
+You can edit YAML by hand, but using `agentpack add/remove` is recommended (built-in validation; fewer footguns).
 
-默认：`$AGENTPACK_HOME/repo/agentpack.yaml`（`AGENTPACK_HOME` 默认 `~/.agentpack`）
+## File location
 
-也可用 `agentpack --repo <path>` 指定。
+Default: `$AGENTPACK_HOME/repo/agentpack.yaml` (`AGENTPACK_HOME` defaults to `~/.agentpack`)
 
-## 最小示例
+You can also set it via `agentpack --repo <path>`.
+
+## Minimal example
 
 ```yaml
 version: 1
@@ -48,50 +50,50 @@ modules:
         path: "modules/instructions/base"
 ```
 
-## 字段说明
+## Field reference
 
 ### version
 
-- 当前支持：`1`
+- Currently supported: `1`
 
 ### profiles
 
-Profile 用来从一堆 modules 里筛选“本次要部署哪些”。
+Profiles select which modules should be deployed for a run.
 
-字段：
-- `include_tags: [string]`：包含这些 tags 的模块
-- `include_modules: [module_id]`：显式包含模块
-- `exclude_modules: [module_id]`：显式排除模块
+Fields:
+- `include_tags: [string]`: include modules with these tags
+- `include_modules: [module_id]`: explicitly include modules
+- `exclude_modules: [module_id]`: explicitly exclude modules
 
-建议：
-- 至少有一个 `default` profile（必需）
+Required:
+- A `default` profile must exist.
 
 ### targets
 
-目前内置 targets：
+Built-in targets:
 - `codex`
 - `claude_code`
 
-每个 target 的字段：
-- `mode`: 目前只有 `files`
+Per-target fields:
+- `mode`: currently only `files`
 - `scope`: `user|project|both`
-- `options`: target-specific 的 key/value（YAML 任意值）
+- `options`: target-specific key/value (arbitrary YAML values)
 
-注意：
-- `scope` 会影响哪些 roots 会被写入（例如 user 目录 / project 目录）。
+Note:
+- `scope` controls which roots are written (user dirs and/or project dirs).
 
 ### modules
 
-每个 module 的字段：
-- `id: string`：全局唯一，建议 `type:name`（例如 `skill:git-review`）
+Per-module fields:
+- `id: string`: globally unique; recommended format is `type:name` (e.g. `skill:git-review`)
 - `type: instructions|skill|prompt|command`
-- `enabled: bool`：默认 true
-- `tags: [string]`：用于 profiles
-- `targets: [string]`：限制仅对某些 target 生效；空数组 = all
-- `source`: 见下
-- `metadata: {k: v}`：可选（纯透传，便于写注释/描述）
+- `enabled: bool`: default true
+- `tags: [string]`: used by profiles
+- `targets: [string]`: restrict to specific targets; empty = all
+- `source`: see below
+- `metadata: {k: v}`: optional; passthrough for comments/annotations
 
-#### source（两种）
+#### source (two kinds)
 
 1) local_path
 
@@ -101,36 +103,36 @@ source:
     path: "modules/instructions/base"
 ```
 
-约定：
-- 建议使用 repo 内相对路径。
+Convention:
+- Prefer repo-relative paths.
 
 2) git
 
 ```yaml
-source:
-  git:
-    url: "https://github.com/your-org/agentpack-modules.git"
-    ref: "v1.2.0"      # tag/branch/commit；默认 main
-    subdir: "skills/git-review"   # 可空
-    shallow: true       # 默认 true
-```
+	source:
+	  git:
+	    url: "https://github.com/your-org/agentpack-modules.git"
+	    ref: "v1.2.0"      # tag/branch/commit; default is main
+	    subdir: "skills/git-review"   # optional
+	    shallow: true       # default true
+	```
 
-说明：
-- git sources 会被 lock 到具体 commit（写进 `agentpack.lock.json`），确保可复现。
+Notes:
+- Git sources are locked to an exact commit (written to `agentpack.lock.json`) for reproducibility.
 
-## module 类型约束（重要）
+## Module type constraints (important)
 
-Agentpack 会在渲染前验证每个 module 的结构：
+Before rendering, Agentpack validates the materialized module structure:
 
-- `instructions`：必须包含 `AGENTS.md`
-- `skill`：必须包含 `SKILL.md`
-- `prompt`：必须“最终只有一个 `.md` 文件”
-- `command`：必须“最终只有一个 `.md` 文件”，且必须包含 YAML frontmatter：
-  - 必需字段：`description`
-  - 若正文里使用 `!bash`/`!\`bash\``：frontmatter 必须包含 `allowed-tools` 并允许 `Bash(...)`
+- `instructions`: must contain `AGENTS.md`
+- `skill`: must contain `SKILL.md`
+- `prompt`: must contain exactly one `.md` file after materialization
+- `command`: must contain exactly one `.md` file after materialization, and must include YAML frontmatter:
+  - Required: `description`
+  - If the body uses `!bash`/`!`bash``: frontmatter must include `allowed-tools` and allow `Bash(...)`
 
-提示：prompt/command 的 source 可以是单文件，也可以是一个目录；但 materialize 后必须只剩 1 个文件。
+Tip: for prompt/command modules, the source can be a single file or a directory, but the materialized result must contain exactly one file.
 
-更多：
-- targets 具体写入规则见 `TARGETS.md`
-- overlays 与 source 合成规则见 `OVERLAYS.md`
+See also:
+- Target writing rules: `TARGETS.md`
+- Overlay/source composition: `OVERLAYS.md`

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,100 +1,100 @@
-# ERROR_CODES（稳定错误码注册表）
+# ERROR_CODES.md (stable error code registry)
 
-> Current as of **v0.5.0** (2026-01-13). `SPEC.md` 是语义级权威；本文件是 `--json` 自动化分支用的“注册表”。
+> Current as of **v0.5.0** (2026-01-13). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
 
-本文件定义 `--json` 模式下对外稳定的错误码（`errors[0].code`）。
+This file defines stable, externally-consumable error codes for `--json` mode (`errors[0].code`).
 
-约定：
-- `ok=false` 时进程退出码非 0。
-- `errors[0].code` 用于自动化分支；`errors[0].message` 主要用于人类阅读（可能随版本优化）。
-- `warnings` 不用于强逻辑分支（字符串不保证稳定）。
+Conventions:
+- When `ok=false`, the process exit code is non-zero.
+- `errors[0].code` is for automation branching; `errors[0].message` is primarily for humans (may be refined over time).
+- Do not branch critically on `warnings` (strings are not stable).
 
-## 稳定错误码
+## Stable error codes
 
 ### E_CONFIRM_REQUIRED
-含义：在 `--json` 模式下，命令会产生写入（文件系统或 git），但缺少 `--yes`。
-典型场景：`deploy --apply --json`、`update --json`、`overlay edit --json` 等。
-是否可重试：是。
-建议动作：确认确实要写入后，补上 `--yes` 重试；或去掉 `--json` 走人类确认流程。
-details：通常包含 `{"command": "..."}`。
+Meaning: in `--json` mode, the command would perform a mutation (filesystem and/or git), but `--yes` is missing.
+Typical cases: `deploy --apply --json`, `update --json`, `overlay edit --json`, etc.
+Retryable: yes.
+Recommended action: confirm you intend to write, then retry with `--yes`, or drop `--json` and use interactive confirmation.
+Details: usually includes `{"command": "..."}`.
 
 ### E_ADOPT_CONFIRM_REQUIRED
-含义：`deploy --apply` 将覆盖一个“非托管但已存在”的文件（adopt_update），但未显式提供 `--adopt`。
-是否可重试：是。
-建议动作：
-- 先 `preview --diff` 确认影响范围；
-- 若确实要接管并覆盖，重新执行并加 `--adopt`。
-details：包含 `{flag, adopt_updates, sample_paths}`。
+Meaning: `deploy --apply` would overwrite an existing unmanaged file (`adopt_update`), but `--adopt` was not provided.
+Retryable: yes.
+Recommended action:
+- Run `preview --diff` to confirm scope/impact.
+- If you truly want to take over and overwrite, retry with `--adopt`.
+Details: includes `{flag, adopt_updates, sample_paths}`.
 
 ### E_CONFIG_MISSING
-含义：缺少 `repo/agentpack.yaml`。
-是否可重试：是。
-建议动作：运行 `agentpack init` 创建 skeleton，或指定正确 `--repo`。
-details：通常包含 `{path, hint}`。
+Meaning: missing `repo/agentpack.yaml`.
+Retryable: yes.
+Recommended action: run `agentpack init` to create a skeleton, or point to the correct repo via `--repo`.
+Details: typically includes `{path, hint}`.
 
 ### E_CONFIG_INVALID
-含义：`agentpack.yaml` 语法或语义不合法。
-是否可重试：取决于修复配置。
-建议动作：根据 `details`/报错信息修复 YAML（例如缺少 default profile、module id 重复、source 不合法、target 未配置等）。
+Meaning: `agentpack.yaml` is syntactically or semantically invalid.
+Retryable: depends on fixing config.
+Recommended action: fix YAML based on `details` and/or error message (e.g., missing default profile, duplicate module id, invalid source, missing target config).
 
 ### E_CONFIG_UNSUPPORTED_VERSION
-含义：`agentpack.yaml` 的 `version` 不被支持。
-是否可重试：取决于修复配置或升级工具版本。
-建议动作：将 `version` 调整为支持值（当前为 `1`），或升级 agentpack。
-details：通常包含 `{version, supported}`。
+Meaning: `agentpack.yaml` `version` is unsupported.
+Retryable: depends on fixing config or upgrading agentpack.
+Recommended action: set `version` to a supported value (currently `1`) or upgrade agentpack.
+Details: typically includes `{version, supported}`.
 
 ### E_LOCKFILE_MISSING
-含义：缺少 `repo/agentpack.lock.json`（但当前命令需要它，例如 `fetch`）。
-是否可重试：是。
-建议动作：运行 `agentpack lock` 或 `agentpack update`。
+Meaning: missing `repo/agentpack.lock.json` but the command requires it (e.g., `fetch`).
+Retryable: yes.
+Recommended action: run `agentpack lock` or `agentpack update`.
 
 ### E_LOCKFILE_INVALID
-含义：`agentpack.lock.json` JSON 不合法或无法解析。
-是否可重试：取决于修复/重建 lockfile。
-建议动作：修复 JSON 或删除后重新 `agentpack update` 生成。
+Meaning: `agentpack.lock.json` is invalid JSON or cannot be parsed.
+Retryable: depends on repair/rebuild.
+Recommended action: fix JSON or delete it and regenerate via `agentpack update`.
 
 ### E_TARGET_UNSUPPORTED
-含义：
-- `--target` 指定了不支持的值；或
-- manifest 里配置了未知 target。
-是否可重试：是。
-建议动作：
-- `--target` 只能是 `all|codex|claude_code`
-- manifest targets 只能包含内置 target（目前 `codex` 与 `claude_code`）
+Meaning:
+- `--target` specifies an unsupported value, or
+- The manifest config contains an unknown target.
+Retryable: yes.
+Recommended action:
+- `--target` must be `all|codex|claude_code`
+- Manifest targets must be built-in targets (currently `codex` and `claude_code`)
 
 ### E_DESIRED_STATE_CONFLICT
-含义：多个模块对同一 `(target,path)` 产出不同内容，Agentpack 拒绝静默覆盖。
-是否可重试：取决于配置/overlay 调整。
-建议动作：调整 modules/overlays，使同一路径只由一个模块产出，或让冲突路径内容一致。
-details：包含冲突双方的 sha256 与 module_ids。
+Meaning: multiple modules produced different content for the same `(target, path)`. Agentpack refuses to silently overwrite.
+Retryable: depends on config/overlay fixes.
+Recommended action: adjust modules/overlays so only one module produces that path, or make the contents identical.
+Details: includes both sides’ sha256 and module_ids.
 
 ### E_OVERLAY_NOT_FOUND
-含义：请求的 overlay 目录不存在。
-是否可重试：是。
-建议动作：先执行 `agentpack overlay edit <module_id>` 创建 overlay。
+Meaning: requested overlay directory does not exist.
+Retryable: yes.
+Recommended action: run `agentpack overlay edit <module_id>` to create the overlay.
 
 ### E_OVERLAY_BASELINE_MISSING
-含义：overlay 元数据缺失（`<overlay_dir>/.agentpack/baseline.json` 不存在），无法 rebase。
-是否可重试：是。
-建议动作：重新运行 `agentpack overlay edit <module_id>` 以补齐元数据。
+Meaning: overlay metadata is missing (`<overlay_dir>/.agentpack/baseline.json`), so rebase cannot proceed.
+Retryable: yes.
+Recommended action: re-run `agentpack overlay edit <module_id>` to regenerate metadata.
 
 ### E_OVERLAY_BASELINE_UNSUPPORTED
-含义：overlay baseline 缺少可定位的 merge base，无法安全 rebase。
-是否可重试：取决于修复 baseline。
-建议动作：通常建议重新创建 overlay（生成新 baseline），或确保 upstream 可追溯（git）后再重建。
+Meaning: overlay baseline cannot locate a merge base, so rebase cannot proceed safely.
+Retryable: depends on baseline repair.
+Recommended action: usually recreate the overlay (new baseline), or ensure upstream is traceable (git) and recreate.
 
 ### E_OVERLAY_REBASE_CONFLICT
-含义：`overlay rebase` 检测到无法自动合并的冲突。
-是否可重试：是（解决冲突后重试）。
-建议动作：打开 overlay 目录中带冲突标记的文件，手动解决后再次运行 `agentpack overlay rebase` 或直接提交 overlay 变更。
-details：包含 `{conflicts, summary, overlay_dir, scope, ...}`。
+Meaning: `overlay rebase` produced conflicts that cannot be auto-merged.
+Retryable: yes (after resolving conflicts).
+Recommended action: open the conflict-marked files under the overlay directory, resolve, then re-run `agentpack overlay rebase` (or commit overlay changes directly).
+Details: includes `{conflicts, summary, overlay_dir, scope, ...}`.
 
-## 非稳定/兜底错误码
+## Non-stable / fallback error codes
 
 ### E_UNEXPECTED
-含义：未被分类为稳定 UserError 的异常失败。
-是否可重试：不确定。
-建议动作：
-- 把 `errors[0].message` 与上下文输出（stdout/stderr）保存下来；
-- 尝试用更小的复现步骤重试；
-- 如果你在做自动化：通常应当“转人工”或 fail-fast，而不是基于 message 文本做分支。
+Meaning: unexpected failure that was not classified as a stable UserError.
+Retryable: unknown.
+Recommended action:
+- Save `errors[0].message` plus surrounding context (stdout/stderr).
+- Retry with a smaller repro.
+- For automation: typically “escalate to human” or fail-fast, rather than branching on message text.

--- a/docs/EVOLVE.md
+++ b/docs/EVOLVE.md
@@ -1,69 +1,71 @@
-# Evolve（自进化闭环）
+# Evolve (closed loop)
 
-Evolve 的定位不是“自动修改你的系统”，而是把变化变成 **可 review、可回滚、可同步** 的改动：
-- 变化发生在目标目录（例如你手工改了 `~/.claude/commands/ap-plan.md`）
-- agentpack 负责把这类 drift 捕获为 overlays（在 config repo 创建分支），让你像 code review 一样审查与合并
+> Language: English | [Chinese (Simplified)](zh-CN/EVOLVE.md)
 
-相关命令：
+Evolve is not “auto-modify your system”. Its job is to turn changes into **reviewable, rollbackable, syncable** updates:
+- Changes happen under target roots (e.g., you manually edit `~/.claude/commands/ap-plan.md`).
+- Agentpack captures that drift into overlays (on a new branch in your config repo) so you can review and merge like normal code review.
+
+Related commands:
 - `agentpack record` / `agentpack score`
 - `agentpack explain plan|diff|status`
 - `agentpack evolve propose` / `agentpack evolve restore`
 
-## 1) record / score（观测）
+## 1) record / score (observability)
 
 ### record
 
-`agentpack record` 会从 stdin 读取一段 JSON，并追加写入 `state/logs/events.jsonl`。
+`agentpack record` reads a JSON object from stdin and appends it to `state/logs/events.jsonl`.
 
-用法示例：
+Example:
 - `echo '{"module_id":"command:ap-plan","success":true}' | agentpack record`
 
-约定：
-- 顶层可以有 `module_id`/`success`，也可以放在内部 event 结构里。
-- score 会容忍坏行（例如 JSON 截断），跳过并输出 warnings。
+Notes:
+- You can place `module_id`/`success` at the top-level or inside a nested event object.
+- `score` tolerates malformed lines (e.g., truncated JSON), skips them, and emits warnings.
 
 ### score
 
-`agentpack score` 基于 events.jsonl 做简单统计（例如失败率），用于：
-- 找到“经常失败/需要修”的模块
-- 作为 evolve 的优先级信号（未来可扩展）
+`agentpack score` aggregates events.jsonl into simple stats (e.g., failure rates), used to:
+- Find modules that fail often and should be fixed
+- Provide a prioritization signal for evolve (extensible)
 
-## 2) explain（解释）
+## 2) explain
 
-`agentpack explain plan|diff|status` 会解释：
-- 某个输出文件来自哪个 module_id
-- 来自哪一层 source（upstream/global/machine/project overlay）
+`agentpack explain plan|diff|status` explains:
+- Which module id produced a given output file
+- Which source layer it came from (upstream/global/machine/project overlay)
 
-这对排查“为什么是这个版本生效”很关键。
+This is critical when debugging “why is this version active?”
 
-## 3) evolve propose（把 drift 变成 overlays）
+## 3) evolve propose (turn drift into overlays)
 
-命令：
+Command:
 - `agentpack evolve propose [--module-id <id>] [--scope global|machine|project] [--branch <name>]`
 
-推荐流程：
-1) 先看候选（不写入）：
+Recommended flow:
+1) Inspect candidates (no writes):
 - `agentpack evolve propose --dry-run --json`
 
-2) 再创建提案分支：
+2) Create a proposal branch:
 - `agentpack evolve propose --scope global`
 
-行为与限制：
-- 这是写入类命令：`--json` 下必须 `--yes`。
-- 会要求 config repo 是 git 仓库，并且工作区必须干净（否则拒绝）。
-- 会创建分支（默认 `evolve/propose-<timestamp>`），把 drifted 文件写入对应 overlay 路径，然后 `git add -A` 并尝试 commit。
-  - commit 失败（例如缺 git identity）时不会丢改动：分支与变更会保留。
+Behavior and constraints:
+- This is a mutating command: in `--json` mode you must pass `--yes`.
+- Requires the config repo to be a git repo, and the working tree must be clean (otherwise it refuses).
+- Creates a branch (default `evolve/propose-<timestamp>`), writes drifted files into the appropriate overlay paths, then runs `git add -A` and attempts to commit.
+  - If commit fails (e.g., missing git identity), changes are not lost: the branch and working tree changes remain.
 
-### 哪些 drift 会被 propose？
+### What drift is proposable?
 
-默认是保守策略：只对“能安全映射回 source 的改动”自动提案。
+The default strategy is conservative: only propose drift that can be safely mapped back to its source.
 
-1) **单模块输出**（推荐）：
-- 某个输出文件的 `module_ids.len() == 1`
-- 文件存在且内容不同（modified）
+1) **Single-module output** (recommended):
+- The output file has `module_ids.len() == 1`
+- The file exists and content differs (`modified`)
 
-2) **聚合输出（Codex 的 AGENTS.md）**：
-- 当多个 instructions 模块合成一个 `AGENTS.md` 时，agentpack 会在每个模块段落外包 marker：
+2) **Aggregated output (Codex `AGENTS.md`)**
+- When multiple instructions modules are combined into one `AGENTS.md`, agentpack wraps each module section with markers:
 
 ```md
 <!-- agentpack:module=instructions:one -->
@@ -71,33 +73,33 @@ Evolve 的定位不是“自动修改你的系统”，而是把变化变成 **�
 <!-- /agentpack -->
 ```
 
-- 若 deployed 与 desired 都包含 marker，evolve propose 可以逐模块对比段落差异，并把变更写回对应 instructions 模块的 overlay。
+- If both deployed and desired contain markers, evolve propose can diff sections per module and write changes back to that module’s overlay.
 
-以下情况会被跳过（会在 `skipped` 里给 reason）：
-- `missing`：文件不存在（见 evolve restore）
-- `multi_module_output`：无法安全定位到单个模块
-- `read_error`：文件读失败
+These cases are skipped (reported in `skipped` with a reason):
+- `missing`: file does not exist (see evolve restore)
+- `multi_module_output`: cannot safely attribute to a single module
+- `read_error`: failed to read the file
 
-## 4) evolve restore（恢复 missing 文件，create-only）
+## 4) evolve restore (restore missing files; create-only)
 
-命令：
+Command:
 - `agentpack evolve restore [--module-id <id>]`
 
-用途：
-- 当某些托管文件被删除（missing），你只想把它们“创建回来”，不想更新/删除其他东西。
+Use case:
+- Some managed files were deleted (missing) and you only want to recreate them without updating/deleting anything else.
 
-特性：
-- create-only：只创建缺失文件
-- 不更新已有文件
-- 不删除任何文件
+Properties:
+- create-only: creates missing files only
+- does not update existing files
+- does not delete anything
 
-推荐：
-- 先 `--dry-run --json` 看将要恢复哪些路径，再决定执行。
+Recommended:
+- Run `--dry-run --json` first to inspect which paths would be restored.
 
-## 5) 与 overlays 的关系
+## 5) Relationship to overlays
 
-- evolve propose 写入的内容本质就是 overlays。
-- 你最终应该把它们通过 review 合入 config repo，然后 `deploy --apply` 让系统回到“期望态”。
+- The output of evolve propose is overlays.
+- The intended flow is: review/merge into the config repo, then run `deploy --apply` to bring target roots back to desired state.
 
-如果你想手工做同样的事：
-- 可以直接 `agentpack overlay edit --sparse <module_id>` 然后自己把 drift copy 进去。
+If you want to do it manually:
+- You can run `agentpack overlay edit --sparse <module_id>` and copy drifted content into the overlay yourself.

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -1,93 +1,93 @@
-# GitHub 设置清单（需要你手工做）
+# GitHub setup checklist (manual / admin-only)
 
-这份清单专门放“代码里做不了/需要仓库管理员权限”的事情。
+This checklist captures repository settings that cannot be done from code, or require admin privileges.
 
-建议顺序：先把 CI 跑起来并稳定，然后再上分支保护与安全策略。
+Recommended order: get CI green and stable first, then enable branch protection and security hardening.
 
-## 1) 基础仓库设置
+## 1) Basic repo settings
 
-在 GitHub 仓库页面：Settings → General
+GitHub repo page: Settings → General
 
 - Features
-  - Issues：建议开启
-  - Discussions：可选（如果你希望把“使用问题/想法”从 Issues 分流出去）
+  - Issues: recommended
+  - Discussions: optional (useful if you want to offload “usage questions/ideas” from Issues)
 
 - Pull Requests
-  - 勾选：Always suggest updating pull request branches
-  - 勾选：Allow squash merging（并建议关闭 merge commit，保持线性历史）
-  - 可选：Automatically delete head branches
+  - Enable: Always suggest updating pull request branches
+  - Enable: Allow squash merging (and consider disabling merge commits to keep linear history)
+  - Optional: Automatically delete head branches
 
-## 2) 分支保护（Branch protection rules）
+## 2) Branch protection rules
 
 Settings → Branches → Add branch protection rule
 
-以 `main` 为例，建议打开：
+For `main`, recommended:
 - Require a pull request before merging
-  - Require approvals: 1~2（视团队而定）
-  - Require review from Code Owners（如果你有 CODEOWNERS）
+  - Require approvals: 1–2 (team dependent)
+  - Require review from Code Owners (if you use CODEOWNERS)
   - Dismiss stale PR approvals when new commits are pushed
 - Require status checks to pass before merging
-  - 把 CI 工作流里的关键 checks 设为 Required（例如：fmt/clippy/test/security audit/cargo-deny）
+  - Mark key CI checks as Required (e.g. fmt/clippy/test/security audit/cargo-deny)
 - Require conversation resolution before merging
 - Require linear history
-- (可选) Require signed commits
+- (Optional) Require signed commits
 
-提示：required checks 的名字要与 workflow job 名对齐，避免未来重命名导致保护失效。
+Tip: Required check names must match workflow job names; renaming jobs can silently weaken protection if you don’t update the rule.
 
-## 3) Actions 与发布权限
+## 3) Actions and release permissions
 
 Settings → Actions
 
 - General
-  - 允许 GitHub Actions 运行（默认即可）
+  - Allow GitHub Actions to run (default is fine)
 - Workflow permissions
-  - 如果你的 release workflow 需要写 Release/Tag：选择 “Read and write permissions”
-  - 勾选：Allow GitHub Actions to create and approve pull requests（如果你后续要自动化版本 bump/更新 changelog）
+  - If your release workflow needs to create Releases/Tags: choose “Read and write permissions”
+  - Optional: enable “Allow GitHub Actions to create and approve pull requests” (useful for automated version bump/changelog PRs)
 
-## 4) 安全设置（建议全开）
+## 4) Security & analysis (recommended to enable)
 
 Settings → Security & analysis
 
-建议开启：
+Recommended:
 - Dependency graph
 - Dependabot alerts
 - Dependabot security updates
 - Secret scanning
-- Secret scanning push protection（如果你的组织/计划支持）
+- Secret scanning push protection (if available for your org/plan)
 
-如果你打算用 GitHub 的 Code scanning（可选）：
+If you plan to use GitHub Code Scanning (optional):
 - Code scanning alerts
-- 配置 CodeQL workflow（Rust 支持良好，但会增加 CI 时间）
+- Set up a CodeQL workflow (Rust support is solid, but it increases CI time)
 
 ## 5) Releases
 
-如果你使用 `cargo-dist`（仓库内已有 release workflow）：
-- 确认默认分支与 tag 触发规则符合你的发布策略（例如 `vx.y.z`）
-- 发布前：检查 `CHANGELOG.md` 已更新
-- 发布后：检查 assets、checksums 是否齐全
+If you use `cargo-dist` (this repo ships a release workflow):
+- Verify the default branch and tag trigger rules match your release strategy (e.g. `vX.Y.Z`)
+- Before releasing: ensure `CHANGELOG.md` is updated
+- After releasing: verify assets and checksums are present
 
-## 6) Issue/PR 模板与标签
+## 6) Issue/PR templates and labels
 
-建议你在仓库里添加（可由代码 PR 完成）：
+Recommended templates (can be added via PR):
 - `.github/ISSUE_TEMPLATE/bug_report.yml`
 - `.github/ISSUE_TEMPLATE/feature_request.yml`
 - `.github/pull_request_template.md`
 
-但这些“默认标签（labels）”通常需要你在 UI 里准备（或用脚本/terraform 管理）：
-- `bug`, `enhancement`, `docs`, `good first issue`, `help wanted`, `breaking`, `security`, `target:codex`, `target:claude_code` ...
+Default labels usually need to be created in the UI (or managed via scripts/terraform), for example:
+- `bug`, `enhancement`, `docs`, `good first issue`, `help wanted`, `breaking`, `security`, `target:codex`, `target:claude_code`, ...
 
-## 7) 安全漏洞上报入口
+## 7) Vulnerability reporting
 
-如果你希望用户通过 GitHub 的 Private vulnerability reporting：
-- Settings → Security & analysis → Private vulnerability reporting（如果可用则开启）
+If you want GitHub’s Private vulnerability reporting:
+- Settings → Security & analysis → Private vulnerability reporting (enable if available)
 
-并建议在根目录提供 `SECURITY.md`（说明披露流程与响应 SLA）。
+Also consider adding a top-level `SECURITY.md` describing the disclosure process and response SLA.
 
-## 8) 社区运营（可选）
+## 8) Community ops (optional)
 
-如果你希望它成为“真正优秀的开源项目”，建议逐步开启：
-- Discussions（Q&A / Ideas）
-- GitHub Projects（Roadmap 可视化）
-- Sponsors（如果你打算接受赞助）
+If you want to invest in long-term OSS hygiene, consider enabling over time:
+- Discussions (Q&A / Ideas)
+- GitHub Projects (roadmap visualization)
+- Sponsors (if you want to accept sponsorship)
 
-注意：这些不影响核心质量，但能显著降低维护者的沟通成本。
+These don’t affect core quality, but they can significantly reduce maintainer communication overhead.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -2,54 +2,54 @@
 
 > Current as of **v0.5.0** (2026-01-13). Historical content is tracked in git history.
 
-## 1. 背景
+## 1. Background
 
-你会同时使用多个 AI coding 工具（例如 Codex CLI、Claude Code 等），而这些工具各自支持一套可插拔资产：AGENTS.md、skills、slash commands、prompts……
+You likely use multiple AI coding tools (e.g., Codex CLI, Claude Code). Each of them supports a set of pluggable assets: AGENTS.md, skills, slash commands, prompts, etc.
 
-现实痛点通常来自：
-- 发现成本：同类能力有大量实现，需要筛选与对比。
-- 维护成本：安装后会不断微调；上游更新后需要合并。
-- 协同成本：多台电脑、多项目、多工具导致版本与路径不一致。
-- 可控性：希望可审计、可回滚、可复现，而不是“当前生效的是哪个版本我不确定”。
+Common real-world pain points:
+- Discovery cost: there are many variants of similar capabilities; you need to filter and compare.
+- Maintenance cost: once installed, you keep tweaking; when upstream updates, you need to merge.
+- Collaboration cost: multiple machines/projects/tools lead to inconsistent versions and paths.
+- Control: you want auditable, rollbackable, reproducible state—not “I’m not sure which version is active right now”.
 
-Agentpack 的定位：在本地提供一个“资产控制平面（control plane）”，用声明式清单 + overlays + lockfile，把资产从管理到分发再到回滚统一起来，并对 AI 与人类都友好（AI-first）。
+Agentpack’s positioning: a local “asset control plane” that uses a declarative manifest + overlays + lockfile to unify management, distribution, and rollback of these assets—friendly to both humans and agents (AI-first).
 
-## 2. 产品目标
+## 2. Product goals
 
-P0（必须）
-- **可复现**：git sources 通过 lockfile 锁到 commit + sha256。
-- **可回滚**：deploy/rollback snapshots。
-- **安全写入**：仅删除托管文件；覆盖非托管文件必须显式 adopt。
-- **可编排**：`--json` 输出稳定；写入类命令在 `--json` 下必须 `--yes`。
+P0 (must-have)
+- **Reproducible**: git sources are locked to commit + sha256 via lockfile.
+- **Rollbackable**: deploy/rollback snapshots.
+- **Safe writes**: only delete managed files; overwriting unmanaged files requires explicit adopt.
+- **Composable**: stable `--json` output; mutating commands require `--yes` in `--json` mode.
 
-P1（强烈建议）
-- overlays 的编辑/合并体验足够顺滑（sparse overlay + rebase）。
-- 能把 drift 回流成可 review 的改动（evolve propose）。
+P1 (strongly recommended)
+- Smooth overlay edit/merge experience (sparse overlays + rebase).
+- Convert drift into reviewable changes (evolve propose).
 
-## 3. v5 milestone 已实现能力（当前实现）
+## 3. Shipped surface area (current implementation)
 
-闭环能力：
-- Config repo（manifest + overlays）作为单一真源
-- lockfile（`agentpack.lock.json`）+ store/cache（git checkout）
-- plan/diff/deploy：计划、diff、带备份写入与 snapshots
-- 每个 root 写 `.agentpack.manifest.json`：安全删除、可靠 drift/status
-- 覆盖保护：`adopt_update` 需要 `--adopt`
+Closed-loop capabilities:
+- Config repo (manifest + overlays) as the single source of truth
+- Lockfile (`agentpack.lock.json`) + store/cache (git checkout)
+- plan/diff/deploy: planning, diffs, backed-up writes, and snapshots
+- Per-root `.agentpack.manifest.json`: safe deletes and reliable drift/status
+- Overwrite protection: `adopt_update` requires `--adopt`
 
-体验与 AI-first：
-- 组合命令：`update`（lock+fetch）/ `preview`（plan + 可选 diff）
-- overlays 三 scope：global/machine/project
-- sparse overlay + `overlay rebase`（3-way merge）
-- `doctor --fix`：降低 manifest 被误提交风险
-- bootstrap：安装 operator assets（Codex operator skill + Claude `/ap-*` commands）
-- evolve：`propose`（把 drift 变成 overlays 提案分支）+ `restore`（create-only 恢复 missing）
+UX and AI-first:
+- Composite commands: `update` (lock+fetch) / `preview` (plan + optional diff)
+- Three overlay scopes: global/machine/project
+- Sparse overlays + `overlay rebase` (3-way merge)
+- `doctor --fix`: reduce accidental commits of manifests
+- bootstrap: install operator assets (Codex operator skill + Claude `/ap-*` commands)
+- evolve: `propose` (turn drift into overlay proposal branches) + `restore` (create-only restore missing files)
 
-## 4. 非目标（短期）
+## 4. Non-goals (short term)
 
-- Registry/marketplace 的完整发现体系（先以 git/local 为主）
-- 复杂 patch-based overlays（更强三方合并/patch 模型）
-- GUI（先保持 CLI；需要时再做轻量 TUI）
+- A full discovery system / marketplace (start with git/local sources)
+- Complex patch-based overlays (stronger merge/patch model)
+- GUI (keep CLI-first; add a lightweight TUI only if needed)
 
-## 5. 参考（上游官方文档）
+## 5. References
 
 - AGENTS.md: https://agents.md/
 - Codex:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,137 +1,139 @@
-# 快速开始（v0.5.0）
+# Quickstart (v0.5.0)
 
-本指南的目标：从 0 到第一次成功部署（deploy），并理解最核心的安全边界（不误删、不误覆盖）。
+> Language: English | [Chinese (Simplified)](zh-CN/QUICKSTART.md)
 
-## 0) 安装
+Goal: get from 0 → your first successful deploy, and understand the key safety guardrails (no accidental deletes/overwrites).
 
-- Rust 用户：
+## 0) Install
+
+- Rust users:
   - `cargo install agentpack --locked`
-- 非 Rust 用户：
-  - 从 GitHub Releases 下载对应平台二进制（见仓库 README）。
+- Non-Rust users:
+  - Download a prebuilt binary from GitHub Releases (see the repository README).
 
-验证：
+Verify:
 - `agentpack help`
 
-## 1) 初始化你的配置仓库（config repo）
+## 1) Initialize your config repo
 
-Agentpack 默认在 `~/.agentpack/repo` 创建/读取配置仓库（可用 `AGENTPACK_HOME` 或 `--repo` 改位置）。
+By default, Agentpack creates/uses the config repo at `~/.agentpack/repo` (override via `AGENTPACK_HOME` or `--repo`).
 
-1. 初始化 skeleton：
+1. Initialize a skeleton:
 - `agentpack init`
 
-会生成：
-- `agentpack.yaml`（清单）
-- `modules/`（示例模块目录：instructions/prompts/claude-commands）
+This creates:
+- `agentpack.yaml` (manifest)
+- `modules/` (example module dirs: instructions/prompts/claude-commands)
 
-建议你把它变成一个真正的 git repo（agentpack **不会**自动 `git init`）：
+We recommend turning it into a real git repo (Agentpack does **not** run `git init` automatically):
 - `cd ~/.agentpack/repo && git init && git add . && git commit -m "init agentpack"`
 
-可选：配置远端并同步（多机器）：
+Optional: set a remote and sync across machines:
 - `agentpack remote set <your_git_url>`
 - `agentpack sync --rebase`
 
-## 2) 配置 targets（Codex / Claude Code）
+## 2) Configure targets (Codex / Claude Code)
 
-`agentpack init` 会写入一份可用的 targets 默认配置。你通常只需要按需调整 options。
+`agentpack init` writes a usable default `targets:` config. You usually only need to tweak `options`.
 
-常见最小建议：
-- Codex：写 user skills、repo skills、global/repo AGENTS.md、user prompts（prompts 只支持 user scope）
-- Claude Code：写 repo commands + user commands（skills 默认先关闭，按需开启）
+Common minimal recommendations:
+- Codex: write user skills, repo skills, global/repo `AGENTS.md`, and user prompts (prompts are user-scope only)
+- Claude Code: write repo commands + user commands (skills are off by default; enable if needed)
 
-先跑一次自检：
+Run a self-check:
 - `agentpack doctor`
 
-如果你看到权限/目录不存在的告警，按提示创建目录或修正 `agentpack.yaml` 里的路径选项。
+If you see warnings about permissions or missing directories, create the directories or fix paths/options in `agentpack.yaml` as suggested.
 
-## 3) 添加模块（modules）
+## 3) Add modules
 
-模块写在 `agentpack.yaml -> modules:` 里。你可以用命令添加（推荐，少踩坑）：
+Modules live under `agentpack.yaml -> modules:`. You can edit YAML by hand, but using CLI commands is recommended (fewer footguns):
 
-- 添加一份 instructions（目录模块）：
+- Add an instructions module (directory module):
   - `agentpack add instructions local:modules/instructions/base --id instructions:base --tags base`
 
-- 添加一个 Codex prompt（单文件模块）：
+- Add a Codex prompt (single-file module):
   - `agentpack add prompt local:modules/prompts/draftpr.md --id prompt:draftpr --tags base`
 
-- 添加一个 Claude slash command（单文件模块）：
+- Add a Claude slash command (single-file module):
   - `agentpack add command local:modules/claude-commands/ap-plan.md --id command:ap-plan --tags base --targets claude_code`
 
-你也可以添加 git 模块（锁到 commit，可复现）：
+You can also add git modules (locked to a commit for reproducibility):
 - `agentpack add skill git:https://github.com/your-org/agentpack-modules.git#ref=v1.2.0&subdir=skills/git-review --id skill:git-review --tags work`
 
-## 4) 锁版本并拉取依赖（update）
+## 4) Lock and fetch dependencies (update)
 
-推荐用组合命令：
+Recommended composite command:
 - `agentpack update`
 
-行为：
-- 若 `agentpack.lock.json` 不存在：会先 lock 再 fetch
-- 若已存在：默认只 fetch
+Behavior:
+- If `agentpack.lock.json` does not exist: runs `lock` then `fetch`
+- If it exists: runs `fetch` only by default
 
-## 5) 预览（preview）
+## 5) Preview
 
-先看会发生什么：
+First, see what would change:
 - `agentpack preview --diff`
 
-常见你会看到：
-- 将要写入哪些 target
-- 哪些文件 create/update/delete
-- diff（如果加了 `--diff`）
+Typical output includes:
+- Which targets will be written
+- Which files would be created/updated/deleted
+- Diffs (when `--diff` is set)
 
-提示：如果你只想看某个 profile 或 target：
+Tip: preview only a specific profile or target:
 - `agentpack --profile work preview --diff`
 - `agentpack --target codex preview --diff`
 
-## 6) 部署（deploy）
+## 6) Deploy
 
-执行写入需要 `--apply`：
+To actually write files, you must pass `--apply`:
 - `agentpack deploy --apply`
 
-安全边界：
-- 删除只会删除“托管文件”（见每个 target root 的 `.agentpack.manifest.json`），不会删用户非托管文件。
-- 覆盖保护：如果目标路径存在但**不属于托管文件**，会被标记为 `adopt_update`，默认拒绝覆盖。
+Safety model:
+- Deletes only remove **managed files** (tracked via `.agentpack.manifest.json` per target root), never arbitrary user files.
+- Overwrite protection: if a destination path exists but is **not managed**, it is classified as `adopt_update` and is refused by default.
 
-如果你确认要“接管并覆盖”这类文件：
+If you want to explicitly take over and overwrite those unmanaged existing files:
 - `agentpack deploy --apply --adopt`
 
-如果你在自动化里用 `--json`：
-- 所有写入类命令都需要显式 `--yes`
+If you use `--json` in automation:
+- All mutating commands require explicit `--yes`
   - `agentpack --json deploy --apply --yes`
-  - 若存在 adopt_update，还需要 `--adopt`
+  - If there are `adopt_update`s, also add `--adopt`
 
-## 7) 漂移检查（status）与回滚（rollback）
+## 7) Drift (status) and rollback
 
-- 查看漂移：
+- Check drift:
   - `agentpack status`
 
-- 回滚到某次部署快照：
+- Roll back to a previous snapshot:
   - `agentpack rollback --to <snapshot_id>`
 
-快照 id 会在 `deploy --apply` 成功后输出（JSON 里在 `data.snapshot_id`）。
+The snapshot id is printed after a successful `deploy --apply` (in JSON: `data.snapshot_id`).
 
-## 8) 改动沉淀：overlays
+## 8) Capture local edits with overlays
 
-当你想基于上游模块做本地改动（并希望未来还能合并上游更新），用 overlays：
+When you want to customize an upstream module locally (and still be able to merge upstream updates later), use overlays:
 
-- 创建并编辑 overlay（默认 global scope）：
+- Create/edit an overlay (default: global scope):
   - `agentpack overlay edit <module_id>`
 
-- 更推荐的做法：创建稀疏 overlay（不复制整棵上游树，只放改动文件）：
+- Recommended: create a sparse overlay (don’t copy the entire upstream tree; keep only changed files):
   - `agentpack overlay edit <module_id> --sparse`
 
-- 需要浏览上游文件时再补齐（missing-only，不覆盖已改文件）：
+- When you need to browse upstream files, materialize missing-only (does not overwrite your edits):
   - `agentpack overlay edit <module_id> --materialize`
 
-- 上游更新后，把 overlay 3-way merge 到最新上游：
+- After upstream updates, rebase (3-way merge) your overlay onto the new upstream:
   - `agentpack overlay rebase <module_id> --sparsify`
 
-## 9) AI-first 自举（bootstrap）
+## 9) AI-first bootstrap (operator assets)
 
-让 AI 自己会用 agentpack（推荐完成一次）：
+Let agents learn how to use agentpack (recommended once):
 - `agentpack bootstrap --scope both`
 
-它会安装：
-- Codex：一个 operator skill（教 Codex 调 agentpack CLI，优先用 `--json`）
-- Claude Code：一组 `/ap-*` slash commands（计划/部署/状态/提案等）
+It installs:
+- Codex: an operator skill (teaches Codex to call agentpack CLI, preferring `--json`)
+- Claude Code: a set of `/ap-*` slash commands (plan/deploy/status/propose, etc.)
 
-更多见：`BOOTSTRAP.md`。
+See `BOOTSTRAP.md` for details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,64 +1,69 @@
 # Agentpack Docs
 
-这份文档集面向两类读者：
-- **用户（会用就行）**：照着做能完成安装、配置、预览、部署、回滚，并把改动沉淀为 overlays。
-- **贡献者（要改代码/加 target）**：需要理解引擎、数据模型、`--json` 契约、conformance 测试。
+> Language: English | [Chinese (Simplified)](zh-CN/README.md)
 
-如果你只想“现在就用起来”，从《快速开始》开始。
+This documentation set serves two audiences:
+- **Users (just want it to work)**: install, configure, preview, deploy, rollback, and capture local edits via overlays.
+- **Contributors (changing code / adding targets)**: understand the engine, data model, the `--json` contract, and conformance tests.
 
-## 用户文档（推荐阅读顺序）
+English docs under `docs/` are canonical. Chinese (Simplified) translations for user docs live under `docs/zh-CN/` and may lag slightly behind.
 
-1) **快速开始**：`QUICKSTART.md`
-- 30 分钟从 0 到第一次 deploy
+If you just want to start using Agentpack, begin with **Quickstart**.
 
-2) **日常工作流**：`WORKFLOWS.md`
-- 更新依赖（update）→ 预览（preview）→ 应用（deploy --apply）
-- 漂移（status）→ 提案（evolve propose）→ review → 合入
+## User docs (recommended order)
 
-3) **CLI 命令参考**：`CLI.md`
-- 全局参数、每个命令的用途/关键 flag/示例
+1) **Quickstart**: `QUICKSTART.md`
+- Get from 0 → first successful deploy in ~30 minutes.
 
-4) **配置文件与模块**：`CONFIG.md`
-- `agentpack.yaml`（profiles/targets/modules）与 source spec（local/git）
+2) **Daily workflows**: `WORKFLOWS.md`
+- Update (update) → Preview (preview) → Apply (deploy --apply)
+- Drift (status) → Proposal (evolve propose) → Review → Merge
 
-5) **Targets（Codex / Claude Code）**：`TARGETS.md`
-- 写入位置、options、限制（尤其是 prompts 仅 user scope）
+3) **CLI reference**: `CLI.md`
+- Global flags and per-command usage/examples.
 
-6) **Overlays**：`OVERLAYS.md`
-- global/machine/project 三层 overlay
-- `overlay edit --sparse/--materialize` 与 `overlay rebase`（3-way merge）
+4) **Config & modules**: `CONFIG.md`
+- `agentpack.yaml` (profiles/targets/modules) and source specs (local/git).
 
-7) **AI 自举（Bootstrap）**：`BOOTSTRAP.md`
-- 安装 operator assets：让 AI 自己会用 agentpack
+5) **Targets (Codex / Claude Code)**: `TARGETS.md`
+- Where files are written, options, and limitations (especially prompts = user scope only).
 
-8) **Evolve（自进化闭环）**：`EVOLVE.md`
+6) **Overlays**: `OVERLAYS.md`
+- global/machine/project overlays
+- `overlay edit --sparse/--materialize` and `overlay rebase` (3-way merge)
+
+7) **Bootstrap (AI operator assets)**: `BOOTSTRAP.md`
+- Install operator assets so agents can self-serve with agentpack.
+
+8) **Evolve loop**: `EVOLVE.md`
 - record/score/explain/propose/restore
 
-9) **排障**：`TROUBLESHOOTING.md`
-- 常见错误码、冲突、权限、Windows 路径问题等
+9) **Troubleshooting**: `TROUBLESHOOTING.md`
+- Common error codes, conflicts, permissions, Windows path gotchas, etc.
 
-## 参考/契约（给自动化与贡献者）
+## Contracts & references (automation + contributors)
 
-- **SPEC（实现对齐的唯一权威）**：`SPEC.md`
-- **JSON 输出契约**：`JSON_API.md`
-- **稳定错误码注册表**：`ERROR_CODES.md`
-- **架构总览**：`ARCHITECTURE.md`
-- **Target SDK（如何加新 target）**：`TARGET_SDK.md`
-- **Target conformance**：`TARGET_CONFORMANCE.md`
+- **SPEC (implementation-aligned source of truth)**: `SPEC.md`
+- **JSON output contract**: `JSON_API.md`
+- **Stable error code registry**: `ERROR_CODES.md`
+- **Architecture overview**: `ARCHITECTURE.md`
+- **Target SDK (how to add a target)**: `TARGET_SDK.md`
+- **Target conformance**: `TARGET_CONFORMANCE.md`
 
-## 维护者/工程化
+## Maintainer / project ops
 
-- 发布流程：`RELEASING.md`
-- 依赖与安全检查：`SECURITY_CHECKS.md`
-- 产品文档（历史背景/规划）：`PRD.md`、`BACKLOG.md`
-- 可执行工作单（给 Codex CLI 直接干活）：`CODEX_WORKPLAN.md`
+- Release process: `RELEASING.md`
+- Dependency & security checks: `SECURITY_CHECKS.md`
+- GitHub setup checklist (manual / admin-only): `GITHUB_SETUP.md`
+- Product docs (background/roadmap): `PRD.md`, `BACKLOG.md`
+- Executable workplan (for Codex CLI): `CODEX_WORKPLAN.md`
 
-## 外部参考（上游工具的官方文档）
+## External references
 
-- AGENTS.md（规范/示例）：https://agents.md/
-- Codex：
-  - AGENTS.md 指令发现：https://developers.openai.com/codex/guides/agents-md/
-  - Skills：https://developers.openai.com/codex/skills/
-  - Custom Prompts：https://developers.openai.com/codex/custom-prompts/
-- Claude Code：
-  - Slash commands：https://code.claude.com/docs/en/slash-commands
+- AGENTS.md: https://agents.md/
+- Codex:
+  - AGENTS.md discovery: https://developers.openai.com/codex/guides/agents-md/
+  - Skills: https://developers.openai.com/codex/skills/
+  - Custom prompts: https://developers.openai.com/codex/custom-prompts/
+- Claude Code:
+  - Slash commands: https://code.claude.com/docs/en/slash-commands

--- a/docs/SECURITY_CHECKS.md
+++ b/docs/SECURITY_CHECKS.md
@@ -1,36 +1,36 @@
-# SECURITY_CHECKS.md
+# Security checks (CI defaults)
 
-本仓库在 CI 中默认启用两类依赖/安全检查：
+This repository enables two dependency/security checks in CI by default.
 
-## 1) RustSec 漏洞扫描（advisories）
+## 1) RustSec advisory scan (`cargo audit`)
 
-- CI: `.github/workflows/ci.yml` 的 `Security audit` job（`rustsec/audit-check`）
-- 本地（可选）：安装后运行 `cargo audit`
-  - 安装：`cargo install cargo-audit --locked`
+- CI: `.github/workflows/ci.yml` → `Security audit` job (`rustsec/audit-check`)
+- Local (optional): install and run `cargo audit`
+  - Install: `cargo install cargo-audit --locked`
 
-失败处理建议：
-- **优先**升级/替换依赖以消除漏洞。
-- 若必须临时忽略（不推荐）：需要在 PR/Issue 中写明原因、影响范围、以及移除 ignore 的计划。
+How to handle failures:
+- Prefer upgrading/replacing dependencies to eliminate advisories.
+- If you must temporarily ignore something (not recommended): document the reason, impact, and a concrete removal plan in the PR/issue.
 
-## 2) cargo-deny 依赖策略检查（licenses / bans / sources）
+## 2) `cargo-deny` dependency policy (licenses / bans / sources)
 
-- CI: `.github/workflows/ci.yml` 的 `Dependency policy (cargo-deny)` job
-- 配置：`deny.toml`
-- 当前 CI 运行的 checks：
-  - `licenses`：许可证允许列表与例外
-  - `bans`：重复依赖版本与通配版本约束（`*`）
-  - `sources`：依赖来源（仅允许 crates.io；禁止未知 registry/git）
+- CI: `.github/workflows/ci.yml` → `Dependency policy (cargo-deny)` job
+- Config: `deny.toml`
+- Checks currently run in CI:
+  - `licenses`: allowlist/exceptions
+  - `bans`: duplicate versions and wildcard constraints (`*`)
+  - `sources`: dependency sources (allow crates.io only; disallow unknown registries/git by default)
 
-本地运行：
+Run locally:
 - `cargo install cargo-deny@0.18.3 --locked`
 - `cargo deny check licenses bans sources`
 
-失败处理建议：
-- **licenses**：
-  - 新增的许可证若可接受：将 SPDX 标识加入 `deny.toml` 的 `licenses.allow`
-  - 若仅某个 crate 需要例外：使用 `licenses.exceptions`（并写清楚 reason/issue）
-- **sources**：
-  - 尽量避免 git 依赖；若确实必要，显式加入 `sources.allow-git`（并写清楚 reason/issue）
-- **bans**：
-  - `wildcards`（`*`）被拒绝：将依赖版本固定到明确的 semver 约束
-  - `multiple-versions` 当前为 warning：可逐步通过 `cargo update -p <crate>` / 依赖升级来收敛
+How to handle failures:
+- `licenses`:
+  - If the new license is acceptable: add its SPDX identifier to `deny.toml` → `licenses.allow`
+  - If only one crate needs an exception: use `licenses.exceptions` (and document `reason`/issue)
+- `sources`:
+  - Avoid git deps when possible; if you must, add it explicitly under `sources.allow-git` (and document `reason`/issue)
+- `bans`:
+  - If `wildcards` (`*`) is rejected: pin the dependency to an explicit semver range
+  - `multiple-versions` is currently a warning: reduce over time via dependency upgrades and `cargo update -p <crate>`

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -1,75 +1,77 @@
-# Targets（codex / claude_code）
+# Targets (`codex` / `claude_code`)
 
-Target 决定 agentpack 要把“编译后的资产”写到哪里，以及哪些目录需要写 `.agentpack.manifest.json` 来实现安全删除和漂移检测。
+> Language: English | [Chinese (Simplified)](zh-CN/TARGETS.md)
 
-目前内置 targets：
+Targets define where agentpack writes the “compiled assets”, and which directories must write `.agentpack.manifest.json` to enable safe deletes and drift detection.
+
+Built-in targets:
 - `codex`
 - `claude_code`
 
-Target 的通用字段见 `CONFIG.md`。
+For shared target fields, see `CONFIG.md`.
 
 ## 1) codex
 
-### 写入位置（roots）
+### Managed roots
 
-由 `targets.codex.scope` 和 `targets.codex.options.*` 决定，可能包含：
-- `~/.codex`（global instructions：`AGENTS.md`）
-- `~/.codex/skills`（user skills）
-- `~/.codex/prompts`（custom prompts；只支持 user scope）
-- `<project_root>/AGENTS.md`（project instructions）
-- `<project_root>/.codex/skills`（repo skills）
+Determined by `targets.codex.scope` and `targets.codex.options.*`, and may include:
+- `~/.codex` (global instructions: `AGENTS.md`)
+- `~/.codex/skills` (user skills)
+- `~/.codex/prompts` (custom prompts; user scope only)
+- `<project_root>/AGENTS.md` (project instructions)
+- `<project_root>/.codex/skills` (repo skills)
 
-说明：
-- `project_root` 来自当前工作目录的 project 识别（通常是 git repo root）。
-- 每个 root 都会写入（或更新）`.agentpack.manifest.json`，用于安全删除与 drift。
+Notes:
+- `project_root` is derived from the current working directory’s project identity (usually the git repo root).
+- Each root writes (or updates) `.agentpack.manifest.json` for safe deletes and drift detection.
 
-### module → 输出映射
+### Module → output mapping
 
 - `instructions`
-  - 收集每个 instructions module 的 `AGENTS.md` 内容
-  - 多个模块时会合成一个 `AGENTS.md`：用 per-module section markers 标记来源，以支持 `evolve propose` 对聚合文件回溯
+  - Collects each instructions module’s `AGENTS.md`
+  - When multiple modules exist, agentpack generates a single `AGENTS.md` with per-module section markers to support `evolve propose` mapping for aggregated files
 
 - `skill`
-  - 复制 module 目录下所有文件到：
-    - `~/.codex/skills/<skill_name>/...`（如启用 user skills）
-    - `<project_root>/.codex/skills/<skill_name>/...`（如启用 repo skills）
-  - `<skill_name>` 默认从 module id 推导（`skill:<name>`），否则会做一次安全规整
+  - Copies all files under the module directory to:
+    - `~/.codex/skills/<skill_name>/...` (if user skills are enabled)
+    - `<project_root>/.codex/skills/<skill_name>/...` (if repo skills are enabled)
+  - `<skill_name>` is derived from the module id (`skill:<name>`) when possible; otherwise it is sanitized
 
 - `prompt`
-  - 复制单个 `.md` 文件到 `~/.codex/prompts/<filename>.md`
+  - Copies a single `.md` file to `~/.codex/prompts/<filename>.md`
 
-### 常用 options
+### Common options
 
-- `codex_home`：默认 `"~/.codex"`
-- `write_repo_skills`：默认 true（需要 project scope 允许）
-- `write_user_skills`：默认 true（需要 user scope 允许）
-- `write_user_prompts`：默认 true（需要 user scope 允许）
-- `write_agents_global`：默认 true（需要 user scope 允许）
-- `write_agents_repo_root`：默认 true（需要 project scope 允许）
+- `codex_home`: default `"~/.codex"`
+- `write_repo_skills`: default true (requires project scope)
+- `write_user_skills`: default true (requires user scope)
+- `write_user_prompts`: default true (requires user scope)
+- `write_agents_global`: default true (requires user scope)
+- `write_agents_repo_root`: default true (requires project scope)
 
-### 限制与建议
+### Limitations and tips
 
-- agentpack 默认使用 copy/render，不依赖 symlink（目标是让 Codex 稳定发现）。
-- prompts 按 Codex 语义只写 user scope（`~/.codex/prompts`）。如果你想共享“可复用能力”，更推荐写成 skill。
+- Agentpack uses copy/render by default (no symlinks) to keep discovery reliable in Codex.
+- Prompts are written to user scope only (`~/.codex/prompts`) per Codex semantics. If you want to share reusable behavior, prefer a skill instead.
 
 ## 2) claude_code
 
-### 写入位置（roots）
+### Managed roots
 
-- `~/.claude/commands`（user commands；默认启用）
-- `<project_root>/.claude/commands`（repo commands；默认启用）
+- `~/.claude/commands` (user commands; enabled by default)
+- `<project_root>/.claude/commands` (repo commands; enabled by default)
 
-### module → 输出映射
+### Module → output mapping
 
 - `command`
-  - 复制单个 `.md` 文件到 commands 目录
-  - 文件名就是 slash command 名（例如 `ap-plan.md` → `/ap-plan`）
+  - Copies a single `.md` file into the commands directory
+  - The filename becomes the slash command name (e.g. `ap-plan.md` → `/ap-plan`)
 
-### frontmatter 约束（很重要）
+### Frontmatter requirements (important)
 
-Claude Code 的自定义命令文件需要 YAML frontmatter。
+Claude Code custom command files require YAML frontmatter.
 
-最小示例：
+Minimal example:
 
 ```md
 ---
@@ -83,18 +85,18 @@ allowed-tools:
 ...
 ```
 
-规则：
-- 必须有 `description`
-- 如果正文包含 `!bash` 或 `!\`bash\``：必须声明 `allowed-tools` 且允许 `Bash(...)`
+Rules:
+- `description` is required
+- If the body contains `!bash` or `!`bash``: you must declare `allowed-tools` and include `Bash(...)`
 
-## 3) scan_extras（extra 文件的处理）
+## 3) scan_extras (handling extra files)
 
-某些 roots 会启用 `scan_extras`：
-- `true`：status 会报告“目录中存在但不在托管清单里”的 extra 文件（不会自动删除）
-- `false`：不扫描 extra（例如 global `~/.codex` 根目录通常不做全量扫描）
+Some roots enable `scan_extras`:
+- `true`: `status` reports “extra” files that exist on disk but are not in the managed manifest (never auto-deleted)
+- `false`: do not scan extras (e.g., the global `~/.codex` root typically avoids full scans)
 
-## 4) 想加新 target？
+## 4) Adding a new target?
 
-看：
+See:
 - `TARGET_SDK.md`
 - `TARGET_CONFORMANCE.md`

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,124 +1,126 @@
-# 排障（Troubleshooting）
+# Troubleshooting
 
-这份文档按“症状 → 原因 → 解决”组织，并尽量用稳定错误码来定位问题。
+> Language: English | [Chinese (Simplified)](zh-CN/TROUBLESHOOTING.md)
 
-如果你使用 `--json`，请优先看：
+This document is organized as **symptom → cause → fix**, and aims to use stable error codes whenever possible.
+
+If you use `--json`, prioritize:
 - `errors[0].code`
-- `errors[0].details`（如果有）
+- `errors[0].details` (if present)
 
-错误码全集见：`ERROR_CODES.md`。
+See `ERROR_CODES.md` for the full registry.
 
 ## 1) E_CONFIRM_REQUIRED
 
-症状：
-- `--json` 模式下执行写入类命令失败
-- 错误码：`E_CONFIRM_REQUIRED`
+Symptom:
+- Mutating commands fail in `--json` mode
+- Error code: `E_CONFIRM_REQUIRED`
 
-原因：
-- agentpack 把 `--json` 输出当作机器 API，为了避免脚本/LLM“误写入”，对写入类命令必须显式 `--yes`。
+Cause:
+- Agentpack treats `--json` as a machine API. To prevent accidental writes from scripts/LLMs, mutating commands require explicit `--yes`.
 
-解决：
-- 确认你确实想执行写入，然后重试并加 `--yes`：
+Fix:
+- Confirm you truly intend to write, then retry with `--yes`:
   - `agentpack --json deploy --apply --yes`
   - `agentpack --json update --yes`
   - `agentpack --json bootstrap --yes`
 
 ## 2) E_ADOPT_CONFIRM_REQUIRED
 
-症状：
-- `deploy --apply` 被拒绝覆盖某些文件
-- 错误码：`E_ADOPT_CONFIRM_REQUIRED`
+Symptom:
+- `deploy --apply` refuses to overwrite some files
+- Error code: `E_ADOPT_CONFIRM_REQUIRED`
 
-原因：
-- 这些更新是 `adopt_update`：目标路径已有文件，但它不在 agentpack 的托管清单里（非托管）。默认不会无感覆盖。
+Cause:
+- These updates are `adopt_update`: the destination file exists but is not in agentpack’s managed manifest. It is refused by default.
 
-解决：
-1) 先预览并确认影响范围：
+Fix:
+1) Preview and confirm the impact:
 - `agentpack preview --diff`
 
-2) 如果确认要接管覆盖：
+2) If you want to take over and overwrite:
 - `agentpack deploy --apply --adopt`
 
-提示：
-- `errors[0].details.sample_paths` 通常会给出部分路径样例。
+Tip:
+- `errors[0].details.sample_paths` usually includes a sample list of affected paths.
 
 ## 3) E_DESIRED_STATE_CONFLICT
 
-症状：
-- `plan/preview/deploy` 报“conflicting desired outputs...`
-- 错误码：`E_DESIRED_STATE_CONFLICT`
+Symptom:
+- `plan/preview/deploy` reports “conflicting desired outputs...`
+- Error code: `E_DESIRED_STATE_CONFLICT`
 
-原因：
-- 多个模块对同一 `(target, path)` 产出了不同内容。agentpack 拒绝静默覆盖。
+Cause:
+- Multiple modules produced different content for the same `(target, path)`. Agentpack refuses to silently overwrite.
 
-解决：
-- 调整 manifest：让该路径只由一个模块负责；或让冲突路径内容一致。
-- 如果是 overlays 引起的，优先检查 overlay 中是否有同名文件覆盖了其他模块输出。
+Fix:
+- Adjust the manifest so the path is produced by only one module, or ensure the content is identical.
+- If caused by overlays, check whether an overlay file is unintentionally overriding another module’s output.
 
 ## 4) E_CONFIG_MISSING / E_CONFIG_INVALID / E_CONFIG_UNSUPPORTED_VERSION
 
-症状：
-- 找不到或解析不了 `agentpack.yaml`
+Symptom:
+- `agentpack.yaml` is missing or cannot be parsed
 
-解决：
-- `E_CONFIG_MISSING`：运行 `agentpack init` 或用 `--repo` 指定正确 repo
-- `E_CONFIG_INVALID`：按 `details.error` 修复 YAML；注意必须存在 `profiles.default`
-- `E_CONFIG_UNSUPPORTED_VERSION`：将 manifest `version` 调整为支持值（当前 1）或升级工具
+Fix:
+- `E_CONFIG_MISSING`: run `agentpack init` or point to the correct repo via `--repo`
+- `E_CONFIG_INVALID`: fix YAML based on `details.error`; note `profiles.default` is required
+- `E_CONFIG_UNSUPPORTED_VERSION`: set manifest `version` to a supported value (currently `1`) or upgrade agentpack
 
 ## 5) E_LOCKFILE_MISSING / E_LOCKFILE_INVALID
 
-症状：
-- fetch 或需要 git 模块时提示缺少/损坏 lockfile
+Symptom:
+- `fetch` (or commands that need git modules) report missing/invalid lockfile
 
-解决：
-- 生成：`agentpack lock` 或 `agentpack update`
-- 如果 lockfile 损坏：删除 `agentpack.lock.json` 后重新 `agentpack update`
+Fix:
+- Generate: `agentpack lock` or `agentpack update`
+- If corrupted: delete `agentpack.lock.json`, then run `agentpack update` again
 
 ## 6) E_TARGET_UNSUPPORTED
 
-症状：
-- `--target` 传了不支持值，或 manifest 里 targets 配了未知 target
+Symptom:
+- `--target` uses an unsupported value, or the manifest config contains an unknown target
 
-解决：
-- `--target` 只能是 `all|codex|claude_code`
-- manifest targets 只能包含 `codex` 与 `claude_code`
+Fix:
+- `--target` must be `all|codex|claude_code`
+- Manifest targets must be `codex` and/or `claude_code`
 
-## 7) Overlay 相关
+## 7) Overlay errors
 
 ### E_OVERLAY_NOT_FOUND
-- 先 `agentpack overlay edit <module_id>` 创建 overlay
+- Run `agentpack overlay edit <module_id>` to create the overlay.
 
 ### E_OVERLAY_BASELINE_MISSING
-- overlay 元数据缺失，通常是手工创建目录导致
-- 解决：重新运行 `agentpack overlay edit <module_id>` 让它补齐 `.agentpack/baseline.json`
+- Overlay metadata is missing (often due to manual directory creation).
+- Fix: re-run `agentpack overlay edit <module_id>` to regenerate `.agentpack/baseline.json`.
 
 ### E_OVERLAY_BASELINE_UNSUPPORTED
-- baseline 无法定位 merge base（例如历史版本 baseline 信息不足）
-- 解决：重新创建 overlay（新 baseline），或把 upstream 变成可追溯（git）再创建 overlay
+- The baseline cannot locate a merge base (e.g., baseline too old or upstream identity missing).
+- Fix: recreate the overlay (new baseline), or switch upstream to a traceable git source and recreate the overlay.
 
 ### E_OVERLAY_REBASE_CONFLICT
-- 发生 3-way merge 冲突
-- 解决：打开冲突文件手工处理后再 rebase，或直接手动 commit overlay
+- 3-way merge conflicts during `overlay rebase`.
+- Fix: open conflict-marked files under the overlay directory, resolve, then re-run rebase (or commit overlay changes manually).
 
-## 8) evolve propose 失败：dirty working tree
+## 8) evolve propose fails: dirty working tree
 
-症状：
-- `evolve propose` 提示 working tree dirty / refusing to propose...
+Symptom:
+- `evolve propose` reports “working tree dirty” / “refusing to propose...”
 
-原因：
-- propose 会创建分支并写入 overlay 文件，要求 config repo 干净，避免把不相关改动混进去。
+Cause:
+- Propose creates a branch and writes overlay files. It requires a clean config repo working tree to avoid mixing unrelated changes.
 
-解决：
-- 先 `git status`，把未提交改动 commit 或 stash
-- 再重试 `agentpack evolve propose ...`
+Fix:
+- Run `git status`, then commit or stash changes
+- Retry `agentpack evolve propose ...`
 
-## 9) Windows 路径问题
+## 9) Windows path issues
 
-症状：
-- module id 里有 `:`，创建 overlay 目录失败
+Symptom:
+- Module ids containing `:` fail to create overlay directories
 
-说明：
-- agentpack 使用 `module_fs_key`（sanitize + hash）作为目录名，已避免 Windows 的非法字符。
-- 如果你从历史版本迁移而来，旧目录名可能不兼容。建议：
-  - 用 `agentpack overlay path <module_id>` 找到当前生效目录
-  - 只保留一个目录命名（避免 legacy + canonical 并存引发困惑）
+Notes:
+- Agentpack uses `module_fs_key` (sanitize + hash) as directory names to avoid Windows invalid characters.
+- If migrating from older versions, legacy overlay directory names may be incompatible. Recommended:
+  - Use `agentpack overlay path <module_id>` to see the effective directory
+  - Keep only one naming scheme to avoid confusion (legacy + canonical coexisting)

--- a/docs/zh-CN/BOOTSTRAP.md
+++ b/docs/zh-CN/BOOTSTRAP.md
@@ -1,0 +1,59 @@
+# Bootstrap（AI 自举 / Operator assets）
+
+> Language: 简体中文 | [English](../BOOTSTRAP.md)
+
+Bootstrap 的目标：把“会用 agentpack”这件事交给 AI 自己完成。
+
+执行一次 bootstrap 后：
+- Codex 会多一个 `agentpack-operator` skill，教它如何调用 `agentpack` CLI（优先 `--json`），以及推荐的工作流。
+- Claude Code 会多一组 `/ap-*` slash commands，封装常用的 `doctor/update/preview/plan/diff/deploy/status/explain/evolve` 操作，并使用最小化的 `allowed-tools`。
+
+## 1) 命令
+
+`agentpack bootstrap [--scope user|project|both]`
+
+- `--scope` 默认 `both`：同时写 user 与 project 位置
+- 选择写哪些 target 用全局 `--target`：
+  - `agentpack --target codex bootstrap`
+  - `agentpack --target claude_code bootstrap`
+
+## 2) 写入位置
+
+- Codex：
+  - user：`~/.codex/skills/agentpack-operator/SKILL.md`
+  - project：`<project_root>/.codex/skills/agentpack-operator/SKILL.md`
+
+- Claude Code：
+  - user：`~/.claude/commands/ap-*.md`
+  - project：`<project_root>/.claude/commands/ap-*.md`
+
+这些文件也会被纳入 target manifest（`.agentpack.manifest.json`），因此：
+- 可以被 `status` 检测
+- 可以被 `rollback` 回滚
+- 删除只会删托管文件
+
+## 3) 版本标记与更新
+
+Bootstrap 写入的模板会替换 `{{AGENTPACK_VERSION}}` 为当前 agentpack 版本号。
+
+当你升级 agentpack 后，如果 `status` 提示 operator assets 过期：
+- 直接重新运行 `agentpack bootstrap` 即可更新。
+
+## 4) dry-run 与 --json
+
+- 预览（不写入）：`agentpack bootstrap --dry-run --json`
+- 应用（写入）：
+  - human：`agentpack bootstrap`（会交互确认）
+  - json：`agentpack --json bootstrap --yes`
+
+说明：bootstrap 属于写入类命令；在 `--json` 下必须显式 `--yes`，否则返回 `E_CONFIRM_REQUIRED`。
+
+## 5) 自定义 operator assets（可选）
+
+Bootstrap 使用内置模板（随版本更新）：
+- `templates/codex/skills/agentpack-operator/SKILL.md`
+- `templates/claude/commands/ap-*.md`
+
+如果你希望完全自定义：
+- 你可以把这些内容做成普通 module（`skill`/`command`），由 manifest 管理；
+- 或者在 bootstrap 后用 overlays 覆盖模板写入的文件（更推荐作为“你自己的版本”沉淀进 config repo）。

--- a/docs/zh-CN/CLI.md
+++ b/docs/zh-CN/CLI.md
@@ -1,0 +1,131 @@
+# CLI 参考
+
+> Language: 简体中文 | [English](../CLI.md)
+
+本文件面向“想快速查命令怎么用”的场景。更偏工作流的内容见：`WORKFLOWS.md`。
+
+## 全局参数（所有命令都支持）
+
+- `--repo <path>`：指定 config repo 路径（默认 `$AGENTPACK_HOME/repo`）
+- `--profile <name>`：选择 profile（默认 `default`）
+- `--target <codex|claude_code|all>`：选择 target（默认 `all`）
+- `--machine <id>`：覆盖 machineId（用于 machine overlays；默认自动探测）
+- `--json`：stdout 输出机器可读 JSON（envelope）
+- `--yes`：跳过确认（注意：`--json` 下写入类命令必须显式给）
+- `--dry-run`：强制 dry-run（即使传了 `deploy --apply` 或 `overlay rebase` 等也不写入）
+
+提示：
+- `agentpack help --json` 会返回结构化的命令列表与 mutating 命令集合。
+- `agentpack schema --json` 会返回 JSON envelope 与常用命令的 data 字段提示。
+
+## init
+
+`agentpack init`
+- 初始化 config repo skeleton（创建 `agentpack.yaml` 与示例目录）
+- 不会自动 `git init`
+
+## add / remove
+
+- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code]`
+- `agentpack remove <module_id>`
+
+source spec：
+- `local:<path>`（repo 内相对路径）
+- `git:<url>#ref=<ref>&subdir=<path>`
+
+例子：
+- `agentpack add instructions local:modules/instructions/base --id instructions:base --tags base`
+- `agentpack add skill git:https://github.com/your-org/agentpack-modules.git#ref=v1.2.0&subdir=skills/git-review --id skill:git-review --tags work`
+
+## lock / fetch / update
+
+- `agentpack lock`：生成/更新 `agentpack.lock.json`
+- `agentpack fetch`：按 lockfile 拉取外部 sources 到 cache/store
+- `agentpack update`：组合命令
+  - 默认：lockfile 不存在时执行 lock+fetch；存在时默认只 fetch
+  - flags：`--lock`/`--fetch`/`--no-lock`/`--no-fetch`
+
+## preview / plan / diff
+
+- `agentpack plan`：展示将要发生的 create/update/delete（不写入）
+- `agentpack diff`：对当前计划输出 diff
+- `agentpack preview [--diff]`：组合命令（总是 plan；加 `--diff` 时同时 diff）
+
+说明：
+- 计划中 update 可能是两类：
+  - `managed_update`：更新托管文件
+  - `adopt_update`：目标路径存在但非托管，默认拒绝覆盖（见 deploy 的 `--adopt`）
+
+## deploy
+
+`agentpack deploy [--apply] [--adopt]`
+
+- 不带 `--apply`：只展示计划与 diff（相当于“plan + diff”）
+- 带 `--apply`：写入目标目录、生成 snapshot，并写入每个 target root 的 `.agentpack.manifest.json`
+- 若计划包含 `adopt_update`：必须显式给 `--adopt` 才允许覆盖写入（否则报 `E_ADOPT_CONFIRM_REQUIRED`）
+
+常用：
+- `agentpack deploy --apply`
+- `agentpack --json deploy --apply --yes`
+- `agentpack deploy --apply --adopt`
+
+## status
+
+`agentpack status`
+- 基于 `.agentpack.manifest.json` 检测 drift（missing/modified/extra）
+- 若缺少 manifest（首次使用或旧版本迁移），会降级为“desired vs FS”的对比并给 warning
+
+## rollback
+
+`agentpack rollback --to <snapshot_id>`
+- 回滚到某次部署/引导产生的快照
+
+## doctor
+
+`agentpack doctor [--fix]`
+- 检查 machineId、目标目录可写性、常见配置错误
+- `--fix`：在检测到的 git repo 的 `.gitignore` 中追加 `.agentpack.manifest.json`（避免误提交）
+
+## remote / sync
+
+- `agentpack remote set <url> [--name origin]`：配置 config repo 的 git remote
+- `agentpack sync [--rebase] [--remote origin]`：pull/rebase + push 的推荐同步流程
+
+## bootstrap
+
+`agentpack bootstrap [--scope user|project|both]`
+- 安装 operator assets：
+  - Codex：operator skill
+  - Claude Code：`/ap-*` 命令集合
+
+提示：target 选择使用全局 `--target`：
+- `agentpack --target codex bootstrap --scope both`
+
+## overlay
+
+- `agentpack overlay edit <module_id> [--scope global|machine|project] [--sparse|--materialize]`
+- `agentpack overlay rebase <module_id> [--scope ...] [--sparsify]`（3-way merge；支持 `--dry-run`）
+- `agentpack overlay path <module_id> [--scope ...]`
+
+## explain
+
+`agentpack explain plan|diff|status`
+- 解释某个变更/漂移来自哪个 module，来自哪一层 overlay（upstream/global/machine/project）
+
+## record / score
+
+- `agentpack record`：从 stdin 读取 JSON，写入 `state/logs/events.jsonl`
+- `agentpack score`：基于 events 统计模块成功率/失败率（容忍坏行，输出 warnings）
+
+## evolve
+
+- `agentpack evolve propose [--module-id <id>] [--scope global|machine|project] [--branch <name>]`
+  - 捕获 drifted deployed 内容，生成 overlay proposal（创建分支并写文件）
+  - 推荐先 `--dry-run --json` 看候选
+- `agentpack evolve restore [--module-id <id>]`
+  - 恢复 missing 的 desired outputs（create-only；支持 `--dry-run`）
+
+## completions
+
+`agentpack completions <shell>`
+- 生成 shell completion 脚本（bash/zsh/fish/powershell 等）

--- a/docs/zh-CN/CONFIG.md
+++ b/docs/zh-CN/CONFIG.md
@@ -1,0 +1,138 @@
+# 配置文件与模块（agentpack.yaml）
+
+> Language: 简体中文 | [English](../CONFIG.md)
+
+Agentpack 的“单一真源”是 config repo 里的 `agentpack.yaml`。
+
+你也可以手改 YAML，但更推荐用 `agentpack add/remove` 来改（能自动校验、少踩坑）。
+
+## 文件位置
+
+默认：`$AGENTPACK_HOME/repo/agentpack.yaml`（`AGENTPACK_HOME` 默认 `~/.agentpack`）
+
+也可用 `agentpack --repo <path>` 指定。
+
+## 最小示例
+
+```yaml
+version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  codex:
+    mode: files
+    scope: both
+    options:
+      codex_home: "~/.codex"
+      write_repo_skills: true
+      write_user_skills: true
+      write_user_prompts: true
+      write_agents_global: true
+      write_agents_repo_root: true
+  claude_code:
+    mode: files
+    scope: both
+    options:
+      write_repo_commands: true
+      write_user_commands: true
+      write_repo_skills: false
+      write_user_skills: false
+
+modules:
+  - id: instructions:base
+    type: instructions
+    tags: ["base"]
+    source:
+      local_path:
+        path: "modules/instructions/base"
+```
+
+## 字段说明
+
+### version
+
+- 当前支持：`1`
+
+### profiles
+
+Profile 用来从一堆 modules 里筛选“本次要部署哪些”。
+
+字段：
+- `include_tags: [string]`：包含这些 tags 的模块
+- `include_modules: [module_id]`：显式包含模块
+- `exclude_modules: [module_id]`：显式排除模块
+
+建议：
+- 至少有一个 `default` profile（必需）
+
+### targets
+
+目前内置 targets：
+- `codex`
+- `claude_code`
+
+每个 target 的字段：
+- `mode`: 目前只有 `files`
+- `scope`: `user|project|both`
+- `options`: target-specific 的 key/value（YAML 任意值）
+
+注意：
+- `scope` 会影响哪些 roots 会被写入（例如 user 目录 / project 目录）。
+
+### modules
+
+每个 module 的字段：
+- `id: string`：全局唯一，建议 `type:name`（例如 `skill:git-review`）
+- `type: instructions|skill|prompt|command`
+- `enabled: bool`：默认 true
+- `tags: [string]`：用于 profiles
+- `targets: [string]`：限制仅对某些 target 生效；空数组 = all
+- `source`: 见下
+- `metadata: {k: v}`：可选（纯透传，便于写注释/描述）
+
+#### source（两种）
+
+1) local_path
+
+```yaml
+source:
+  local_path:
+    path: "modules/instructions/base"
+```
+
+约定：
+- 建议使用 repo 内相对路径。
+
+2) git
+
+```yaml
+source:
+  git:
+    url: "https://github.com/your-org/agentpack-modules.git"
+    ref: "v1.2.0"      # tag/branch/commit；默认 main
+    subdir: "skills/git-review"   # 可空
+    shallow: true       # 默认 true
+```
+
+说明：
+- git sources 会被 lock 到具体 commit（写进 `agentpack.lock.json`），确保可复现。
+
+## module 类型约束（重要）
+
+Agentpack 会在渲染前验证每个 module 的结构：
+
+- `instructions`：必须包含 `AGENTS.md`
+- `skill`：必须包含 `SKILL.md`
+- `prompt`：必须“最终只有一个 `.md` 文件”
+- `command`：必须“最终只有一个 `.md` 文件”，且必须包含 YAML frontmatter：
+  - 必需字段：`description`
+  - 若正文里使用 `!bash`/`!\`bash\``：frontmatter 必须包含 `allowed-tools` 并允许 `Bash(...)`
+
+提示：prompt/command 的 source 可以是单文件，也可以是一个目录；但 materialize 后必须只剩 1 个文件。
+
+更多：
+- targets 具体写入规则见 `TARGETS.md`
+- overlays 与 source 合成规则见 `OVERLAYS.md`

--- a/docs/zh-CN/EVOLVE.md
+++ b/docs/zh-CN/EVOLVE.md
@@ -1,0 +1,105 @@
+# Evolve（自进化闭环）
+
+> Language: 简体中文 | [English](../EVOLVE.md)
+
+Evolve 的定位不是“自动修改你的系统”，而是把变化变成 **可 review、可回滚、可同步** 的改动：
+- 变化发生在目标目录（例如你手工改了 `~/.claude/commands/ap-plan.md`）
+- agentpack 负责把这类 drift 捕获为 overlays（在 config repo 创建分支），让你像 code review 一样审查与合并
+
+相关命令：
+- `agentpack record` / `agentpack score`
+- `agentpack explain plan|diff|status`
+- `agentpack evolve propose` / `agentpack evolve restore`
+
+## 1) record / score（观测）
+
+### record
+
+`agentpack record` 会从 stdin 读取一段 JSON，并追加写入 `state/logs/events.jsonl`。
+
+用法示例：
+- `echo '{"module_id":"command:ap-plan","success":true}' | agentpack record`
+
+约定：
+- 顶层可以有 `module_id`/`success`，也可以放在内部 event 结构里。
+- score 会容忍坏行（例如 JSON 截断），跳过并输出 warnings。
+
+### score
+
+`agentpack score` 基于 events.jsonl 做简单统计（例如失败率），用于：
+- 找到“经常失败/需要修”的模块
+- 作为 evolve 的优先级信号（未来可扩展）
+
+## 2) explain（解释）
+
+`agentpack explain plan|diff|status` 会解释：
+- 某个输出文件来自哪个 module_id
+- 来自哪一层 source（upstream/global/machine/project overlay）
+
+这对排查“为什么是这个版本生效”很关键。
+
+## 3) evolve propose（把 drift 变成 overlays）
+
+命令：
+- `agentpack evolve propose [--module-id <id>] [--scope global|machine|project] [--branch <name>]`
+
+推荐流程：
+1) 先看候选（不写入）：
+- `agentpack evolve propose --dry-run --json`
+
+2) 再创建提案分支：
+- `agentpack evolve propose --scope global`
+
+行为与限制：
+- 这是写入类命令：`--json` 下必须 `--yes`。
+- 会要求 config repo 是 git 仓库，并且工作区必须干净（否则拒绝）。
+- 会创建分支（默认 `evolve/propose-<timestamp>`），把 drifted 文件写入对应 overlay 路径，然后 `git add -A` 并尝试 commit。
+  - commit 失败（例如缺 git identity）时不会丢改动：分支与变更会保留。
+
+### 哪些 drift 会被 propose？
+
+默认是保守策略：只对“能安全映射回 source 的改动”自动提案。
+
+1) **单模块输出**（推荐）：
+- 某个输出文件的 `module_ids.len() == 1`
+- 文件存在且内容不同（modified）
+
+2) **聚合输出（Codex 的 AGENTS.md）**：
+- 当多个 instructions 模块合成一个 `AGENTS.md` 时，agentpack 会在每个模块段落外包 marker：
+
+```md
+<!-- agentpack:module=instructions:one -->
+...content...
+<!-- /agentpack -->
+```
+
+- 若 deployed 与 desired 都包含 marker，evolve propose 可以逐模块对比段落差异，并把变更写回对应 instructions 模块的 overlay。
+
+以下情况会被跳过（会在 `skipped` 里给 reason）：
+- `missing`：文件不存在（见 evolve restore）
+- `multi_module_output`：无法安全定位到单个模块
+- `read_error`：文件读失败
+
+## 4) evolve restore（恢复 missing 文件，create-only）
+
+命令：
+- `agentpack evolve restore [--module-id <id>]`
+
+用途：
+- 当某些托管文件被删除（missing），你只想把它们“创建回来”，不想更新/删除其他东西。
+
+特性：
+- create-only：只创建缺失文件
+- 不更新已有文件
+- 不删除任何文件
+
+推荐：
+- 先 `--dry-run --json` 看将要恢复哪些路径，再决定执行。
+
+## 5) 与 overlays 的关系
+
+- evolve propose 写入的内容本质就是 overlays。
+- 你最终应该把它们通过 review 合入 config repo，然后 `deploy --apply` 让系统回到“期望态”。
+
+如果你想手工做同样的事：
+- 可以直接 `agentpack overlay edit --sparse <module_id>` 然后自己把 drift copy 进去。

--- a/docs/zh-CN/OVERLAYS.md
+++ b/docs/zh-CN/OVERLAYS.md
@@ -1,0 +1,86 @@
+# Overlays（覆盖层）
+
+> Language: 简体中文 | [English](../OVERLAYS.md)
+
+Overlays 的目的：让你在不 fork 上游模块的情况下做本地定制，并且能在上游更新时尽量“可合并、可回滚、可 review”。
+
+## 1) 覆盖层级与优先级
+
+同一个模块的最终内容由 4 层组成（低 → 高）：
+1) upstream（local_path 或 git checkout）
+2) global overlay
+3) machine overlay
+4) project overlay
+
+同路径文件的合成策略：高优先级文件覆盖低优先级文件。
+
+## 2) 磁盘布局
+
+Config repo 内：
+- global: `repo/overlays/<module_fs_key>/...`
+- machine: `repo/overlays/machines/<machine_id>/<module_fs_key>/...`
+- project: `repo/projects/<project_id>/overlays/<module_fs_key>/...`
+
+说明：
+- `module_fs_key` 是从 `module_id` 派生的文件系统安全目录名（会 sanitize，并附带短 hash；前缀长度有上限，避免超长路径）。
+- CLI 与 manifest 仍然用 `module_id`；`module_fs_key` 仅用于磁盘寻址。
+- 为兼容历史目录命名，agentpack 会在读取 overlay 时尝试 legacy 目录（存在则使用）。
+
+## 3) overlay 元数据（.agentpack）
+
+每个 overlay 目录内都会有：
+- `.agentpack/baseline.json`：记录创建 overlay 时的 upstream 指纹，用于 drift 警告与 3-way merge。
+- `.agentpack/module_id`：记录原始 module_id（便于审计与诊断）。
+
+规则：
+- `.agentpack/` 为保留目录，不参与部署（不会写到 target roots）。
+
+## 4) 创建与编辑：overlay edit
+
+命令：
+- `agentpack overlay edit <module_id> [--scope global|machine|project] [--sparse|--materialize]`
+
+行为：
+- 默认（不加 `--sparse/--materialize`）：
+  - 若 overlay 不存在，会复制 upstream 模块的完整文件树到 overlay，然后打开 `$EDITOR`（如果设置了）。
+- `--sparse`：
+  - 创建“稀疏 overlay”：只创建 `.agentpack` 元数据目录，不复制上游文件。
+  - 推荐做法：在 overlay 内只放你修改过的文件（差异最小，未来合并更轻松）。
+- `--materialize`：
+  - 以 missing-only 的方式把 upstream 文件补齐到 overlay（不覆盖已有 overlay edits）。
+  - 适合“我想浏览/参考上游实现，但不想把整棵树都纳入 overlay diff”。
+
+提示：
+- `overlay edit` 是写入类命令；`--json` 模式下需要 `--yes`。
+
+## 5) 上游更新后的合并：overlay rebase（3-way merge）
+
+命令：
+- `agentpack overlay rebase <module_id> [--scope ...] [--sparsify]`
+
+用途：
+- 上游模块更新后，把 overlay 的改动在新的 upstream 上“重新应用”，尽量自动解决简单冲突。
+
+行为要点：
+- 读取 `.agentpack/baseline.json` 作为 merge base，对 overlay 中的文件做 3-way merge。
+- 对“复制进 overlay 但你其实没改”的文件（ours == base），会更新到最新 upstream，避免无意 pin 老版本。
+- `--sparsify`：删除 rebase 后与 upstream 完全一致的 overlay 文件，让 overlay 尽量保持稀疏。
+- 支持 `--dry-run`：只输出会发生什么，不写入。
+
+冲突：
+- 如果产生冲突，命令会失败并返回 `E_OVERLAY_REBASE_CONFLICT`，details 里包含冲突文件列表。
+- 解决方式：打开冲突文件手工处理后，再跑一次 `overlay rebase`（或直接手工提交 overlay）。
+
+## 6) overlay path
+
+命令：
+- `agentpack overlay path <module_id> [--scope ...]`
+
+用途：
+- 打印 overlay 目录路径（human）或在 JSON 输出里提供 `data.overlay_dir`（便于脚本/agent 直接打开）。
+
+## 7) 常见建议
+
+- 优先使用 `--sparse`：减少 overlay 体积与未来合并成本。
+- 只在需要浏览时再 `--materialize`。
+- 上游更新后：先 `agentpack update`，再 `agentpack overlay rebase ...`，最后 `preview --diff` 看变化。

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -1,0 +1,139 @@
+# 快速开始（v0.5.0）
+
+> Language: 简体中文 | [English](../QUICKSTART.md)
+
+本指南的目标：从 0 到第一次成功部署（deploy），并理解最核心的安全边界（不误删、不误覆盖）。
+
+## 0) 安装
+
+- Rust 用户：
+  - `cargo install agentpack --locked`
+- 非 Rust 用户：
+  - 从 GitHub Releases 下载对应平台二进制（见仓库 README）。
+
+验证：
+- `agentpack help`
+
+## 1) 初始化你的配置仓库（config repo）
+
+Agentpack 默认在 `~/.agentpack/repo` 创建/读取配置仓库（可用 `AGENTPACK_HOME` 或 `--repo` 改位置）。
+
+1. 初始化 skeleton：
+- `agentpack init`
+
+会生成：
+- `agentpack.yaml`（清单）
+- `modules/`（示例模块目录：instructions/prompts/claude-commands）
+
+建议你把它变成一个真正的 git repo（agentpack **不会**自动 `git init`）：
+- `cd ~/.agentpack/repo && git init && git add . && git commit -m "init agentpack"`
+
+可选：配置远端并同步（多机器）：
+- `agentpack remote set <your_git_url>`
+- `agentpack sync --rebase`
+
+## 2) 配置 targets（Codex / Claude Code）
+
+`agentpack init` 会写入一份可用的 targets 默认配置。你通常只需要按需调整 options。
+
+常见最小建议：
+- Codex：写 user skills、repo skills、global/repo AGENTS.md、user prompts（prompts 只支持 user scope）
+- Claude Code：写 repo commands + user commands（skills 默认先关闭，按需开启）
+
+先跑一次自检：
+- `agentpack doctor`
+
+如果你看到权限/目录不存在的告警，按提示创建目录或修正 `agentpack.yaml` 里的路径选项。
+
+## 3) 添加模块（modules）
+
+模块写在 `agentpack.yaml -> modules:` 里。你可以用命令添加（推荐，少踩坑）：
+
+- 添加一份 instructions（目录模块）：
+  - `agentpack add instructions local:modules/instructions/base --id instructions:base --tags base`
+
+- 添加一个 Codex prompt（单文件模块）：
+  - `agentpack add prompt local:modules/prompts/draftpr.md --id prompt:draftpr --tags base`
+
+- 添加一个 Claude slash command（单文件模块）：
+  - `agentpack add command local:modules/claude-commands/ap-plan.md --id command:ap-plan --tags base --targets claude_code`
+
+你也可以添加 git 模块（锁到 commit，可复现）：
+- `agentpack add skill git:https://github.com/your-org/agentpack-modules.git#ref=v1.2.0&subdir=skills/git-review --id skill:git-review --tags work`
+
+## 4) 锁版本并拉取依赖（update）
+
+推荐用组合命令：
+- `agentpack update`
+
+行为：
+- 若 `agentpack.lock.json` 不存在：会先 lock 再 fetch
+- 若已存在：默认只 fetch
+
+## 5) 预览（preview）
+
+先看会发生什么：
+- `agentpack preview --diff`
+
+常见你会看到：
+- 将要写入哪些 target
+- 哪些文件 create/update/delete
+- diff（如果加了 `--diff`）
+
+提示：如果你只想看某个 profile 或 target：
+- `agentpack --profile work preview --diff`
+- `agentpack --target codex preview --diff`
+
+## 6) 部署（deploy）
+
+执行写入需要 `--apply`：
+- `agentpack deploy --apply`
+
+安全边界：
+- 删除只会删除“托管文件”（见每个 target root 的 `.agentpack.manifest.json`），不会删用户非托管文件。
+- 覆盖保护：如果目标路径存在但**不属于托管文件**，会被标记为 `adopt_update`，默认拒绝覆盖。
+
+如果你确认要“接管并覆盖”这类文件：
+- `agentpack deploy --apply --adopt`
+
+如果你在自动化里用 `--json`：
+- 所有写入类命令都需要显式 `--yes`
+  - `agentpack --json deploy --apply --yes`
+  - 若存在 adopt_update，还需要 `--adopt`
+
+## 7) 漂移检查（status）与回滚（rollback）
+
+- 查看漂移：
+  - `agentpack status`
+
+- 回滚到某次部署快照：
+  - `agentpack rollback --to <snapshot_id>`
+
+快照 id 会在 `deploy --apply` 成功后输出（JSON 里在 `data.snapshot_id`）。
+
+## 8) 改动沉淀：overlays
+
+当你想基于上游模块做本地改动（并希望未来还能合并上游更新），用 overlays：
+
+- 创建并编辑 overlay（默认 global scope）：
+  - `agentpack overlay edit <module_id>`
+
+- 更推荐的做法：创建稀疏 overlay（不复制整棵上游树，只放改动文件）：
+  - `agentpack overlay edit <module_id> --sparse`
+
+- 需要浏览上游文件时再补齐（missing-only，不覆盖已改文件）：
+  - `agentpack overlay edit <module_id> --materialize`
+
+- 上游更新后，把 overlay 3-way merge 到最新上游：
+  - `agentpack overlay rebase <module_id> --sparsify`
+
+## 9) AI-first 自举（bootstrap）
+
+让 AI 自己会用 agentpack（推荐完成一次）：
+- `agentpack bootstrap --scope both`
+
+它会安装：
+- Codex：一个 operator skill（教 Codex 调 agentpack CLI，优先用 `--json`）
+- Claude Code：一组 `/ap-*` slash commands（计划/部署/状态/提案等）
+
+更多见：`BOOTSTRAP.md`。

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,0 +1,68 @@
+# Agentpack Docs
+
+> Language: 简体中文 | [English](../README.md)
+
+这份文档集面向两类读者：
+- **用户（会用就行）**：照着做能完成安装、配置、预览、部署、回滚，并把改动沉淀为 overlays。
+- **贡献者（要改代码/加 target）**：需要理解引擎、数据模型、`--json` 契约、conformance 测试。
+
+英文文档（`docs/`）为权威版本；简体中文用户文档位于 `docs/zh-CN/`，可能会有少量滞后。
+
+如果你只想“现在就用起来”，从《快速开始》开始。
+
+## 用户文档（推荐阅读顺序）
+
+1) **快速开始**：`QUICKSTART.md`
+- 30 分钟从 0 到第一次 deploy
+
+2) **日常工作流**：`WORKFLOWS.md`
+- 更新依赖（update）→ 预览（preview）→ 应用（deploy --apply）
+- 漂移（status）→ 提案（evolve propose）→ review → 合入
+
+3) **CLI 命令参考**：`CLI.md`
+- 全局参数、每个命令的用途/关键 flag/示例
+
+4) **配置文件与模块**：`CONFIG.md`
+- `agentpack.yaml`（profiles/targets/modules）与 source spec（local/git）
+
+5) **Targets（Codex / Claude Code）**：`TARGETS.md`
+- 写入位置、options、限制（尤其是 prompts 仅 user scope）
+
+6) **Overlays**：`OVERLAYS.md`
+- global/machine/project 三层 overlay
+- `overlay edit --sparse/--materialize` 与 `overlay rebase`（3-way merge）
+
+7) **AI 自举（Bootstrap）**：`BOOTSTRAP.md`
+- 安装 operator assets：让 AI 自己会用 agentpack
+
+8) **Evolve（自进化闭环）**：`EVOLVE.md`
+- record/score/explain/propose/restore
+
+9) **排障**：`TROUBLESHOOTING.md`
+- 常见错误码、冲突、权限、Windows 路径问题等
+
+## 参考/契约（给自动化与贡献者）
+
+- **SPEC（实现对齐的唯一权威）**：`SPEC.md`
+- **JSON 输出契约**：`JSON_API.md`
+- **稳定错误码注册表**：`ERROR_CODES.md`
+- **架构总览**：`ARCHITECTURE.md`
+- **Target SDK（如何加新 target）**：`TARGET_SDK.md`
+- **Target conformance**：`TARGET_CONFORMANCE.md`
+
+## 维护者/工程化
+
+- 发布流程：`RELEASING.md`
+- 依赖与安全检查：`SECURITY_CHECKS.md`
+- 产品文档（历史背景/规划）：`PRD.md`、`BACKLOG.md`
+- 可执行工作单（给 Codex CLI 直接干活）：`CODEX_WORKPLAN.md`
+
+## 外部参考（上游工具的官方文档）
+
+- AGENTS.md（规范/示例）：https://agents.md/
+- Codex：
+  - AGENTS.md 指令发现：https://developers.openai.com/codex/guides/agents-md/
+  - Skills：https://developers.openai.com/codex/skills/
+  - Custom Prompts：https://developers.openai.com/codex/custom-prompts/
+- Claude Code：
+  - Slash commands：https://code.claude.com/docs/en/slash-commands

--- a/docs/zh-CN/TARGETS.md
+++ b/docs/zh-CN/TARGETS.md
@@ -1,0 +1,102 @@
+# Targets（codex / claude_code）
+
+> Language: 简体中文 | [English](../TARGETS.md)
+
+Target 决定 agentpack 要把“编译后的资产”写到哪里，以及哪些目录需要写 `.agentpack.manifest.json` 来实现安全删除和漂移检测。
+
+目前内置 targets：
+- `codex`
+- `claude_code`
+
+Target 的通用字段见 `CONFIG.md`。
+
+## 1) codex
+
+### 写入位置（roots）
+
+由 `targets.codex.scope` 和 `targets.codex.options.*` 决定，可能包含：
+- `~/.codex`（global instructions：`AGENTS.md`）
+- `~/.codex/skills`（user skills）
+- `~/.codex/prompts`（custom prompts；只支持 user scope）
+- `<project_root>/AGENTS.md`（project instructions）
+- `<project_root>/.codex/skills`（repo skills）
+
+说明：
+- `project_root` 来自当前工作目录的 project 识别（通常是 git repo root）。
+- 每个 root 都会写入（或更新）`.agentpack.manifest.json`，用于安全删除与 drift。
+
+### module → 输出映射
+
+- `instructions`
+  - 收集每个 instructions module 的 `AGENTS.md` 内容
+  - 多个模块时会合成一个 `AGENTS.md`：用 per-module section markers 标记来源，以支持 `evolve propose` 对聚合文件回溯
+
+- `skill`
+  - 复制 module 目录下所有文件到：
+    - `~/.codex/skills/<skill_name>/...`（如启用 user skills）
+    - `<project_root>/.codex/skills/<skill_name>/...`（如启用 repo skills）
+  - `<skill_name>` 默认从 module id 推导（`skill:<name>`），否则会做一次安全规整
+
+- `prompt`
+  - 复制单个 `.md` 文件到 `~/.codex/prompts/<filename>.md`
+
+### 常用 options
+
+- `codex_home`：默认 `"~/.codex"`
+- `write_repo_skills`：默认 true（需要 project scope 允许）
+- `write_user_skills`：默认 true（需要 user scope 允许）
+- `write_user_prompts`：默认 true（需要 user scope 允许）
+- `write_agents_global`：默认 true（需要 user scope 允许）
+- `write_agents_repo_root`：默认 true（需要 project scope 允许）
+
+### 限制与建议
+
+- agentpack 默认使用 copy/render，不依赖 symlink（目标是让 Codex 稳定发现）。
+- prompts 按 Codex 语义只写 user scope（`~/.codex/prompts`）。如果你想共享“可复用能力”，更推荐写成 skill。
+
+## 2) claude_code
+
+### 写入位置（roots）
+
+- `~/.claude/commands`（user commands；默认启用）
+- `<project_root>/.claude/commands`（repo commands；默认启用）
+
+### module → 输出映射
+
+- `command`
+  - 复制单个 `.md` 文件到 commands 目录
+  - 文件名就是 slash command 名（例如 `ap-plan.md` → `/ap-plan`）
+
+### frontmatter 约束（很重要）
+
+Claude Code 的自定义命令文件需要 YAML frontmatter。
+
+最小示例：
+
+```md
+---
+description: Plan changes with agentpack
+allowed-tools:
+  - Bash(agentpack*)
+  - Bash(git status)
+---
+
+# /ap-plan
+...
+```
+
+规则：
+- 必须有 `description`
+- 如果正文包含 `!bash` 或 `!\`bash\``：必须声明 `allowed-tools` 且允许 `Bash(...)`
+
+## 3) scan_extras（extra 文件的处理）
+
+某些 roots 会启用 `scan_extras`：
+- `true`：status 会报告“目录中存在但不在托管清单里”的 extra 文件（不会自动删除）
+- `false`：不扫描 extra（例如 global `~/.codex` 根目录通常不做全量扫描）
+
+## 4) 想加新 target？
+
+看：
+- `TARGET_SDK.md`
+- `TARGET_CONFORMANCE.md`

--- a/docs/zh-CN/TROUBLESHOOTING.md
+++ b/docs/zh-CN/TROUBLESHOOTING.md
@@ -1,0 +1,126 @@
+# 排障（Troubleshooting）
+
+> Language: 简体中文 | [English](../TROUBLESHOOTING.md)
+
+这份文档按“症状 → 原因 → 解决”组织，并尽量用稳定错误码来定位问题。
+
+如果你使用 `--json`，请优先看：
+- `errors[0].code`
+- `errors[0].details`（如果有）
+
+错误码全集见：`ERROR_CODES.md`。
+
+## 1) E_CONFIRM_REQUIRED
+
+症状：
+- `--json` 模式下执行写入类命令失败
+- 错误码：`E_CONFIRM_REQUIRED`
+
+原因：
+- agentpack 把 `--json` 输出当作机器 API，为了避免脚本/LLM“误写入”，对写入类命令必须显式 `--yes`。
+
+解决：
+- 确认你确实想执行写入，然后重试并加 `--yes`：
+  - `agentpack --json deploy --apply --yes`
+  - `agentpack --json update --yes`
+  - `agentpack --json bootstrap --yes`
+
+## 2) E_ADOPT_CONFIRM_REQUIRED
+
+症状：
+- `deploy --apply` 被拒绝覆盖某些文件
+- 错误码：`E_ADOPT_CONFIRM_REQUIRED`
+
+原因：
+- 这些更新是 `adopt_update`：目标路径已有文件，但它不在 agentpack 的托管清单里（非托管）。默认不会无感覆盖。
+
+解决：
+1) 先预览并确认影响范围：
+- `agentpack preview --diff`
+
+2) 如果确认要接管覆盖：
+- `agentpack deploy --apply --adopt`
+
+提示：
+- `errors[0].details.sample_paths` 通常会给出部分路径样例。
+
+## 3) E_DESIRED_STATE_CONFLICT
+
+症状：
+- `plan/preview/deploy` 报“conflicting desired outputs...`
+- 错误码：`E_DESIRED_STATE_CONFLICT`
+
+原因：
+- 多个模块对同一 `(target, path)` 产出了不同内容。agentpack 拒绝静默覆盖。
+
+解决：
+- 调整 manifest：让该路径只由一个模块负责；或让冲突路径内容一致。
+- 如果是 overlays 引起的，优先检查 overlay 中是否有同名文件覆盖了其他模块输出。
+
+## 4) E_CONFIG_MISSING / E_CONFIG_INVALID / E_CONFIG_UNSUPPORTED_VERSION
+
+症状：
+- 找不到或解析不了 `agentpack.yaml`
+
+解决：
+- `E_CONFIG_MISSING`：运行 `agentpack init` 或用 `--repo` 指定正确 repo
+- `E_CONFIG_INVALID`：按 `details.error` 修复 YAML；注意必须存在 `profiles.default`
+- `E_CONFIG_UNSUPPORTED_VERSION`：将 manifest `version` 调整为支持值（当前 1）或升级工具
+
+## 5) E_LOCKFILE_MISSING / E_LOCKFILE_INVALID
+
+症状：
+- fetch 或需要 git 模块时提示缺少/损坏 lockfile
+
+解决：
+- 生成：`agentpack lock` 或 `agentpack update`
+- 如果 lockfile 损坏：删除 `agentpack.lock.json` 后重新 `agentpack update`
+
+## 6) E_TARGET_UNSUPPORTED
+
+症状：
+- `--target` 传了不支持值，或 manifest 里 targets 配了未知 target
+
+解决：
+- `--target` 只能是 `all|codex|claude_code`
+- manifest targets 只能包含 `codex` 与 `claude_code`
+
+## 7) Overlay 相关
+
+### E_OVERLAY_NOT_FOUND
+- 先 `agentpack overlay edit <module_id>` 创建 overlay
+
+### E_OVERLAY_BASELINE_MISSING
+- overlay 元数据缺失，通常是手工创建目录导致
+- 解决：重新运行 `agentpack overlay edit <module_id>` 让它补齐 `.agentpack/baseline.json`
+
+### E_OVERLAY_BASELINE_UNSUPPORTED
+- baseline 无法定位 merge base（例如历史版本 baseline 信息不足）
+- 解决：重新创建 overlay（新 baseline），或把 upstream 变成可追溯（git）再创建 overlay
+
+### E_OVERLAY_REBASE_CONFLICT
+- 发生 3-way merge 冲突
+- 解决：打开冲突文件手工处理后再 rebase，或直接手动 commit overlay
+
+## 8) evolve propose 失败：dirty working tree
+
+症状：
+- `evolve propose` 提示 working tree dirty / refusing to propose...
+
+原因：
+- propose 会创建分支并写入 overlay 文件，要求 config repo 干净，避免把不相关改动混进去。
+
+解决：
+- 先 `git status`，把未提交改动 commit 或 stash
+- 再重试 `agentpack evolve propose ...`
+
+## 9) Windows 路径问题
+
+症状：
+- module id 里有 `:`，创建 overlay 目录失败
+
+说明：
+- agentpack 使用 `module_fs_key`（sanitize + hash）作为目录名，已避免 Windows 的非法字符。
+- 如果你从历史版本迁移而来，旧目录名可能不兼容。建议：
+  - 用 `agentpack overlay path <module_id>` 找到当前生效目录
+  - 只保留一个目录命名（避免 legacy + canonical 并存引发困惑）

--- a/docs/zh-CN/WORKFLOWS.md
+++ b/docs/zh-CN/WORKFLOWS.md
@@ -1,0 +1,112 @@
+# 日常工作流
+
+> Language: 简体中文 | [English](../WORKFLOWS.md)
+
+这份文档给你一套“每天都能用”的固定套路。你可以把它当作最佳实践，也可以直接交给 Codex/Claude 让它按流程执行。
+
+## 1) 最常用：更新 → 预览 → 应用
+
+1. 更新依赖（锁文件缺失时会自动 lock）：
+- `agentpack update`
+
+2. 预览（建议总是带 diff）：
+- `agentpack preview --diff`
+
+3. 应用：
+- `agentpack deploy --apply`
+
+常用变体：
+- 只对某个 profile：`agentpack --profile work update && agentpack --profile work preview --diff && agentpack --profile work deploy --apply`
+- 只对某个 target：`agentpack --target codex preview --diff`
+
+## 2) 多机器同步（把 config repo 当单一真源）
+
+建议策略：配置 repo 走 git，同步时使用 rebase。
+
+1. 设置 remote：
+- `agentpack remote set <url>`
+
+2. 同步：
+- `agentpack sync --rebase`
+
+冲突处理：
+- agentpack 不会自动解决 merge 冲突。遇到冲突会失败并提示你用 git 手动解决。
+
+## 3) 覆盖保护（adopt_update）与安全接管
+
+当计划里出现 `adopt_update`：
+- 代表目标路径已有文件，但它不在托管范围内（不是由 agentpack 之前写入/管理）。
+- 默认 `deploy --apply` 会拒绝覆盖。
+
+如果确认要接管（覆盖并纳入托管）：
+- `agentpack deploy --apply --adopt`
+
+推荐做法：
+- 先 `agentpack preview --diff` 看清楚影响范围。
+- 能用 overlays 解决的尽量用 overlays，避免覆盖用户手工文件。
+
+## 4) 用 overlays 做本地定制（建议优先 sparse overlay）
+
+典型场景：你加了一个上游 skill/command，但想加两句自己的说明或改默认行为。
+
+1. 创建稀疏 overlay：
+- `agentpack overlay edit <module_id> --sparse`
+
+2. 在 overlay 目录里只放你改动的文件（保持最小差异）。
+
+3. 重新 preview / deploy：
+- `agentpack preview --diff`
+- `agentpack deploy --apply`
+
+上游更新后（你跑了 `update` 拉到新 commit）：
+- `agentpack overlay rebase <module_id> --sparsify`
+
+如果 rebase 发生冲突：
+- 会返回 `E_OVERLAY_REBASE_CONFLICT`，并列出冲突文件。
+- 打开 overlay 目录里带冲突标记的文件，手动解决后再跑一次 rebase 或直接 commit。
+
+## 5) 漂移（status）→ 提案（evolve propose）→ review → 合入
+
+目标：把“线上（目标目录）里的改动”回流到 config repo，变成可 review 的 overlay 改动。
+
+1. 检查漂移：
+- `agentpack status`
+
+2. 生成提案（建议先 dry-run 看候选）：
+- `agentpack evolve propose --dry-run --json`
+
+3. 确认没问题后创建提案分支（会在 config repo 创建 branch 并写入 overlay 文件）：
+- `agentpack evolve propose --scope global`
+
+4. 进入 config repo review：
+- `cd ~/.agentpack/repo && git status && git diff`
+- 提交、开 PR（如果你用远端）或本地合入。
+
+5. 最后重新部署，使目标目录与期望态一致：
+- `agentpack deploy --apply`
+
+说明：
+- 默认只会对“能安全映射回单个模块”的 drift 生成 proposal。
+- 对聚合输出（例如 Codex 的 `AGENTS.md`）如果包含模块分段 marker，agentpack 可以把 drift 映射回具体 instructions 模块片段。
+
+## 6) 恢复缺失文件（evolve restore）
+
+当 status 显示一些托管文件被删了（missing），你只想“把缺失的创建回来”，不想更新/删除其他东西：
+
+- 预览：`agentpack evolve restore --dry-run --json`
+- 应用：`agentpack evolve restore`
+
+特性：
+- create-only：只创建缺失文件，不更新已存在文件，不删除任何文件。
+
+## 7) 自动化/Agent 调用建议（--json）
+
+如果你把 agentpack 当作可编排组件（例如让 Codex CLI 调用）：
+- 读取 `--json` 输出做下一步决策。
+- 遇到 `E_CONFIRM_REQUIRED`：必须在确认写入意图后加 `--yes` 重试。
+- 遇到 `E_ADOPT_CONFIRM_REQUIRED`：必须明确加 `--adopt` 才能覆盖非托管文件。
+
+推荐模式：
+- 只要是写入类命令（deploy --apply / update / lock / fetch / bootstrap / evolve propose/restore / overlay edit/rebase / rollback 等），自动化里总是显式加 `--yes`，并在执行前先 `preview`。
+
+更多：`JSON_API.md`、`ERROR_CODES.md`。


### PR DESCRIPTION
Summary:
- Make all docs under `docs/` English (canonical) and remove mixed-language content.
- Add Simplified Chinese translations for user-facing docs under `docs/zh-CN/` (mirrors filenames).
- Add `README.zh-CN.md` and language switches in entrypoints.

Entry points:
- `README.md` -> `docs/README.md`
- Chinese user docs: `README.zh-CN.md`, `docs/zh-CN/README.md`

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
