### PR TITLE
feat(manifest): tolerate unsupported target manifest schema

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -207,6 +207,7 @@ Schema (v1 example):
 Requirements:
 - `path` must be a relative path and must not contain `..`.
 - The manifest records only files written by agentpack deployments; never treat user-native files as managed files.
+- Readers MUST tolerate unsupported `schema_version` by emitting a warning and treating the manifest as missing (fall back behavior).
 
 ### 2.4 `state/logs/events.jsonl` (event log)
 
@@ -397,7 +398,7 @@ Notes:
 
 `agentpack status`
 - if the target root contains `.agentpack.manifest.json`: compute drift (`modified` / `missing` / `extra`) based on the manifest
-- if there is no manifest (first deploy / upgraded from older versions): fall back to comparing desired outputs vs filesystem, and emit a warning
+- if there is no manifest (or the manifest has an unsupported `schema_version`): fall back to comparing desired outputs vs filesystem, and emit a warning
 - if installed operator assets (bootstrap) are missing or outdated: emit a warning and suggest running `agentpack bootstrap`
 
 ### 4.8 `rollback`

--- a/openspec/specs/agentpack/spec.md
+++ b/openspec/specs/agentpack/spec.md
@@ -27,6 +27,13 @@ Agentpack MUST NOT delete files that are not listed in the target manifest.
 - **WHEN** a managed file is modified, and an unmanaged file is added
 - **THEN** `agentpack status` reports `modified` for the managed file and `extra` for the unmanaged file
 
+#### Scenario: Unsupported manifest schema_version is tolerated
+- **GIVEN** a deployed target root contains `.agentpack.manifest.json` with an unsupported `schema_version`
+- **WHEN** the user runs `agentpack status`
+- **THEN** the command succeeds
+- **AND** it emits a warning indicating the manifest was ignored
+- **AND** drift is computed using the “no manifest” fallback behavior
+
 ### Requirement: Multi-Machine Sync
 Agentpack MUST provide `remote set` and `sync` commands to standardize recommended git workflows for the agentpack config repo.
 

--- a/src/cli/commands/deploy.rs
+++ b/src/cli/commands/deploy.rs
@@ -12,10 +12,12 @@ pub(crate) fn run(ctx: &Ctx<'_>, apply: bool, adopt: bool) -> anyhow::Result<()>
     let targets = super::super::util::selected_targets(&engine.manifest, &ctx.cli.target)?;
     let render = engine.desired_state(&ctx.cli.profile, &ctx.cli.target)?;
     let desired = render.desired;
-    let warnings = render.warnings;
+    let mut warnings = render.warnings;
     let roots = render.roots;
     let managed_paths_from_manifest =
         crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
+    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
     let managed_paths = if !managed_paths_from_manifest.is_empty() {
         Some(super::super::util::filter_managed(
             managed_paths_from_manifest,

--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -11,10 +11,12 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     let targets = super::super::util::selected_targets(&engine.manifest, &ctx.cli.target)?;
     let render = engine.desired_state(&ctx.cli.profile, &ctx.cli.target)?;
     let desired = render.desired;
-    let warnings = render.warnings;
+    let mut warnings = render.warnings;
     let roots = render.roots;
     let managed_paths_from_manifest =
         crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
+    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
     let managed_paths = if !managed_paths_from_manifest.is_empty() {
         Some(super::super::util::filter_managed(
             managed_paths_from_manifest,

--- a/src/cli/commands/explain.rs
+++ b/src/cli/commands/explain.rs
@@ -47,9 +47,13 @@ fn explain_plan(cli: &super::super::args::Cli, engine: &Engine) -> anyhow::Resul
     let roots = render.roots;
 
     let manifest_index = super::super::util::load_manifest_module_ids(&roots)?;
+    warnings.extend(manifest_index.warnings);
+    let manifest_index = manifest_index.index;
 
     let managed_paths_from_manifest =
         crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
+    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
     let managed_paths = if !managed_paths_from_manifest.is_empty() {
         Some(super::super::util::filter_managed(
             managed_paths_from_manifest,
@@ -161,11 +165,14 @@ fn explain_status(cli: &super::super::args::Cli, engine: &Engine) -> anyhow::Res
     let roots = render.roots;
 
     let manifest_index = super::super::util::load_manifest_module_ids(&roots)?;
+    warnings.extend(manifest_index.warnings);
+    let manifest_index = manifest_index.index;
 
     let managed_paths_from_manifest =
         crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
     let managed_paths_from_manifest =
-        super::super::util::filter_managed(managed_paths_from_manifest, &cli.target);
+        super::super::util::filter_managed(managed_paths_from_manifest.managed_paths, &cli.target);
 
     let mut drift = Vec::new();
     if managed_paths_from_manifest.is_empty() {

--- a/src/cli/commands/plan.rs
+++ b/src/cli/commands/plan.rs
@@ -11,10 +11,12 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     let targets = super::super::util::selected_targets(&engine.manifest, &ctx.cli.target)?;
     let render = engine.desired_state(&ctx.cli.profile, &ctx.cli.target)?;
     let desired = render.desired;
-    let warnings = render.warnings;
+    let mut warnings = render.warnings;
     let roots = render.roots;
     let managed_paths_from_manifest =
         crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
+    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
     let managed_paths = if !managed_paths_from_manifest.is_empty() {
         Some(super::super::util::filter_managed(
             managed_paths_from_manifest,

--- a/src/cli/commands/preview.rs
+++ b/src/cli/commands/preview.rs
@@ -33,6 +33,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, diff: bool) -> anyhow::Result<()> {
     let roots = render.roots;
     let managed_paths_from_manifest =
         crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
+    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
     let managed_paths = if !managed_paths_from_manifest.is_empty() {
         Some(super::super::util::filter_managed(
             managed_paths_from_manifest,

--- a/tests/cli_manifest_forward_compat.rs
+++ b/tests/cli_manifest_forward_compat.rs
@@ -1,0 +1,87 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn unsupported_target_manifest_schema_version_is_non_fatal_for_status_and_plan() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(codex_home.join("prompts")).expect("create codex prompts dir");
+
+    let repo_dir = tmp.path().join("repo");
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: []
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: false
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+
+modules: []
+"#,
+        codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest).expect("write manifest");
+
+    std::fs::write(
+        codex_home.join("prompts/.agentpack.manifest.json"),
+        r#"{"schema_version": 999}"#,
+    )
+    .expect("write unsupported manifest");
+
+    let status = agentpack_in(tmp.path(), &["--target", "codex", "status", "--json"]);
+    assert!(status.status.success());
+    let v = parse_stdout_json(&status);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "status");
+    let warnings = v["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings.iter().any(|w| w
+            .as_str()
+            .unwrap_or_default()
+            .contains("unsupported schema_version")),
+        "warnings include unsupported schema_version"
+    );
+
+    let plan = agentpack_in(tmp.path(), &["--target", "codex", "plan", "--json"]);
+    assert!(plan.status.success());
+    let v = parse_stdout_json(&plan);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "plan");
+    let warnings = v["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings.iter().any(|w| w
+            .as_str()
+            .unwrap_or_default()
+            .contains("unsupported schema_version")),
+        "warnings include unsupported schema_version"
+    );
+}

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -654,6 +654,7 @@ fn load_managed_paths_from_manifests_reads_rel_paths() -> anyhow::Result<()> {
         scan_extras: true,
     }];
     let managed = agentpack::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    let managed = managed.managed_paths;
     assert!(managed.contains(&TargetPath {
         target: "codex".to_string(),
         path: root.join("a.txt"),
@@ -683,6 +684,7 @@ fn plan_deletes_only_manifest_managed_files() -> anyhow::Result<()> {
         scan_extras: true,
     }];
     let managed = agentpack::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    let managed = managed.managed_paths;
 
     let desired = deploy::DesiredState::new();
     let plan = deploy::plan(&desired, Some(&managed))?;


### PR DESCRIPTION
Implements docs/CODEX_EXEC_PLAN.md P1-4.

- Treats unsupported/unreadable/invalid <target root>/.agentpack.manifest.json as missing (warn + continue)
- Propagates manifest warnings into command JSON envelopes
- Updates status to compute drift per-root when only some roots have usable manifests
- Updates docs/SPEC.md + OpenSpec requirements
- Adds regression test for unsupported schema_version

Closes #153