### PR TITLE
feat(targets): add vscode target

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -8,7 +8,7 @@ This document is for quickly looking up how a command works. For workflow-orient
 
 - `--repo <path>`: path to the config repo (default: `$AGENTPACK_HOME/repo`)
 - `--profile <name>`: profile name (default: `default`)
-- `--target <codex|claude_code|cursor|all>`: target selection (default: `all`)
+- `--target <codex|claude_code|cursor|vscode|all>`: target selection (default: `all`)
 - `--machine <id>`: override machine id (for machine overlays; default: auto-detect)
 - `--json`: machine-readable JSON output (envelope) on stdout
 - `--yes`: skip confirmations (note: in `--json` mode, mutating commands require explicit `--yes`)
@@ -28,7 +28,7 @@ Tips:
 
 ## add / remove
 
-- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor]`
+- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode]`
 - `agentpack remove <module_id>`
 
 Source spec:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -79,6 +79,7 @@ Built-in targets:
 - `codex`
 - `claude_code`
 - `cursor`
+- `vscode`
 
 Per-target fields:
 - `mode`: currently only `files`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -17,7 +17,7 @@ Default data directory: `~/.agentpack` (override via `AGENTPACK_HOME`), with:
 Optional durability mode: set `AGENTPACK_FSYNC=1` to request `fsync` on atomic writes (slower, but more crash-consistent).
 
 Supported as of v0.5.0:
-- targets: `codex`, `claude_code`, `cursor`
+- targets: `codex`, `claude_code`, `cursor`, `vscode`
 - module types: `instructions`, `skill`, `prompt`, `command`
 - source types: `local_path`, `git` (`url` + `ref` + `subdir`)
 
@@ -78,7 +78,7 @@ Logical fields:
 
 ### 1.4 Target
 
-- `name: oneof [codex, claude_code, cursor]`
+- `name: oneof [codex, claude_code, cursor, vscode]`
 - `mode: oneof [files]` (v0.1)
 - `scope: oneof [user, project, both]`
 - `options: map` (target-specific)
@@ -327,7 +327,7 @@ Optional:
 
 ### 4.2 `add` / `remove`
 
-- `agentpack add <type> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor]`
+- `agentpack add <type> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode]`
 - `agentpack remove <module_id>`
 
 Source expressions:
@@ -559,6 +559,23 @@ Deploy rules:
 
 Notes:
 - `cursor` currently supports project scope only; `scope: user` is invalid.
+
+### 5.4 `vscode` target (files mode)
+
+Paths:
+- project Copilot instructions: `<project_root>/.github/copilot-instructions.md` (project scope only)
+- project prompt files: `<project_root>/.github/prompts/*.prompt.md`
+
+Deploy rules:
+- instructions:
+  - collects enabled `instructions` modules into a single `copilot-instructions.md` file
+  - when multiple modules exist, agentpack uses per-module section markers to preserve module attribution (same marker format as `codex` `AGENTS.md` aggregation)
+- prompts:
+  - copies each `prompt` module’s single `.md` file into `.github/prompts/`
+  - if the source filename does not end with `.prompt.md`, agentpack writes it as `<name>.prompt.md` for VS Code discovery
+
+Notes:
+- `vscode` currently supports project scope only; `scope: user` is invalid.
 
 ## 6. JSON output spec
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -1,4 +1,4 @@
-# Targets (`codex` / `claude_code` / `cursor`)
+# Targets (`codex` / `claude_code` / `cursor` / `vscode`)
 
 > Language: English | [Chinese (Simplified)](zh-CN/TARGETS.md)
 
@@ -8,6 +8,7 @@ Built-in targets:
 - `codex`
 - `claude_code`
 - `cursor`
+- `vscode`
 
 For shared target fields, see `CONFIG.md`.
 
@@ -115,13 +116,42 @@ Cursor rules are stored under `.cursor/rules` and use `.mdc` files with YAML fro
 Notes:
 - `cursor` currently supports project scope only (`scope: user` is invalid).
 
-## 4) scan_extras (handling extra files)
+## 4) vscode
+
+VS Code / GitHub Copilot uses repository-scoped “custom instructions” and “prompt files” under `.github/`.
+
+### Managed roots
+
+- `<project_root>/.github` (instructions; `scan_extras=false` to avoid flagging unrelated `.github/*` files)
+- `<project_root>/.github/prompts` (prompt files; `scan_extras=true`)
+
+### Module → output mapping
+
+- `instructions`
+  - Collects each instructions module’s `AGENTS.md` content into:
+    - `<project_root>/.github/copilot-instructions.md`
+  - When multiple modules exist, agentpack generates a single file with per-module section markers to preserve attribution.
+
+- `prompt`
+  - Copies a single `.md` file into:
+    - `<project_root>/.github/prompts/<name>.prompt.md`
+  - If the source filename does not already end with `.prompt.md`, agentpack appends `.prompt.md` for discovery.
+
+### Common options
+
+- `write_instructions`: default true (requires project scope)
+- `write_prompts`: default true (requires project scope)
+
+Notes:
+- `vscode` currently supports project scope only (`scope: user` is invalid).
+
+## 5) scan_extras (handling extra files)
 
 Some roots enable `scan_extras`:
 - `true`: `status` reports “extra” files that exist on disk but are not in the managed manifest (never auto-deleted)
 - `false`: do not scan extras (e.g., the global `~/.codex` root typically avoids full scans)
 
-## 5) Adding a new target?
+## 6) Adding a new target?
 
 See:
 - `TARGET_SDK.md`

--- a/docs/zh-CN/CLI.md
+++ b/docs/zh-CN/CLI.md
@@ -8,7 +8,7 @@
 
 - `--repo <path>`：指定 config repo 路径（默认 `$AGENTPACK_HOME/repo`）
 - `--profile <name>`：选择 profile（默认 `default`）
-- `--target <codex|claude_code|cursor|all>`：选择 target（默认 `all`）
+- `--target <codex|claude_code|cursor|vscode|all>`：选择 target（默认 `all`）
 - `--machine <id>`：覆盖 machineId（用于 machine overlays；默认自动探测）
 - `--json`：stdout 输出机器可读 JSON（envelope）
 - `--yes`：跳过确认（注意：`--json` 下写入类命令必须显式给）
@@ -28,7 +28,7 @@
 
 ## add / remove
 
-- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor]`
+- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode]`
 - `agentpack remove <module_id>`
 
 source spec：

--- a/docs/zh-CN/CONFIG.md
+++ b/docs/zh-CN/CONFIG.md
@@ -74,6 +74,7 @@ Profile 用来从一堆 modules 里筛选“本次要部署哪些”。
 - `codex`
 - `claude_code`
 - `cursor`
+- `vscode`
 
 每个 target 的字段：
 - `mode`: 目前只有 `files`

--- a/docs/zh-CN/TARGETS.md
+++ b/docs/zh-CN/TARGETS.md
@@ -1,4 +1,4 @@
-# Targets（codex / claude_code / cursor）
+# Targets（codex / claude_code / cursor / vscode）
 
 > Language: 简体中文 | [English](../TARGETS.md)
 
@@ -8,6 +8,7 @@ Target 决定 agentpack 要把“编译后的资产”写到哪里，以及哪�
 - `codex`
 - `claude_code`
 - `cursor`
+- `vscode`
 
 Target 的通用字段见 `CONFIG.md`。
 
@@ -115,13 +116,42 @@ Cursor 的 rules 存在 `.cursor/rules`，文件格式为 `.mdc` + YAML frontmat
 说明：
 - `cursor` 目前只支持 project scope（`scope: user` 会被视为配置错误）。
 
-## 4) scan_extras（extra 文件的处理）
+## 4) vscode
+
+VS Code / GitHub Copilot 使用 repo 级别的 “custom instructions” 和 “prompt files”，默认约定放在 `.github/` 下。
+
+### 写入位置（roots）
+
+- `<project_root>/.github`（instructions；`scan_extras=false`，避免把无关的 `.github/*` 误报为 extra）
+- `<project_root>/.github/prompts`（prompt files；`scan_extras=true`）
+
+### module → 输出映射
+
+- `instructions`
+  - 合并每个 instructions module 的 `AGENTS.md` 内容到：
+    - `<project_root>/.github/copilot-instructions.md`
+  - 多个模块时会生成一个带 per-module section markers 的单文件，保留归因信息。
+
+- `prompt`
+  - 复制单个 `.md` 文件到：
+    - `<project_root>/.github/prompts/<name>.prompt.md`
+  - 如果源文件名不以 `.prompt.md` 结尾，agentpack 会自动追加 `.prompt.md` 以便 VS Code 发现。
+
+### 常用 options
+
+- `write_instructions`：默认 true（需要 project scope）
+- `write_prompts`：默认 true（需要 project scope）
+
+说明：
+- `vscode` 目前只支持 project scope（`scope: user` 会被视为配置错误）。
+
+## 5) scan_extras（extra 文件的处理）
 
 某些 roots 会启用 `scan_extras`：
 - `true`：status 会报告“目录中存在但不在托管清单里”的 extra 文件（不会自动删除）
 - `false`：不扫描 extra（例如 global `~/.codex` 根目录通常不做全量扫描）
 
-## 5) 想加新 target？
+## 6) 想加新 target？
 
 看：
 - `TARGET_SDK.md`

--- a/openspec/changes/add-vscode-target/.openspec.yaml
+++ b/openspec/changes/add-vscode-target/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-13

--- a/openspec/changes/add-vscode-target/README.md
+++ b/openspec/changes/add-vscode-target/README.md
@@ -1,0 +1,3 @@
+# add-vscode-target
+
+Add VS Code target adapter

--- a/openspec/changes/add-vscode-target/proposal.md
+++ b/openspec/changes/add-vscode-target/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add VS Code target
+
+## Why
+VS Code / GitHub Copilot supports repo-scoped “custom instructions” and “prompt files” under `.github/`. Adding a first-party `vscode` target lets agentpack generate these assets from `instructions` and `prompt` modules, keeping configuration portable and reproducible.
+
+## What Changes
+- Add built-in target `vscode` (files mode).
+- Render `instructions` modules into `.github/copilot-instructions.md` (single file; per-module markers when multiple).
+- Render `prompt` modules into `.github/prompts/*.prompt.md` (normalize filename to end with `.prompt.md`).
+- Extend conformance tests and docs to cover the new target.
+
+## Impact
+- Specs: `openspec/specs/agentpack/spec.md` (targets + conformance), `docs/SPEC.md` target adapter details.
+- Code: `src/config.rs`, `src/cli/util.rs`, `src/target_adapters.rs`, `src/engine.rs`.
+- Tests: `tests/conformance_targets.rs`.

--- a/openspec/changes/add-vscode-target/specs/agentpack/spec.md
+++ b/openspec/changes/add-vscode-target/specs/agentpack/spec.md
@@ -1,0 +1,42 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: VS Code target writes Copilot instruction and prompt files
+The system SHALL support a built-in `vscode` target (files mode) that renders:
+- `instructions` modules into `.github/copilot-instructions.md`, and
+- `prompt` modules into `.github/prompts/*.prompt.md`.
+
+#### Scenario: deploy writes vscode files and manifests
+- **GIVEN** at least one enabled module targeting `vscode`
+- **WHEN** the user runs `agentpack --target vscode deploy --apply`
+- **THEN** `<project_root>/.github/copilot-instructions.md` exists when `instructions` modules are present
+- **AND** `<project_root>/.github/prompts/` contains `.prompt.md` files when `prompt` modules are present
+- **AND** per-root `.agentpack.manifest.json` files exist under `.github/` and `.github/prompts/`
+
+#### Scenario: prompt filenames end with .prompt.md
+- **GIVEN** a `prompt` module whose source file is named `hello.md`
+- **WHEN** the user runs `agentpack --target vscode deploy --apply`
+- **THEN** the deployed file name ends with `.prompt.md`
+
+## MODIFIED Requirements
+
+### Requirement: Target rendering is routed via a TargetAdapter registry
+The system SHALL centralize target-specific rendering and validation behind a `TargetAdapter` abstraction, so adding a new target does not require scattering conditional logic across the engine and CLI.
+
+#### Scenario: Known targets are resolved via registry
+- **GIVEN** the system supports the `codex`, `claude_code`, `cursor`, and `vscode` targets
+- **WHEN** the engine renders desired state for a selected target
+- **THEN** the corresponding target adapter is used to compute target roots and desired output paths
+
+### Requirement: Target conformance tests cover critical safety semantics
+The repository SHALL include conformance tests that validate critical cross-target safety semantics, including:
+- delete protection (only manifest-managed paths can be deleted)
+- per-root manifest write/read
+- drift classification (missing/modified/extra)
+- rollback restoring previous outputs
+
+#### Scenario: conformance tests exist for built-in targets
+- **GIVEN** built-in targets `codex`, `claude_code`, `cursor`, and `vscode`
+- **WHEN** the test suite is run
+- **THEN** conformance tests execute these semantics for all built-in targets

--- a/openspec/changes/add-vscode-target/tasks.md
+++ b/openspec/changes/add-vscode-target/tasks.md
@@ -1,0 +1,15 @@
+## 1. Docs & specs
+- [x] Update `docs/SPEC.md` target list and add a `vscode` target section
+- [x] Update `docs/CLI.md`, `docs/CONFIG.md`, `docs/TARGETS.md` (and `docs/zh-CN/*`) to document `vscode`
+- [x] Add OpenSpec delta requirements under `openspec/changes/add-vscode-target/specs/`
+
+## 2. Implementation
+- [x] Allow `vscode` in manifest/module validation and CLI `--target` selection
+- [x] Implement `vscode` `TargetAdapter` and `Engine::render_vscode` mapping to `.github/`
+- [x] Add conformance coverage (`deploy/status/rollback`) for `vscode`
+
+## 3. Validation
+- [x] Run: `cargo fmt --all -- --check`
+- [x] Run: `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] Run: `cargo test --all --locked`
+- [x] Run: `openspec validate add-vscode-target --strict --no-interactive`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -17,7 +17,7 @@ pub struct Cli {
     #[arg(long, default_value = "default", global = true)]
     pub(crate) profile: String,
 
-    /// Target name: codex|claude_code|cursor|all (default: "all")
+    /// Target name: codex|claude_code|cursor|vscode|all (default: "all")
     #[arg(long, default_value = "all", global = true)]
     pub(crate) target: String,
 
@@ -95,7 +95,7 @@ pub enum Commands {
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
 
-        /// Comma-separated target names (codex, claude_code, cursor). Empty = all.
+        /// Comma-separated target names (codex, claude_code, cursor, vscode). Empty = all.
         #[arg(long, value_delimiter = ',')]
         targets: Vec<String>,
     },

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -54,7 +54,7 @@ pub(crate) fn selected_targets(
 
     match target_filter {
         "all" => Ok(known),
-        "codex" | "claude_code" | "cursor" => {
+        "codex" | "claude_code" | "cursor" | "vscode" => {
             if !manifest.targets.contains_key(target_filter) {
                 return Err(anyhow::Error::new(
                     UserError::new(
@@ -76,7 +76,7 @@ pub(crate) fn selected_targets(
             )
             .with_details(serde_json::json!({
                 "target": other,
-                "allowed": ["all","codex","claude_code","cursor"],
+                "allowed": ["all","codex","claude_code","cursor","vscode"],
             })),
         )),
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -212,6 +212,20 @@ fn validate_manifest(manifest: &Manifest) -> anyhow::Result<()> {
                     ));
                 }
             }
+            "vscode" => {
+                if matches!(cfg.scope, TargetScope::User) {
+                    return Err(anyhow::Error::new(
+                        UserError::new(
+                            "E_CONFIG_INVALID",
+                            "vscode target does not support user scope",
+                        )
+                        .with_details(serde_json::json!({
+                            "target": "vscode",
+                            "allowed_scopes": ["project","both"],
+                        })),
+                    ));
+                }
+            }
             _ => {
                 return Err(anyhow::Error::new(
                     UserError::new(
@@ -220,7 +234,7 @@ fn validate_manifest(manifest: &Manifest) -> anyhow::Result<()> {
                     )
                     .with_details(serde_json::json!({
                         "target": target_name,
-                        "allowed": ["codex","claude_code","cursor"],
+                        "allowed": ["codex","claude_code","cursor","vscode"],
                     })),
                 ));
             }
@@ -244,7 +258,7 @@ fn validate_manifest(manifest: &Manifest) -> anyhow::Result<()> {
         }
 
         for t in &m.targets {
-            if t != "codex" && t != "claude_code" && t != "cursor" {
+            if t != "codex" && t != "claude_code" && t != "cursor" && t != "vscode" {
                 return Err(anyhow::Error::new(
                     UserError::new(
                         "E_TARGET_UNSUPPORTED",
@@ -253,7 +267,7 @@ fn validate_manifest(manifest: &Manifest) -> anyhow::Result<()> {
                     .with_details(serde_json::json!({
                         "module_id": m.id,
                         "target": t,
-                        "allowed": ["codex","claude_code","cursor"],
+                        "allowed": ["codex","claude_code","cursor","vscode"],
                     })),
                 ));
             }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -98,6 +98,7 @@ impl Engine {
             "codex" => Ok(vec!["codex".to_string()]),
             "claude_code" => Ok(vec!["claude_code".to_string()]),
             "cursor" => Ok(vec!["cursor".to_string()]),
+            "vscode" => Ok(vec!["vscode".to_string()]),
             other => Err(anyhow::Error::new(
                 UserError::new(
                     "E_TARGET_UNSUPPORTED",
@@ -105,7 +106,7 @@ impl Engine {
                 )
                 .with_details(serde_json::json!({
                     "target": other,
-                    "allowed": ["all","codex","claude_code","cursor"],
+                    "allowed": ["all","codex","claude_code","cursor","vscode"],
                 })),
             )),
         }
@@ -451,6 +452,126 @@ impl Engine {
                 "cursor",
                 rules_dir.join(name),
                 out,
+                vec![m.id.clone()],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn render_vscode(
+        &self,
+        modules: &[&Module],
+        desired: &mut DesiredState,
+        warnings: &mut Vec<String>,
+        roots: &mut Vec<TargetRoot>,
+    ) -> anyhow::Result<()> {
+        let target_cfg = self
+            .manifest
+            .targets
+            .get("vscode")
+            .context("missing vscode target config")?;
+        let opts = &target_cfg.options;
+
+        let (_allow_user, allow_project) = scope_flags(&target_cfg.scope);
+        let write_instructions = allow_project && get_bool(opts, "write_instructions", true);
+        let write_prompts = allow_project && get_bool(opts, "write_prompts", true);
+
+        let github_dir = self.project.project_root.join(".github");
+        let prompts_dir = github_dir.join("prompts");
+
+        if write_instructions {
+            roots.push(TargetRoot {
+                target: "vscode".to_string(),
+                root: github_dir.clone(),
+                scan_extras: false,
+            });
+        }
+        if write_prompts {
+            roots.push(TargetRoot {
+                target: "vscode".to_string(),
+                root: prompts_dir.clone(),
+                scan_extras: true,
+            });
+        }
+
+        let mut instructions_parts: Vec<(String, String)> = Vec::new();
+        for m in modules
+            .iter()
+            .filter(|m| matches!(m.module_type, ModuleType::Instructions))
+            .filter(|m| m.targets.is_empty() || m.targets.iter().any(|t| t == "vscode"))
+        {
+            let (_tmp, materialized) = self.materialize_module(m, warnings)?;
+            let agents_path = materialized.join("AGENTS.md");
+            if agents_path.exists() {
+                instructions_parts.push((
+                    m.id.clone(),
+                    std::fs::read_to_string(&agents_path)
+                        .with_context(|| format!("read {}", agents_path.display()))?,
+                ));
+            }
+        }
+
+        if write_instructions && !instructions_parts.is_empty() {
+            let module_ids: Vec<String> = instructions_parts
+                .iter()
+                .map(|(id, _)| id.clone())
+                .collect();
+            let add_markers = instructions_parts.len() > 1;
+            let combined = if add_markers {
+                instructions_parts
+                    .into_iter()
+                    .map(|(module_id, text)| {
+                        crate::markers::format_module_section(&module_id, &text)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n\n---\n\n")
+            } else {
+                instructions_parts
+                    .into_iter()
+                    .map(|(_, text)| text)
+                    .collect::<Vec<_>>()
+                    .join("\n\n---\n\n")
+            };
+
+            insert_file(
+                desired,
+                "vscode",
+                github_dir.join("copilot-instructions.md"),
+                combined.into_bytes(),
+                module_ids,
+            )?;
+        }
+
+        for m in modules
+            .iter()
+            .filter(|m| matches!(m.module_type, ModuleType::Prompt))
+            .filter(|m| m.targets.is_empty() || m.targets.iter().any(|t| t == "vscode"))
+        {
+            if !write_prompts {
+                continue;
+            }
+            let (_tmp, materialized) = self.materialize_module(m, warnings)?;
+            let prompt_file = first_file(&materialized)?;
+            let name = prompt_file
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("prompt.md");
+
+            let name = if name.ends_with(".prompt.md") {
+                name.to_string()
+            } else if let Some(stem) = name.strip_suffix(".md") {
+                format!("{stem}.prompt.md")
+            } else {
+                format!("{name}.prompt.md")
+            };
+
+            let bytes = std::fs::read(&prompt_file)?;
+            insert_file(
+                desired,
+                "vscode",
+                prompts_dir.join(name),
+                bytes,
                 vec![m.id.clone()],
             )?;
         }

--- a/src/target_adapters.rs
+++ b/src/target_adapters.rs
@@ -18,6 +18,7 @@ pub trait TargetAdapter {
 struct CodexAdapter;
 struct ClaudeCodeAdapter;
 struct CursorAdapter;
+struct VscodeAdapter;
 
 impl TargetAdapter for CodexAdapter {
     fn id(&self) -> &'static str {
@@ -70,15 +71,34 @@ impl TargetAdapter for CursorAdapter {
     }
 }
 
+impl TargetAdapter for VscodeAdapter {
+    fn id(&self) -> &'static str {
+        "vscode"
+    }
+
+    fn render(
+        &self,
+        engine: &Engine,
+        modules: &[&crate::config::Module],
+        desired: &mut DesiredState,
+        warnings: &mut Vec<String>,
+        roots: &mut Vec<TargetRoot>,
+    ) -> anyhow::Result<()> {
+        engine.render_vscode(modules, desired, warnings, roots)
+    }
+}
+
 pub fn adapter_for(target: &str) -> Option<&'static dyn TargetAdapter> {
     static CODEX: CodexAdapter = CodexAdapter;
     static CLAUDE: ClaudeCodeAdapter = ClaudeCodeAdapter;
     static CURSOR: CursorAdapter = CursorAdapter;
+    static VSCODE: VscodeAdapter = VscodeAdapter;
 
     match target {
         "codex" => Some(&CODEX),
         "claude_code" => Some(&CLAUDE),
         "cursor" => Some(&CURSOR),
+        "vscode" => Some(&VSCODE),
         _ => None,
     }
 }


### PR DESCRIPTION
Closes #177.

Adds a built-in vscode target:
- Writes Copilot custom instructions to .github/copilot-instructions.md (aggregated when multiple modules).
- Writes prompt modules to .github/prompts/*.prompt.md (normalizes filenames to end with .prompt.md).
- Adds conformance coverage for vscode (deploy/status/rollback/delete-protection).
- Updates docs (SPEC/CLI/CONFIG/TARGETS + zh-CN) and adds an OpenSpec change record (openspec/changes/add-vscode-target).

Validation:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
- openspec validate add-vscode-target --strict --no-interactive
