### PR TITLE
feat(store): dedup git checkouts by url+commit

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -214,11 +214,6 @@ fn ensure_locked_git_checkout(
     module_id: &str,
     locked: &crate::lockfile::ResolvedGitSource,
 ) -> anyhow::Result<PathBuf> {
-    let checkout_dir = store.git_checkout_dir(module_id, &locked.commit);
-    if checkout_dir.exists() {
-        return Ok(checkout_dir);
-    }
-
     // Lockfile stores the exact commit; use the commit itself as the ref name to avoid
     // requiring the original branch/tag in order to populate the checkout.
     let src = GitSource {

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -175,13 +175,13 @@ fn resolve_upstream_module_root_auto_fetches_missing_git_checkout() -> anyhow::R
     assert!(root.join("SKILL.md").is_file());
 
     // Ensure the checkout was created under cache.
-    let fs_key = agentpack::ids::module_fs_key("skill:test");
+    let store = agentpack::store::Store::new(&home);
+    let url = upstream.to_string_lossy().to_string();
+    let checkout_dir = store.git_checkout_dir(&url, &commit);
     assert!(
-        home.cache_dir
-            .join("git")
-            .join(fs_key)
-            .join(&commit)
-            .exists()
+        checkout_dir.exists(),
+        "expected checkout dir missing at {}",
+        checkout_dir.display()
     );
 
     Ok(())


### PR DESCRIPTION
Closes #172.

- Store git checkout dirs keyed by sha256(url)+commit.
- Best-effort migration from legacy module_id-based checkout paths.
- Added regression coverage for dedup + updated checkout-path assertion.

Regression:
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked