### PR TITLE
docs(examples): add minimal example repo

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -50,6 +50,11 @@ modules:
         path: "modules/instructions/base"
 ```
 
+## Full example repo
+
+For a copy/pasteable working example (manifest + module files), see:
+- `docs/examples/minimal_repo/`
+
 ## Field reference
 
 ### version

--- a/docs/examples/minimal_repo/README.md
+++ b/docs/examples/minimal_repo/README.md
@@ -1,0 +1,22 @@
+# Minimal example config repo
+
+This directory is a copy/pasteable example of an Agentpack config repo layout:
+
+- `agentpack.yaml` (manifest)
+- `modules/` (local modules: instructions, prompt, and a Claude Code slash command)
+
+It is similar to what `agentpack init` creates, but with `modules:` entries pre-filled so you can see a working end-to-end example.
+
+## Try it (dry / read-only)
+
+- `agentpack --repo docs/examples/minimal_repo doctor`
+- `agentpack --repo docs/examples/minimal_repo plan`
+
+## Use it for real
+
+1. Copy this directory to your Agentpack repo path (default: `~/.agentpack/repo`), or point to it via `agentpack --repo <path>`.
+2. Edit `targets.codex.options.codex_home` if needed.
+3. Run:
+   - `agentpack update`
+   - `agentpack preview --diff`
+   - `agentpack deploy --apply`

--- a/docs/examples/minimal_repo/agentpack.yaml
+++ b/docs/examples/minimal_repo/agentpack.yaml
@@ -1,0 +1,48 @@
+version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  codex:
+    mode: files
+    scope: both
+    options:
+      codex_home: "~/.codex"
+      write_repo_skills: true
+      write_user_skills: true
+      write_user_prompts: true
+      write_agents_global: true
+      write_agents_repo_root: true
+  claude_code:
+    mode: files
+    scope: both
+    options:
+      write_repo_commands: true
+      write_user_commands: true
+      write_repo_skills: false
+      write_user_skills: false
+
+modules:
+  - id: "instructions:base"
+    type: instructions
+    tags: ["base"]
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/instructions/base"
+  - id: "prompt:draftpr"
+    type: prompt
+    tags: ["base"]
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompts/draftpr.md"
+  - id: "command:ap-plan"
+    type: command
+    tags: ["base"]
+    targets: ["claude_code"]
+    source:
+      local_path:
+        path: "modules/claude-commands/ap-plan.md"

--- a/docs/examples/minimal_repo/modules/claude-commands/ap-plan.md
+++ b/docs/examples/minimal_repo/modules/claude-commands/ap-plan.md
@@ -1,0 +1,5 @@
+---
+description: "agentpack: show plan"
+---
+
+Run `agentpack plan --json` and summarize the changes.

--- a/docs/examples/minimal_repo/modules/instructions/base/AGENTS.md
+++ b/docs/examples/minimal_repo/modules/instructions/base/AGENTS.md
@@ -1,0 +1,6 @@
+# Agent Instructions (base)
+
+This is a minimal `AGENTS.md` template managed by agentpack.
+
+- Follow repository conventions and run tests before making changes.
+- Prefer small, reviewable commits and keep diffs focused.

--- a/docs/examples/minimal_repo/modules/prompts/draftpr.md
+++ b/docs/examples/minimal_repo/modules/prompts/draftpr.md
@@ -1,0 +1,8 @@
+# draftpr
+
+Draft a pull request description:
+- Summary
+- Motivation
+- Changes
+- Testing
+- Rollout / Risk


### PR DESCRIPTION
Implements docs/CODEX_EXEC_PLAN.md P1-3.

- Adds a copy/pasteable minimal example config repo under docs/examples/minimal_repo/
- Links it from docs/CONFIG.md

Closes #157