### PR TITLE
feat(lockfile): validate lockfile version

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -53,6 +53,12 @@ Meaning: `agentpack.lock.json` is invalid JSON or cannot be parsed.
 Retryable: depends on repair/rebuild.
 Recommended action: fix JSON or delete it and regenerate via `agentpack update`.
 
+### E_LOCKFILE_UNSUPPORTED_VERSION
+Meaning: `agentpack.lock.json` `version` is unsupported.
+Retryable: depends on upgrading agentpack or regenerating lockfile.
+Recommended action: upgrade agentpack, or regenerate the lockfile via `agentpack lock` / `agentpack update`.
+Details: typically includes `{version, supported}`.
+
 ### E_TARGET_UNSUPPORTED
 Meaning:
 - `--target` specifies an unsupported value, or

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -31,6 +31,7 @@ When `--json` is enabled, common actionable failures must return stable error co
 - `E_CONFIG_UNSUPPORTED_VERSION`: `agentpack.yaml` `version` is unsupported.
 - `E_LOCKFILE_MISSING`: missing `repo/agentpack.lock.json` but the command requires it (e.g. `fetch`).
 - `E_LOCKFILE_INVALID`: `agentpack.lock.json` is invalid JSON.
+- `E_LOCKFILE_UNSUPPORTED_VERSION`: `agentpack.lock.json` `version` is unsupported.
 - `E_TARGET_UNSUPPORTED`: an unsupported target (manifest targets or CLI `--target` selection).
 - `E_DESIRED_STATE_CONFLICT`: multiple modules produced different content for the same `(target, path)` (refuse silent overwrite).
 - `E_OVERLAY_NOT_FOUND`: overlay directory does not exist (overlay not created yet).

--- a/openspec/specs/agentpack/spec.md
+++ b/openspec/specs/agentpack/spec.md
@@ -173,6 +173,7 @@ At minimum, the following scenarios MUST return stable codes:
 - Unsupported config version: `E_CONFIG_UNSUPPORTED_VERSION`
 - Missing lockfile when required: `E_LOCKFILE_MISSING`
 - Invalid lockfile JSON: `E_LOCKFILE_INVALID`
+- Unsupported lockfile version: `E_LOCKFILE_UNSUPPORTED_VERSION`
 - Unsupported `--target`: `E_TARGET_UNSUPPORTED`
 
 #### Scenario: missing config yields stable error code

--- a/tests/cli_error_codes.rs
+++ b/tests/cli_error_codes.rs
@@ -102,6 +102,23 @@ fn json_error_code_lockfile_invalid_for_fetch() {
 }
 
 #[test]
+fn json_error_code_lockfile_unsupported_version_for_fetch() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    std::fs::write(
+        tmp.path().join("repo").join("agentpack.lock.json"),
+        r#"{"version":2,"generated_at":"t","modules":[]}"#,
+    )
+    .expect("write lockfile");
+
+    let out = agentpack_in(tmp.path(), &["fetch", "--json", "--yes"]);
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["errors"][0]["code"], "E_LOCKFILE_UNSUPPORTED_VERSION");
+}
+
+#[test]
 fn json_error_code_target_unsupported() {
     let tmp = tempfile::tempdir().expect("tempdir");
     assert!(agentpack_in(tmp.path(), &["init"]).status.success());


### PR DESCRIPTION
Implements docs/CODEX_EXEC_PLAN.md P2-7.

- Validates agentpack.lock.json version on read
- Adds stable JSON error code E_LOCKFILE_UNSUPPORTED_VERSION
- Updates docs/SPEC.md, docs/ERROR_CODES.md, and OpenSpec requirements
- Adds regression test in tests/cli_error_codes.rs

Closes #161