### PR TITLE
docs: document help --json and schema commands

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -487,6 +487,21 @@ Notes:
 - In `--json` mode, if it writes, it requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
 - Supports `--dry-run`: prints the file list only; does not write.
 
+### 4.16 `help` / `schema` (utility commands)
+
+`agentpack help`
+- prints CLI help/usage
+- `agentpack help --json` emits machine-consumable command metadata (see: `JSON_API.md`), including at minimum:
+  - `data.commands[]` (command catalog)
+  - `data.mutating_commands[]` (command IDs that require `--yes` in `--json` mode)
+  - `data.global_args[]` (global flags)
+
+`agentpack schema`
+- prints a brief JSON schema summary (human mode)
+- `agentpack schema --json` documents:
+  - `data.envelope` (the `schema_version=1` envelope fields/types)
+  - `data.commands` (minimum expected `data` fields for key read commands)
+
 ## 5. Target adapter details
 
 ### 5.1 `codex` target


### PR DESCRIPTION
Closes #137

Intent: Make docs/SPEC.md explicitly cover the help --json and schema commands (minimal contract), with full shape described in docs/JSON_API.md.

Acceptance criteria:
- docs/SPEC.md has a utility section for help/schema
- No behavior changes

Verification:
- cargo test --all --locked