### PR TITLE
feat(fs): add AGENTPACK_FSYNC durability mode

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -14,6 +14,8 @@ Default data directory: `~/.agentpack` (override via `AGENTPACK_HOME`), with:
 - `state/snapshots/` (deploy/rollback snapshots)
 - `state/logs/` (record events)
 
+Optional durability mode: set `AGENTPACK_FSYNC=1` to request `fsync` on atomic writes (slower, but more crash-consistent).
+
 Supported as of v0.5.0:
 - targets: `codex`, `claude_code`
 - module types: `instructions`, `skill`, `prompt`, `command`

--- a/openspec/changes/add-fsync-durability/proposal.md
+++ b/openspec/changes/add-fsync-durability/proposal.md
@@ -1,0 +1,12 @@
+# Change: Add optional durability mode for atomic writes
+
+## Why
+Some users prefer stronger crash consistency guarantees during deploy/apply, even at the cost of slower writes.
+
+## What Changes
+- Add an opt-in durability mode controlled by the environment variable `AGENTPACK_FSYNC`.
+- When enabled, `write_atomic` uses `sync_all` to increase the likelihood that bytes and rename are durable on disk.
+
+## Impact
+- Affected specs: `agentpack`
+- Affected code: `src/fs.rs`

--- a/openspec/changes/add-fsync-durability/specs/agentpack/spec.md
+++ b/openspec/changes/add-fsync-durability/specs/agentpack/spec.md
@@ -1,0 +1,12 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Optional durability mode for atomic writes
+When `AGENTPACK_FSYNC` is enabled, the system SHALL increase durability of atomic writes by syncing file contents before persist and (where supported) syncing the parent directory after the atomic replace.
+
+#### Scenario: durability mode is enabled for atomic writes
+- **GIVEN** `AGENTPACK_FSYNC=1` is set in the environment
+- **WHEN** the system writes a file via an atomic write path
+- **THEN** it syncs file contents to disk before the atomic replace
+- **AND** where supported, it syncs the parent directory after the atomic replace

--- a/openspec/changes/add-fsync-durability/tasks.md
+++ b/openspec/changes/add-fsync-durability/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+- [x] Add `AGENTPACK_FSYNC` opt-in behavior to `write_atomic`.
+
+## 2. Tests
+- [x] Add regression coverage for `AGENTPACK_FSYNC=1` write paths.
+
+## 3. Validation
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test`.
+- [x] Run `openspec validate add-fsync-durability --strict --no-interactive`.

--- a/openspec/specs/agentpack/spec.md
+++ b/openspec/specs/agentpack/spec.md
@@ -150,6 +150,15 @@ The system SHALL avoid unnecessary pre-deletes when writing updated outputs. On 
 - **WHEN** a subsequent deploy updates that file
 - **THEN** the system uses atomic replacement semantics where available
 
+### Requirement: Optional durability mode for atomic writes
+When `AGENTPACK_FSYNC` is enabled, the system SHALL increase durability of atomic writes by syncing file contents before persist and (where supported) syncing the parent directory after the atomic replace.
+
+#### Scenario: durability mode is enabled for atomic writes
+- **GIVEN** `AGENTPACK_FSYNC=1` is set in the environment
+- **WHEN** the system writes a file via an atomic write path
+- **THEN** it syncs file contents to disk before the atomic replace
+- **AND** where supported, it syncs the parent directory after the atomic replace
+
 ### Requirement: DesiredState path conflicts are refused
 If multiple modules attempt to produce different content for the same `(target, path)`, the system MUST fail fast instead of silently overwriting based on insertion order.
 


### PR DESCRIPTION
Closes #163.

What
- Add opt-in durability mode via env var AGENTPACK_FSYNC=1.
- When enabled, atomic writes sync file contents; on Unix, also best-effort sync parent dir after persist.

Docs
- docs/SPEC.md: documents AGENTPACK_FSYNC.
- openspec/specs/agentpack/spec.md: adds requirement for durability mode.
- openspec/changes/add-fsync-durability: proposal + delta + completed tasks.

Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
- openspec validate --all --strict --no-interactive