### PR TITLE
docs: align drift kind terminology to modified

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -182,7 +182,7 @@ Requirements:
 
 Goals:
 - Safe delete (delete managed files only)
-- Drift/status (`changed` / `missing` / `extra`)
+- Drift/status (`modified` / `missing` / `extra`)
 
 Schema (v1 example):
 
@@ -394,7 +394,7 @@ Notes:
 ### 4.7 `status`
 
 `agentpack status`
-- if the target root contains `.agentpack.manifest.json`: compute drift (`changed` / `missing` / `extra`) based on the manifest
+- if the target root contains `.agentpack.manifest.json`: compute drift (`modified` / `missing` / `extra`) based on the manifest
 - if there is no manifest (first deploy / upgraded from older versions): fall back to comparing desired outputs vs filesystem, and emit a warning
 - if installed operator assets (bootstrap) are missing or outdated: emit a warning and suggest running `agentpack bootstrap`
 

--- a/openspec/specs/agentpack/spec.md
+++ b/openspec/specs/agentpack/spec.md
@@ -20,12 +20,12 @@ Agentpack MUST NOT delete files that are not listed in the target manifest.
 - **THEN** those unmanaged files remain untouched
 
 ### Requirement: Manifest-Based Status
-`agentpack status` MUST compute drift using the target manifest and report managed-file drift as `changed` or `missing`, and unmanaged files as `extra` (non-fatal).
+`agentpack status` MUST compute drift using the target manifest and report managed-file drift as `modified` or `missing`, and unmanaged files as `extra` (non-fatal).
 
 #### Scenario: Status detects drift and extras
 - **GIVEN** a deployed target root with a valid manifest
 - **WHEN** a managed file is modified, and an unmanaged file is added
-- **THEN** `agentpack status` reports `changed` for the managed file and `extra` for the unmanaged file
+- **THEN** `agentpack status` reports `modified` for the managed file and `extra` for the unmanaged file
 
 ### Requirement: Multi-Machine Sync
 Agentpack MUST provide `remote set` and `sync` commands to standardize recommended git workflows for the agentpack config repo.


### PR DESCRIPTION
Closes #136

Intent: Remove drift-kind naming ambiguity by aligning docs/SPEC.md and OpenSpec core spec to the JSON contract (kind = missing|modified|extra).

Acceptance criteria:
- docs/SPEC.md uses modified/missing/extra terminology
- openspec/specs/agentpack/spec.md uses modified/missing/extra terminology
- openspec validate --all --strict --no-interactive passes

Verification:
- openspec validate --all --strict --no-interactive
- cargo test --all --locked