### PR TITLE
docs: add source install fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Agentpack is an AI-first local “asset control plane” for managing and deploy
 cargo install agentpack --locked
 ```
 
+If crates.io install is not available yet, install from source:
+
+```bash
+cargo install --git https://github.com/liqiongyu/agentpack --tag v0.5.0 --locked
+```
+
 ### Prebuilt binaries
 
 GitHub Releases: https://github.com/liqiongyu/agentpack/releases

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,6 +23,12 @@ Agentpack 是一个 AI-first 的本地“资产控制平面（asset control plan
 cargo install agentpack --locked
 ```
 
+如果暂时无法从 crates.io 安装，可以从源码安装：
+
+```bash
+cargo install --git https://github.com/liqiongyu/agentpack --tag v0.5.0 --locked
+```
+
 ### 预编译二进制
 
 GitHub Releases: https://github.com/liqiongyu/agentpack/releases

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -7,7 +7,10 @@ Goal: get from 0 → your first successful deploy, and understand the key safety
 ## 0) Install
 
 - Rust users:
-  - `cargo install agentpack --locked`
+  - From crates.io:
+    - `cargo install agentpack --locked`
+  - If you see `could not find \`agentpack\` in registry \`crates-io\``, install from source:
+    - `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.5.0 --locked`
 - Non-Rust users:
   - Download a prebuilt binary from GitHub Releases (see the repository README).
 

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -7,7 +7,10 @@
 ## 0) 安装
 
 - Rust 用户：
-  - `cargo install agentpack --locked`
+  - 从 crates.io 安装：
+    - `cargo install agentpack --locked`
+  - 如果你遇到 `could not find \`agentpack\` in registry \`crates-io\``，可以从源码安装：
+    - `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.5.0 --locked`
 - 非 Rust 用户：
   - 从 GitHub Releases 下载对应平台二进制（见仓库 README）。
 


### PR DESCRIPTION
Fixes the common Quickstart install failure when `agentpack` is not available in crates.io yet.

- Keep the crates.io install command
- Add a source install fallback (`cargo install --git ... --tag v0.5.0`)
- Update both English and zh-CN Quickstart + README
