### PR TITLE
feat(targets): add cursor target

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -8,7 +8,7 @@ This document is for quickly looking up how a command works. For workflow-orient
 
 - `--repo <path>`: path to the config repo (default: `$AGENTPACK_HOME/repo`)
 - `--profile <name>`: profile name (default: `default`)
-- `--target <codex|claude_code|all>`: target selection (default: `all`)
+- `--target <codex|claude_code|cursor|all>`: target selection (default: `all`)
 - `--machine <id>`: override machine id (for machine overlays; default: auto-detect)
 - `--json`: machine-readable JSON output (envelope) on stdout
 - `--yes`: skip confirmations (note: in `--json` mode, mutating commands require explicit `--yes`)
@@ -28,7 +28,7 @@ Tips:
 
 ## add / remove
 
-- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code]`
+- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor]`
 - `agentpack remove <module_id>`
 
 Source spec:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -78,6 +78,7 @@ Required:
 Built-in targets:
 - `codex`
 - `claude_code`
+- `cursor`
 
 Per-target fields:
 - `mode`: currently only `files`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -17,7 +17,7 @@ Default data directory: `~/.agentpack` (override via `AGENTPACK_HOME`), with:
 Optional durability mode: set `AGENTPACK_FSYNC=1` to request `fsync` on atomic writes (slower, but more crash-consistent).
 
 Supported as of v0.5.0:
-- targets: `codex`, `claude_code`
+- targets: `codex`, `claude_code`, `cursor`
 - module types: `instructions`, `skill`, `prompt`, `command`
 - source types: `local_path`, `git` (`url` + `ref` + `subdir`)
 
@@ -78,7 +78,7 @@ Logical fields:
 
 ### 1.4 Target
 
-- `name: oneof [codex, claude_code]`
+- `name: oneof [codex, claude_code, cursor]`
 - `mode: oneof [files]` (v0.1)
 - `scope: oneof [user, project, both]`
 - `options: map` (target-specific)
@@ -327,7 +327,7 @@ Optional:
 
 ### 4.2 `add` / `remove`
 
-- `agentpack add <type> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code]`
+- `agentpack add <type> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor]`
 - `agentpack remove <module_id>`
 
 Source expressions:
@@ -545,6 +545,20 @@ Deploy rules:
 - command modules are single `.md` files; filename = slash command name
 - if the body uses `!bash`/`!`bash``: the YAML frontmatter must declare `allowed-tools: Bash(...)`
 - (future) plugin mode is possible (write `.claude-plugin/plugin.json`), but not implemented yet
+
+### 5.3 `cursor` target (files mode)
+
+Paths:
+- project rules: `<project_root>/.cursor/rules` (project scope only)
+
+Deploy rules:
+- instructions:
+  - for each enabled `instructions` module, write one Cursor rule file:
+    - `<project_root>/.cursor/rules/<module_fs_key>.mdc`
+  - each rule file includes YAML frontmatter (`description`, `globs`, `alwaysApply`) and the module’s `AGENTS.md` content.
+
+Notes:
+- `cursor` currently supports project scope only; `scope: user` is invalid.
 
 ## 6. JSON output spec
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -1,4 +1,4 @@
-# Targets (`codex` / `claude_code`)
+# Targets (`codex` / `claude_code` / `cursor`)
 
 > Language: English | [Chinese (Simplified)](zh-CN/TARGETS.md)
 
@@ -7,6 +7,7 @@ Targets define where agentpack writes the “compiled assets”, and which direc
 Built-in targets:
 - `codex`
 - `claude_code`
+- `cursor`
 
 For shared target fields, see `CONFIG.md`.
 
@@ -89,13 +90,38 @@ Rules:
 - `description` is required
 - If the body contains `!bash` or `!`bash``: you must declare `allowed-tools` and include `Bash(...)`
 
-## 3) scan_extras (handling extra files)
+## 3) cursor
+
+Cursor rules are stored under `.cursor/rules` and use `.mdc` files with YAML frontmatter.
+
+### Managed roots
+
+- `<project_root>/.cursor/rules` (project scope only)
+
+### Module → output mapping
+
+- `instructions`
+  - Writes one Cursor rule file per module:
+    - `<project_root>/.cursor/rules/<module_fs_key>.mdc`
+  - Frontmatter defaults:
+    - `description: "agentpack: <module_id>"`
+    - `globs: []`
+    - `alwaysApply: true`
+
+### Common options
+
+- `write_rules`: default true (requires project scope)
+
+Notes:
+- `cursor` currently supports project scope only (`scope: user` is invalid).
+
+## 4) scan_extras (handling extra files)
 
 Some roots enable `scan_extras`:
 - `true`: `status` reports “extra” files that exist on disk but are not in the managed manifest (never auto-deleted)
 - `false`: do not scan extras (e.g., the global `~/.codex` root typically avoids full scans)
 
-## 4) Adding a new target?
+## 5) Adding a new target?
 
 See:
 - `TARGET_SDK.md`

--- a/docs/zh-CN/CLI.md
+++ b/docs/zh-CN/CLI.md
@@ -8,7 +8,7 @@
 
 - `--repo <path>`：指定 config repo 路径（默认 `$AGENTPACK_HOME/repo`）
 - `--profile <name>`：选择 profile（默认 `default`）
-- `--target <codex|claude_code|all>`：选择 target（默认 `all`）
+- `--target <codex|claude_code|cursor|all>`：选择 target（默认 `all`）
 - `--machine <id>`：覆盖 machineId（用于 machine overlays；默认自动探测）
 - `--json`：stdout 输出机器可读 JSON（envelope）
 - `--yes`：跳过确认（注意：`--json` 下写入类命令必须显式给）
@@ -28,7 +28,7 @@
 
 ## add / remove
 
-- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code]`
+- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor]`
 - `agentpack remove <module_id>`
 
 source spec：

--- a/docs/zh-CN/CONFIG.md
+++ b/docs/zh-CN/CONFIG.md
@@ -73,6 +73,7 @@ Profile 用来从一堆 modules 里筛选“本次要部署哪些”。
 目前内置 targets：
 - `codex`
 - `claude_code`
+- `cursor`
 
 每个 target 的字段：
 - `mode`: 目前只有 `files`

--- a/docs/zh-CN/TARGETS.md
+++ b/docs/zh-CN/TARGETS.md
@@ -1,4 +1,4 @@
-# Targets（codex / claude_code）
+# Targets（codex / claude_code / cursor）
 
 > Language: 简体中文 | [English](../TARGETS.md)
 
@@ -7,6 +7,7 @@ Target 决定 agentpack 要把“编译后的资产”写到哪里，以及哪�
 目前内置 targets：
 - `codex`
 - `claude_code`
+- `cursor`
 
 Target 的通用字段见 `CONFIG.md`。
 
@@ -89,13 +90,38 @@ allowed-tools:
 - 必须有 `description`
 - 如果正文包含 `!bash` 或 `!\`bash\``：必须声明 `allowed-tools` 且允许 `Bash(...)`
 
-## 3) scan_extras（extra 文件的处理）
+## 3) cursor
+
+Cursor 的 rules 存在 `.cursor/rules`，文件格式为 `.mdc` + YAML frontmatter。
+
+### 写入位置（roots）
+
+- `<project_root>/.cursor/rules`（目前只支持 project scope）
+
+### module → 输出映射
+
+- `instructions`
+  - 每个 module 写一个 rule 文件：
+    - `<project_root>/.cursor/rules/<module_fs_key>.mdc`
+  - 默认 frontmatter：
+    - `description: "agentpack: <module_id>"`
+    - `globs: []`
+    - `alwaysApply: true`
+
+### 常用 options
+
+- `write_rules`：默认 true（需要 project scope）
+
+说明：
+- `cursor` 目前只支持 project scope（`scope: user` 会被视为配置错误）。
+
+## 4) scan_extras（extra 文件的处理）
 
 某些 roots 会启用 `scan_extras`：
 - `true`：status 会报告“目录中存在但不在托管清单里”的 extra 文件（不会自动删除）
 - `false`：不扫描 extra（例如 global `~/.codex` 根目录通常不做全量扫描）
 
-## 4) 想加新 target？
+## 5) 想加新 target？
 
 看：
 - `TARGET_SDK.md`

--- a/openspec/changes/add-cursor-target/.openspec.yaml
+++ b/openspec/changes/add-cursor-target/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-13

--- a/openspec/changes/add-cursor-target/README.md
+++ b/openspec/changes/add-cursor-target/README.md
@@ -1,0 +1,3 @@
+# add-cursor-target
+
+Add Cursor target adapter

--- a/openspec/changes/add-cursor-target/proposal.md
+++ b/openspec/changes/add-cursor-target/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add Cursor target
+
+## Why
+Cursor supports project “Rules” stored under `.cursor/rules/*.mdc`. Adding a first-party `cursor` target lets agentpack manage these rule files from existing `instructions` modules, keeping the AI-first loop consistent across tools.
+
+## What Changes
+- Add built-in target `cursor` (files mode).
+- Render `instructions` modules to Cursor rule files under `<project_root>/.cursor/rules`.
+- Extend conformance tests to include Cursor.
+- Update docs (`docs/SPEC.md`, `docs/CLI.md`, `docs/CONFIG.md`, `docs/TARGETS.md`) to document mapping and options.
+
+## Impact
+- Specs: `openspec/specs/agentpack/spec.md` (targets + conformance), `docs/SPEC.md` target adapter details.
+- Code: `src/config.rs`, `src/cli/util.rs`, `src/target_adapters.rs`, `src/engine.rs`.
+- Tests: `tests/conformance_targets.rs`.

--- a/openspec/changes/add-cursor-target/specs/agentpack/spec.md
+++ b/openspec/changes/add-cursor-target/specs/agentpack/spec.md
@@ -1,0 +1,39 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Cursor target writes project rules
+The system SHALL support a built-in `cursor` target (files mode) that renders `instructions` modules into Cursor project rule files under `.cursor/rules`.
+
+#### Scenario: deploy writes cursor rule files and a manifest
+- **GIVEN** an enabled `instructions` module targeting `cursor`
+- **WHEN** the user runs `agentpack --target cursor deploy --apply`
+- **THEN** at least one `.mdc` rule file exists under `<project_root>/.cursor/rules`
+- **AND** `<project_root>/.cursor/rules/.agentpack.manifest.json` exists
+
+#### Scenario: rule filenames are stable and unique
+- **GIVEN** two different enabled `instructions` modules targeting `cursor`
+- **WHEN** the user runs `agentpack --target cursor deploy --apply`
+- **THEN** the generated filenames are distinct and derived from each module’s `module_fs_key`
+
+## MODIFIED Requirements
+
+### Requirement: Target rendering is routed via a TargetAdapter registry
+The system SHALL centralize target-specific rendering and validation behind a `TargetAdapter` abstraction, so adding a new target does not require scattering conditional logic across the engine and CLI.
+
+#### Scenario: Known targets are resolved via registry
+- **GIVEN** the system supports the `codex`, `claude_code`, and `cursor` targets
+- **WHEN** the engine renders desired state for a selected target
+- **THEN** the corresponding target adapter is used to compute target roots and desired output paths
+
+### Requirement: Target conformance tests cover critical safety semantics
+The repository SHALL include conformance tests that validate critical cross-target safety semantics, including:
+- delete protection (only manifest-managed paths can be deleted)
+- per-root manifest write/read
+- drift classification (missing/modified/extra)
+- rollback restoring previous outputs
+
+#### Scenario: conformance tests exist for built-in targets
+- **GIVEN** built-in targets `codex`, `claude_code`, and `cursor`
+- **WHEN** the test suite is run
+- **THEN** conformance tests execute these semantics for all built-in targets

--- a/openspec/changes/add-cursor-target/tasks.md
+++ b/openspec/changes/add-cursor-target/tasks.md
@@ -1,0 +1,15 @@
+## 1. Docs & specs
+- [x] Update `docs/SPEC.md` target list and add a `cursor` target section
+- [x] Update `docs/CLI.md`, `docs/CONFIG.md`, `docs/TARGETS.md` (and `docs/zh-CN/*`) to document `cursor`
+- [x] Add OpenSpec delta requirements under `openspec/changes/add-cursor-target/specs/`
+
+## 2. Implementation
+- [x] Allow `cursor` in manifest validation and CLI `--target` selection
+- [x] Implement `cursor` `TargetAdapter` and `Engine::render_cursor` mapping to `.cursor/rules/*.mdc`
+- [x] Add conformance coverage (`deploy/status/rollback`) for `cursor`
+
+## 3. Validation
+- [x] Run: `cargo fmt --all -- --check`
+- [x] Run: `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] Run: `cargo test --all --locked`
+- [x] Run: `openspec validate add-cursor-target --strict --no-interactive`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -17,7 +17,7 @@ pub struct Cli {
     #[arg(long, default_value = "default", global = true)]
     pub(crate) profile: String,
 
-    /// Target name: codex|claude_code|all (default: "all")
+    /// Target name: codex|claude_code|cursor|all (default: "all")
     #[arg(long, default_value = "all", global = true)]
     pub(crate) target: String,
 
@@ -95,7 +95,7 @@ pub enum Commands {
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
 
-        /// Comma-separated target names (codex, claude_code). Empty = all.
+        /// Comma-separated target names (codex, claude_code, cursor). Empty = all.
         #[arg(long, value_delimiter = ',')]
         targets: Vec<String>,
     },

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -54,7 +54,7 @@ pub(crate) fn selected_targets(
 
     match target_filter {
         "all" => Ok(known),
-        "codex" | "claude_code" => {
+        "codex" | "claude_code" | "cursor" => {
             if !manifest.targets.contains_key(target_filter) {
                 return Err(anyhow::Error::new(
                     UserError::new(
@@ -76,7 +76,7 @@ pub(crate) fn selected_targets(
             )
             .with_details(serde_json::json!({
                 "target": other,
-                "allowed": ["all","codex","claude_code"],
+                "allowed": ["all","codex","claude_code","cursor"],
             })),
         )),
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -97,6 +97,7 @@ impl Engine {
             "all" => Ok(known),
             "codex" => Ok(vec!["codex".to_string()]),
             "claude_code" => Ok(vec!["claude_code".to_string()]),
+            "cursor" => Ok(vec!["cursor".to_string()]),
             other => Err(anyhow::Error::new(
                 UserError::new(
                     "E_TARGET_UNSUPPORTED",
@@ -104,7 +105,7 @@ impl Engine {
                 )
                 .with_details(serde_json::json!({
                     "target": other,
-                    "allowed": ["all","codex","claude_code"],
+                    "allowed": ["all","codex","claude_code","cursor"],
                 })),
             )),
         }
@@ -386,6 +387,72 @@ impl Engine {
                     vec![m.id.clone()],
                 )?;
             }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn render_cursor(
+        &self,
+        modules: &[&Module],
+        desired: &mut DesiredState,
+        warnings: &mut Vec<String>,
+        roots: &mut Vec<TargetRoot>,
+    ) -> anyhow::Result<()> {
+        let target_cfg = self
+            .manifest
+            .targets
+            .get("cursor")
+            .context("missing cursor target config")?;
+        let opts = &target_cfg.options;
+
+        let (_allow_user, allow_project) = scope_flags(&target_cfg.scope);
+        let write_rules = allow_project && get_bool(opts, "write_rules", true);
+
+        let rules_dir = self.project.project_root.join(".cursor/rules");
+        if write_rules {
+            roots.push(TargetRoot {
+                target: "cursor".to_string(),
+                root: rules_dir.clone(),
+                scan_extras: true,
+            });
+        }
+
+        for m in modules
+            .iter()
+            .filter(|m| matches!(m.module_type, ModuleType::Instructions))
+            .filter(|m| m.targets.is_empty() || m.targets.iter().any(|t| t == "cursor"))
+        {
+            if !write_rules {
+                continue;
+            }
+
+            let (_tmp, materialized) = self.materialize_module(m, warnings)?;
+            let agents_file = materialized.join("AGENTS.md");
+            let body_bytes = std::fs::read(&agents_file)
+                .with_context(|| format!("read {}", agents_file.display()))?;
+
+            let description = format!("agentpack: {}", m.id);
+            let description_json =
+                serde_json::to_string(&description).context("serialize cursor rule description")?;
+            let header = format!(
+                "---\ndescription: {description_json}\nglobs: []\nalwaysApply: true\n---\n\n"
+            );
+
+            let mut out = header.into_bytes();
+            out.extend(body_bytes);
+            if !out.ends_with(b"\n") {
+                out.push(b'\n');
+            }
+
+            let name = format!("{}.mdc", crate::ids::module_fs_key(&m.id));
+            insert_file(
+                desired,
+                "cursor",
+                rules_dir.join(name),
+                out,
+                vec![m.id.clone()],
+            )?;
         }
 
         Ok(())

--- a/src/target_adapters.rs
+++ b/src/target_adapters.rs
@@ -17,6 +17,7 @@ pub trait TargetAdapter {
 
 struct CodexAdapter;
 struct ClaudeCodeAdapter;
+struct CursorAdapter;
 
 impl TargetAdapter for CodexAdapter {
     fn id(&self) -> &'static str {
@@ -52,13 +53,32 @@ impl TargetAdapter for ClaudeCodeAdapter {
     }
 }
 
+impl TargetAdapter for CursorAdapter {
+    fn id(&self) -> &'static str {
+        "cursor"
+    }
+
+    fn render(
+        &self,
+        engine: &Engine,
+        modules: &[&crate::config::Module],
+        desired: &mut DesiredState,
+        warnings: &mut Vec<String>,
+        roots: &mut Vec<TargetRoot>,
+    ) -> anyhow::Result<()> {
+        engine.render_cursor(modules, desired, warnings, roots)
+    }
+}
+
 pub fn adapter_for(target: &str) -> Option<&'static dyn TargetAdapter> {
     static CODEX: CodexAdapter = CodexAdapter;
     static CLAUDE: ClaudeCodeAdapter = ClaudeCodeAdapter;
+    static CURSOR: CursorAdapter = CursorAdapter;
 
     match target {
         "codex" => Some(&CODEX),
         "claude_code" => Some(&CLAUDE),
+        "cursor" => Some(&CURSOR),
         _ => None,
     }
 }


### PR DESCRIPTION
Closes #174.

Adds a built-in `cursor` target:
- Renders `instructions` modules to `.cursor/rules/<module_fs_key>.mdc` with Cursor frontmatter.
- Adds conformance coverage for cursor (deploy/status/rollback/delete-protection).
- Updates docs (SPEC/CLI/CONFIG/TARGETS + zh-CN) and adds an OpenSpec change record (`openspec/changes/add-cursor-target`).

Validation:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate add-cursor-target --strict --no-interactive`
