### PR TITLE
test: add golden snapshots for help/schema --json

### DIFF
--- a/tests/cli_json_golden.rs
+++ b/tests/cli_json_golden.rs
@@ -1,0 +1,96 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut items: Vec<(String, serde_json::Value)> = map.into_iter().collect();
+            items.sort_by(|a, b| a.0.cmp(&b.0));
+
+            let mut out = serde_json::Map::new();
+            for (k, v) in items {
+                out.insert(k, canonicalize_json(v));
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(canonicalize_json).collect::<Vec<_>>())
+        }
+        other => other,
+    }
+}
+
+fn pretty_json(value: serde_json::Value) -> String {
+    let canonical = canonicalize_json(value);
+    let mut out = serde_json::to_string_pretty(&canonical).expect("pretty json");
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn assert_envelope_shape(v: &serde_json::Value, expected_command: &str, ok: bool) {
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["ok"], ok);
+    assert_eq!(v["command"], expected_command);
+
+    assert_eq!(v["version"], env!("CARGO_PKG_VERSION"));
+    assert!(v["data"].is_object());
+    assert!(v["warnings"].is_array());
+    assert!(v["errors"].is_array());
+}
+
+#[test]
+fn help_json_data_matches_golden_snapshot() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = agentpack_in(tmp.path(), &["help", "--json"]);
+    assert!(output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_envelope_shape(&v, "help", true);
+
+    let actual = pretty_json(v["data"].clone());
+    let expected =
+        std::fs::read_to_string("tests/golden/help_json_data.json").expect("read golden");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn schema_json_data_matches_golden_snapshot() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = agentpack_in(tmp.path(), &["schema", "--json"]);
+    assert!(output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_envelope_shape(&v, "schema", true);
+
+    let actual = pretty_json(v["data"].clone());
+    let expected =
+        std::fs::read_to_string("tests/golden/schema_json_data.json").expect("read golden");
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn json_error_envelope_has_required_fields() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output = agentpack_in(tmp.path(), &["init", "--json"]);
+    assert!(!output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_envelope_shape(&v, "init", false);
+    assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+}

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -1,0 +1,576 @@
+{
+  "commands": [
+    {
+      "args": [
+        {
+          "id": "id",
+          "kind": "option",
+          "long": "id",
+          "required": false
+        },
+        {
+          "id": "module_type",
+          "kind": "option",
+          "required": true
+        },
+        {
+          "id": "source",
+          "kind": "option",
+          "required": true
+        },
+        {
+          "id": "tags",
+          "kind": "option",
+          "long": "tags",
+          "required": false
+        },
+        {
+          "id": "targets",
+          "kind": "option",
+          "long": "targets",
+          "required": false
+        }
+      ],
+      "id": "add",
+      "mutating": true,
+      "path": [
+        "add"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "scope",
+          "kind": "option",
+          "long": "scope",
+          "required": false
+        }
+      ],
+      "id": "bootstrap",
+      "mutating": true,
+      "path": [
+        "bootstrap"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "shell",
+          "kind": "option",
+          "required": true
+        }
+      ],
+      "id": "completions",
+      "mutating": false,
+      "path": [
+        "completions"
+      ],
+      "supports_json": false
+    },
+    {
+      "args": [
+        {
+          "id": "adopt",
+          "kind": "flag",
+          "long": "adopt",
+          "required": false
+        },
+        {
+          "id": "apply",
+          "kind": "flag",
+          "long": "apply",
+          "required": false
+        }
+      ],
+      "id": "deploy",
+      "mutating": false,
+      "path": [
+        "deploy"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "diff",
+      "mutating": false,
+      "path": [
+        "diff"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "fix",
+          "kind": "flag",
+          "long": "fix",
+          "required": false
+        }
+      ],
+      "id": "doctor",
+      "mutating": false,
+      "path": [
+        "doctor"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "fix",
+          "kind": "flag",
+          "long": "fix",
+          "required": false
+        }
+      ],
+      "id": "doctor --fix",
+      "mutating": true,
+      "path": [
+        "doctor"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "branch",
+          "kind": "option",
+          "long": "branch",
+          "required": false
+        },
+        {
+          "id": "module_id",
+          "kind": "option",
+          "long": "module-id",
+          "required": false
+        },
+        {
+          "id": "scope",
+          "kind": "option",
+          "long": "scope",
+          "required": false
+        }
+      ],
+      "id": "evolve propose",
+      "mutating": true,
+      "path": [
+        "evolve",
+        "propose"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "module_id",
+          "kind": "option",
+          "long": "module-id",
+          "required": false
+        }
+      ],
+      "id": "evolve restore",
+      "mutating": true,
+      "path": [
+        "evolve",
+        "restore"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "explain diff",
+      "mutating": false,
+      "path": [
+        "explain",
+        "diff"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "explain plan",
+      "mutating": false,
+      "path": [
+        "explain",
+        "plan"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "explain status",
+      "mutating": false,
+      "path": [
+        "explain",
+        "status"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "fetch",
+      "mutating": true,
+      "path": [
+        "fetch"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "help",
+      "mutating": false,
+      "path": [
+        "help"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "init",
+      "mutating": true,
+      "path": [
+        "init"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "lock",
+      "mutating": true,
+      "path": [
+        "lock"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "module_id",
+          "kind": "option",
+          "required": true
+        },
+        {
+          "id": "scope",
+          "kind": "option",
+          "long": "scope",
+          "required": false
+        },
+        {
+          "id": "materialize",
+          "kind": "flag",
+          "long": "materialize",
+          "required": false
+        },
+        {
+          "id": "project",
+          "kind": "flag",
+          "long": "project",
+          "required": false
+        },
+        {
+          "id": "sparse",
+          "kind": "flag",
+          "long": "sparse",
+          "required": false
+        }
+      ],
+      "id": "overlay edit",
+      "mutating": true,
+      "path": [
+        "overlay",
+        "edit"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "module_id",
+          "kind": "option",
+          "required": true
+        },
+        {
+          "id": "scope",
+          "kind": "option",
+          "long": "scope",
+          "required": false
+        }
+      ],
+      "id": "overlay path",
+      "mutating": false,
+      "path": [
+        "overlay",
+        "path"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "module_id",
+          "kind": "option",
+          "required": true
+        },
+        {
+          "id": "scope",
+          "kind": "option",
+          "long": "scope",
+          "required": false
+        },
+        {
+          "id": "sparsify",
+          "kind": "flag",
+          "long": "sparsify",
+          "required": false
+        }
+      ],
+      "id": "overlay rebase",
+      "mutating": true,
+      "path": [
+        "overlay",
+        "rebase"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "plan",
+      "mutating": false,
+      "path": [
+        "plan"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "diff",
+          "kind": "flag",
+          "long": "diff",
+          "required": false
+        }
+      ],
+      "id": "preview",
+      "mutating": false,
+      "path": [
+        "preview"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "record",
+      "mutating": true,
+      "path": [
+        "record"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "name",
+          "kind": "option",
+          "long": "name",
+          "required": false
+        },
+        {
+          "id": "url",
+          "kind": "option",
+          "required": true
+        }
+      ],
+      "id": "remote set",
+      "mutating": true,
+      "path": [
+        "remote",
+        "set"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "module_id",
+          "kind": "option",
+          "required": true
+        }
+      ],
+      "id": "remove",
+      "mutating": true,
+      "path": [
+        "remove"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "to",
+          "kind": "option",
+          "long": "to",
+          "required": true
+        }
+      ],
+      "id": "rollback",
+      "mutating": true,
+      "path": [
+        "rollback"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "schema",
+      "mutating": false,
+      "path": [
+        "schema"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "score",
+      "mutating": false,
+      "path": [
+        "score"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
+      "id": "status",
+      "mutating": false,
+      "path": [
+        "status"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "remote",
+          "kind": "option",
+          "long": "remote",
+          "required": false
+        },
+        {
+          "id": "rebase",
+          "kind": "flag",
+          "long": "rebase",
+          "required": false
+        }
+      ],
+      "id": "sync",
+      "mutating": true,
+      "path": [
+        "sync"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [
+        {
+          "id": "fetch",
+          "kind": "flag",
+          "long": "fetch",
+          "required": false
+        },
+        {
+          "id": "lock",
+          "kind": "flag",
+          "long": "lock",
+          "required": false
+        },
+        {
+          "id": "no_fetch",
+          "kind": "flag",
+          "long": "no-fetch",
+          "required": false
+        },
+        {
+          "id": "no_lock",
+          "kind": "flag",
+          "long": "no-lock",
+          "required": false
+        }
+      ],
+      "id": "update",
+      "mutating": true,
+      "path": [
+        "update"
+      ],
+      "supports_json": true
+    }
+  ],
+  "global_args": [
+    {
+      "id": "dry_run",
+      "kind": "flag",
+      "long": "dry-run",
+      "required": false
+    },
+    {
+      "id": "json",
+      "kind": "flag",
+      "long": "json",
+      "required": false
+    },
+    {
+      "id": "machine",
+      "kind": "option",
+      "long": "machine",
+      "required": false
+    },
+    {
+      "id": "profile",
+      "kind": "option",
+      "long": "profile",
+      "required": false
+    },
+    {
+      "id": "repo",
+      "kind": "option",
+      "long": "repo",
+      "required": false
+    },
+    {
+      "id": "target",
+      "kind": "option",
+      "long": "target",
+      "required": false
+    },
+    {
+      "id": "yes",
+      "kind": "flag",
+      "long": "yes",
+      "required": false
+    }
+  ],
+  "mutating_commands": [
+    "init",
+    "add",
+    "remove",
+    "lock",
+    "fetch",
+    "update",
+    "deploy --apply",
+    "rollback",
+    "bootstrap",
+    "doctor --fix",
+    "overlay edit",
+    "overlay rebase",
+    "remote set",
+    "sync",
+    "record",
+    "evolve propose",
+    "evolve restore"
+  ],
+  "notes": [
+    "recommended: doctor -> update -> preview -> deploy --apply",
+    "recommended: status -> evolve propose -> review -> deploy --apply",
+    "in --json mode, mutating commands require --yes"
+  ]
+}

--- a/tests/golden/schema_json_data.json
+++ b/tests/golden/schema_json_data.json
@@ -1,0 +1,65 @@
+{
+  "commands": {
+    "diff": {
+      "data_fields": [
+        "profile",
+        "targets",
+        "changes",
+        "summary"
+      ]
+    },
+    "help": {
+      "data_fields": [
+        "global_args",
+        "commands",
+        "mutating_commands",
+        "notes"
+      ]
+    },
+    "plan": {
+      "data_fields": [
+        "profile",
+        "targets",
+        "changes",
+        "summary"
+      ]
+    },
+    "preview": {
+      "data_fields": [
+        "profile",
+        "targets",
+        "plan",
+        "diff?"
+      ]
+    },
+    "status": {
+      "data_fields": [
+        "profile",
+        "targets",
+        "drift",
+        "summary"
+      ]
+    }
+  },
+  "envelope": {
+    "error_item": {
+      "code": "string",
+      "details": "object|null",
+      "message": "string"
+    },
+    "fields": {
+      "command": "string",
+      "data": "object",
+      "errors": "array[{code,message,details?}]",
+      "ok": "boolean",
+      "schema_version": "number",
+      "version": "string",
+      "warnings": "array[string]"
+    },
+    "schema_version": 1
+  },
+  "path_conventions": {
+    "native": "path-like fields use OS-native separators",
+    "posix": "many payloads also include *_posix companion fields using forward slashes"
+  }
+}


### PR DESCRIPTION
Closes #145

Intent: Add golden regression coverage for the schema_version=1 JSON envelope and the self-describing help/schema commands.

Acceptance criteria:
- New tests validate envelope shape (schema_version/ok/command/version/data/warnings/errors)
- Golden snapshots added for help --json and schema --json (data-only)

Verification:
- cargo test --all --locked