### PR TITLE
feat(init): add --git flag

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,9 +20,10 @@ Tips:
 
 ## init
 
-`agentpack init`
+`agentpack init [--git]`
 - Initializes a config repo skeleton (creates `agentpack.yaml` and example directories)
-- Does not run `git init`
+- By default it does not run `git init`
+- `--git`: also initializes the repo directory as a git repo and ensures `.gitignore` ignores `.agentpack.manifest.json`
 
 ## add / remove
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -22,14 +22,15 @@ Verify:
 By default, Agentpack creates/uses the config repo at `~/.agentpack/repo` (override via `AGENTPACK_HOME` or `--repo`).
 
 1. Initialize a skeleton:
-- `agentpack init`
+- `agentpack init` (or `agentpack init --git`)
 
 This creates:
 - `agentpack.yaml` (manifest)
 - `modules/` (example module dirs: instructions/prompts/claude-commands)
 
-We recommend turning it into a real git repo (Agentpack does **not** run `git init` automatically):
-- `cd ~/.agentpack/repo && git init && git add . && git commit -m "init agentpack"`
+We recommend turning it into a real git repo:
+- Easiest: `agentpack init --git`
+- Or manually: `cd ~/.agentpack/repo && git init && git add . && git commit -m "init agentpack"`
 
 Optional: set a remote and sync across machines:
 - `agentpack remote set <your_git_url>`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -316,10 +316,13 @@ Safety guardrails:
 
 ### 4.1 `init`
 
-`agentpack init`
-- creates `$AGENTPACK_HOME/repo` (does not run `git init` automatically)
+`agentpack init [--git]`
+- creates `$AGENTPACK_HOME/repo` (use `--git` to also run `git init` and write/update a minimal `.gitignore`)
 - writes a minimal `agentpack.yaml` skeleton
 - creates a `modules/` directory
+
+Optional:
+- `--git`: ensure `.gitignore` contains `.agentpack.manifest.json` (idempotent).
 
 ### 4.2 `add` / `remove`
 

--- a/docs/zh-CN/CLI.md
+++ b/docs/zh-CN/CLI.md
@@ -20,9 +20,10 @@
 
 ## init
 
-`agentpack init`
+`agentpack init [--git]`
 - 初始化 config repo skeleton（创建 `agentpack.yaml` 与示例目录）
-- 不会自动 `git init`
+- 默认不会自动 `git init`
+- `--git`：同时初始化 git repo，并确保 `.gitignore` 忽略 `.agentpack.manifest.json`
 
 ## add / remove
 

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -22,14 +22,15 @@
 Agentpack 默认在 `~/.agentpack/repo` 创建/读取配置仓库（可用 `AGENTPACK_HOME` 或 `--repo` 改位置）。
 
 1. 初始化 skeleton：
-- `agentpack init`
+- `agentpack init`（或 `agentpack init --git`）
 
 会生成：
 - `agentpack.yaml`（清单）
 - `modules/`（示例模块目录：instructions/prompts/claude-commands）
 
-建议你把它变成一个真正的 git repo（agentpack **不会**自动 `git init`）：
-- `cd ~/.agentpack/repo && git init && git add . && git commit -m "init agentpack"`
+建议你把它变成一个真正的 git repo：
+- 最简单：`agentpack init --git`
+- 或手动执行：`cd ~/.agentpack/repo && git init && git add . && git commit -m "init agentpack"`
 
 可选：配置远端并同步（多机器）：
 - `agentpack remote set <your_git_url>`

--- a/openspec/changes/update-init-git-flag/proposal.md
+++ b/openspec/changes/update-init-git-flag/proposal.md
@@ -1,0 +1,12 @@
+# Change: Add `init --git` convenience flag
+
+## Why
+Many users want the config repo created by `agentpack init` to be immediately git-backed and ready for sync.
+
+## What Changes
+- Add `agentpack init --git` to run `git init` in the repo directory.
+- Write/update a minimal `.gitignore` in the repo directory (idempotent).
+
+## Impact
+- Affected specs: `agentpack-cli`
+- Affected code: `src/cli/args.rs`, `src/cli/commands/init.rs`

--- a/openspec/changes/update-init-git-flag/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-init-git-flag/specs/agentpack-cli/spec.md
@@ -1,0 +1,12 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: init can optionally initialize a git repo
+The system SHALL support `agentpack init --git` to initialize the created repo directory as a git repository and to write/update a minimal `.gitignore` file.
+
+#### Scenario: init --git creates a git-backed repo skeleton
+- **GIVEN** a fresh machine state (empty `AGENTPACK_HOME`)
+- **WHEN** the user runs `agentpack init --git`
+- **THEN** the repo directory contains a `.git/` directory
+- **AND** the repo directory contains `.gitignore` that ignores `.agentpack.manifest.json`

--- a/openspec/changes/update-init-git-flag/tasks.md
+++ b/openspec/changes/update-init-git-flag/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+- [x] Add `--git` flag to `agentpack init`.
+- [x] Implement idempotent `git init` + minimal `.gitignore` update.
+
+## 2. Tests
+- [x] Update `help --json` golden output for the new flag.
+- [x] Add/adjust regression tests if needed.
+
+## 3. Validation
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test`.
+- [x] Run `openspec validate update-init-git-flag --strict --no-interactive`.

--- a/openspec/specs/agentpack-cli/spec.md
+++ b/openspec/specs/agentpack-cli/spec.md
@@ -16,6 +16,15 @@ The system SHALL implement the v0.1 CLI commands described in `docs/SPEC.md`, in
 - **THEN** target outputs are created and discoverable by the configured targets
 - **AND** `agentpack status` reports no drift
 
+### Requirement: init can optionally initialize a git repo
+The system SHALL support `agentpack init --git` to initialize the created repo directory as a git repository and to write/update a minimal `.gitignore` file.
+
+#### Scenario: init --git creates a git-backed repo skeleton
+- **GIVEN** a fresh machine state (empty `AGENTPACK_HOME`)
+- **WHEN** the user runs `agentpack init --git`
+- **THEN** the repo directory contains a `.git/` directory
+- **AND** the repo directory contains `.gitignore` that ignores `.agentpack.manifest.json`
+
 ### Requirement: JSON output contract
 When invoked with `--json`, the system SHALL output machine-readable JSON with the stable top-level fields:
 `schema_version`, `ok`, `command`, `version`, `data`, `warnings`, `errors`.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -44,7 +44,11 @@ pub struct Cli {
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Initialize the agentpack config repo
-    Init,
+    Init {
+        /// Also initialize the repo as a git repository (idempotent)
+        #[arg(long)]
+        git: bool,
+    },
 
     /// Self-describing CLI help (supports --json)
     Help,
@@ -318,7 +322,7 @@ pub enum EvolveCommands {
 impl Cli {
     pub(crate) fn command_name(&self) -> String {
         match &self.command {
-            Commands::Init => "init",
+            Commands::Init { .. } => "init",
             Commands::Help => "help",
             Commands::Schema => "schema",
             Commands::Add { .. } => "add",

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,27 +1,70 @@
 use anyhow::Context as _;
 
+use crate::fs::write_atomic;
 use crate::output::{JsonEnvelope, print_json};
 
 use super::Ctx;
 
-pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
+fn ensure_gitignore_contains(repo_root: &std::path::Path, line: &str) -> anyhow::Result<bool> {
+    let gitignore_path = repo_root.join(".gitignore");
+    let mut contents = std::fs::read_to_string(&gitignore_path).unwrap_or_default();
+    let already = contents.lines().any(|l| l.trim() == line);
+    if already {
+        return Ok(false);
+    }
+
+    if !contents.is_empty() && !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+    contents.push_str(line);
+    contents.push('\n');
+    write_atomic(&gitignore_path, contents.as_bytes())
+        .with_context(|| format!("write {}", gitignore_path.display()))?;
+    Ok(true)
+}
+
+pub(crate) fn run(ctx: &Ctx<'_>, git: bool) -> anyhow::Result<()> {
     super::super::util::require_yes_for_json_mutation(ctx.cli, "init")?;
 
     ctx.repo.init_repo_skeleton().context("init repo")?;
+
+    let mut gitignore_updated = false;
+    if git {
+        crate::git::git_in(&ctx.repo.repo_dir, &["init"]).context("git init")?;
+        gitignore_updated |=
+            ensure_gitignore_contains(&ctx.repo.repo_dir, ".agentpack.manifest.json")?;
+        gitignore_updated |= ensure_gitignore_contains(&ctx.repo.repo_dir, ".DS_Store")?;
+    }
+
     if ctx.cli.json {
-        let envelope = JsonEnvelope::ok(
-            "init",
-            serde_json::json!({
-                "repo": ctx.repo.repo_dir,
-                "repo_posix": crate::paths::path_to_posix_string(&ctx.repo.repo_dir),
-            }),
-        );
+        let mut data = serde_json::json!({
+            "repo": ctx.repo.repo_dir,
+            "repo_posix": crate::paths::path_to_posix_string(&ctx.repo.repo_dir),
+        });
+        if git {
+            data.as_object_mut()
+                .context("init json data must be an object")?
+                .insert(
+                "git".to_string(),
+                serde_json::json!({
+                    "initialized": true,
+                    "gitignore_updated": gitignore_updated,
+                    "gitignore_path": ctx.repo.repo_dir.join(".gitignore"),
+                    "gitignore_path_posix": crate::paths::path_to_posix_string(&ctx.repo.repo_dir.join(".gitignore")),
+                }),
+            );
+        }
+
+        let envelope = JsonEnvelope::ok("init", data);
         print_json(&envelope)?;
     } else {
         println!(
             "Initialized agentpack repo at {}",
             ctx.repo.repo_dir.display()
         );
+        if git {
+            println!("Initialized git repo and ensured .gitignore (updated={gitignore_updated})");
+        }
     }
 
     Ok(())

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -32,8 +32,8 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
     };
 
     match &cli.command {
-        Commands::Init => {
-            super::commands::init::run(&ctx)?;
+        Commands::Init { git } => {
+            super::commands::init::run(&ctx, *git)?;
         }
         Commands::Help => {
             super::commands::help::run(&ctx)?;

--- a/tests/cli_init_git.rs
+++ b/tests/cli_init_git.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+
+#[test]
+fn init_git_initializes_repo_and_writes_gitignore() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+
+    let out = Command::new(bin)
+        .args(["init", "--git"])
+        .env("AGENTPACK_HOME", tmp.path())
+        .output()
+        .expect("run agentpack");
+    assert!(out.status.success());
+
+    let repo = tmp.path().join("repo");
+    assert!(repo.join(".git").exists());
+
+    let gitignore = std::fs::read_to_string(repo.join(".gitignore")).expect("read .gitignore");
+    assert!(
+        gitignore
+            .lines()
+            .any(|l| l.trim() == ".agentpack.manifest.json")
+    );
+}

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -227,7 +227,14 @@
       "supports_json": true
     },
     {
-      "args": [],
+      "args": [
+        {
+          "id": "git",
+          "kind": "flag",
+          "long": "git",
+          "required": false
+        }
+      ],
       "id": "init",
       "mutating": true,
       "path": [


### PR DESCRIPTION
Closes #166.

What
- Add `agentpack init --git` to run `git init` and ensure `.gitignore` ignores `.agentpack.manifest.json`.
- Default `agentpack init` behavior remains unchanged.

Docs
- docs/SPEC.md, docs/CLI.md, docs/QUICKSTART.md (+ zh-CN) updated.
- openspec/specs/agentpack-cli/spec.md updated.
- openspec/changes/update-init-git-flag added (proposal + delta + tasks).

Tests
- Updated `help --json` golden snapshot.
- Added `tests/cli_init_git.rs`.

Validation
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
- openspec validate --all --strict --no-interactive