### PR TITLE
docs: note E_UNEXPECTED fallback code

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -40,6 +40,8 @@ When `--json` is enabled, common actionable failures must return stable error co
 
 See: `ERROR_CODES.md`.
 
+Note: In `--json` mode, unclassified/unexpected failures use the non-stable fallback code `E_UNEXPECTED` (see: `JSON_API.md` and `ERROR_CODES.md`).
+
 ## 1. Core concepts and data model
 
 ### 1.1 Module


### PR DESCRIPTION
Closes #138

Intent: Reduce confusion by explicitly noting the non-stable E_UNEXPECTED fallback in docs/SPEC.md without adding it to the stable error list.

Acceptance criteria:
- docs/SPEC.md mentions E_UNEXPECTED as non-stable fallback and points to JSON_API.md / ERROR_CODES.md

Verification:
- cargo test --all --locked