### PR TITLE
chore(templates): add Codex skill frontmatter

### DIFF
--- a/templates/codex/skills/agentpack-operator/SKILL.md
+++ b/templates/codex/skills/agentpack-operator/SKILL.md
@@ -1,8 +1,14 @@
-<!-- agentpack_version: {{AGENTPACK_VERSION}} -->
+---
+name: agentpack-operator
+description: Operate agentpack safely (doctor/update/preview/diff/deploy/status/explain/evolve/rollback). Prefer --json.
+agentpack_version: "{{AGENTPACK_VERSION}}"
+metadata:
+  short-description: Operate Agentpack safely.
+---
 
 # agentpack-operator
 
-Operate Agentpack (plan/diff/deploy/status/rollback) safely and reproducibly.
+Operate Agentpack safely and reproducibly.
 
 ## What you can do
 - Self-check environment: `agentpack doctor --json`


### PR DESCRIPTION
Closes #183

- Add YAML frontmatter (name/description/agentpack_version/metadata) to `templates/codex/skills/agentpack-operator/SKILL.md`.
- Keeps `{{AGENTPACK_VERSION}}` placeholder for bootstrap substitution.

Tests
- `cargo test --all --locked`
