### PR TITLE
feat(status): add drift summary and root grouping

### DIFF
--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -118,9 +118,11 @@ Tip:
 `data`:
 - `profile, targets`
 - `drift: DriftItem[]`
+- `summary: {modified, missing, extra}` (additive)
 
 `DriftItem`:
 - `target, path, path_posix`
+- Optional: `root, root_posix` (additive; target root that contains `path`)
 - `expected? (sha256:...)`
 - `actual? (sha256:...)`
 - `kind: missing|modified|extra`

--- a/tests/conformance_targets.rs
+++ b/tests/conformance_targets.rs
@@ -202,6 +202,9 @@ fn conformance_codex_smoke() {
         .expect("drift array");
     assert!(drift.iter().any(|d| d["kind"] == "modified"));
     assert!(drift.iter().any(|d| d["kind"] == "extra"));
+    let summary = &status_json["data"]["summary"];
+    assert!(summary["modified"].as_u64().unwrap_or(0) >= 1);
+    assert!(summary["extra"].as_u64().unwrap_or(0) >= 1);
 
     // Safe apply: should not delete unmanaged files.
     let deploy_fix = agentpack_in(
@@ -341,6 +344,9 @@ Hello v1
         .expect("drift array");
     assert!(drift.iter().any(|d| d["kind"] == "modified"));
     assert!(drift.iter().any(|d| d["kind"] == "extra"));
+    let summary = &status_json["data"]["summary"];
+    assert!(summary["modified"].as_u64().unwrap_or(0) >= 1);
+    assert!(summary["extra"].as_u64().unwrap_or(0) >= 1);
 
     let deploy_fix = agentpack_in(
         home,


### PR DESCRIPTION
Closes #149

Intent: Improve status UX while keeping schema_version=1 JSON backward-compatible.

Changes:
- status --json adds data.summary (modified/missing/extra) and drift item root/root_posix fields (additive)
- Human status output groups drift by root and prints a summary line
- docs/JSON_API.md updated for the additive fields

Verification:
- cargo test --all --locked