### PR TITLE
feat(status): add next_actions suggestions

### DIFF
--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -119,6 +119,7 @@ Tip:
 - `profile, targets`
 - `drift: DriftItem[]`
 - `summary: {modified, missing, extra}` (additive)
+- `next_actions?: string[]` (additive; suggested follow-up commands)
 
 `DriftItem`:
 - `target, path, path_posix`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -407,6 +407,7 @@ Notes:
 - if the target root contains `.agentpack.manifest.json`: compute drift (`modified` / `missing` / `extra`) based on the manifest
 - if there is no manifest (or the manifest has an unsupported `schema_version`): fall back to comparing desired outputs vs filesystem, and emit a warning
 - if installed operator assets (bootstrap) are missing or outdated: emit a warning and suggest running `agentpack bootstrap`
+- in `--json` mode, `data.next_actions` MAY be included (additive) to suggest common follow-up commands
 
 ### 4.8 `rollback`
 

--- a/openspec/changes/update-status-next-actions/proposal.md
+++ b/openspec/changes/update-status-next-actions/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add `next_actions` to `agentpack status` output
+
+## Why
+`agentpack status` already detects drift and operator-asset issues, but agents and humans still have to interpret warnings and decide the next command. Adding a structured `next_actions` list makes the output more actionable without breaking the stable `schema_version=1` JSON contract (additive-only change).
+
+## What Changes
+- Add an additive `data.next_actions` field to `agentpack status --json`.
+- Improve human `status` output by printing a “Next actions” section when applicable.
+- Update `agentpack schema` to document the new `status` data field.
+
+## Impact
+- Affected specs: `agentpack-cli`
+- Affected code: `src/cli/commands/status.rs`, `src/cli/commands/schema.rs`
+- Affected docs: `docs/SPEC.md`, `docs/JSON_API.md`
+- Affected tests: golden snapshots under `tests/golden/`

--- a/openspec/changes/update-status-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-status-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: status emits actionable next_actions (additive)
+When invoked as `agentpack status --json`, the system SHALL include an additive `data.next_actions` field that suggests follow-up commands.
+
+`data.next_actions` SHALL be a list of command strings (`string[]`), each describing a safe follow-up command the user/agent can run.
+
+This change MUST be additive for `schema_version=1` (no rename/remove of existing fields).
+
+#### Scenario: status suggests bootstrap when operator assets are missing
+- **GIVEN** operator assets are missing for the selected target/scope
+- **WHEN** the user runs `agentpack status --json`
+- **THEN** `data.next_actions[]` includes an action that runs `agentpack bootstrap`
+
+#### Scenario: status suggests deploy --apply when desired-state drift exists
+- **GIVEN** `status` detects `modified` or `missing` drift
+- **WHEN** the user runs `agentpack status --json`
+- **THEN** `data.next_actions[]` includes an action that runs `agentpack deploy --apply`
+
+## MODIFIED Requirements
+
+### Requirement: schema command documents JSON output contract
+The `agentpack schema --json` payload SHALL document `next_actions` as an additive `status` data field.
+
+#### Scenario: schema lists status next_actions field
+- **WHEN** the user runs `agentpack schema --json`
+- **THEN** the schema output documents `status` data fields including `next_actions`

--- a/openspec/changes/update-status-next-actions/tasks.md
+++ b/openspec/changes/update-status-next-actions/tasks.md
@@ -1,0 +1,15 @@
+## 1. Spec
+- [x] Add OpenSpec delta for `agentpack-cli` describing `status.data.next_actions` (additive) and scenarios.
+
+## 2. Implementation
+- [x] Add `next_actions` computation to `src/cli/commands/status.rs` (JSON + human).
+- [x] Update `src/cli/commands/schema.rs` to include `status.next_actions` in documented `data_fields`.
+
+## 3. Docs
+- [x] Update `docs/SPEC.md` `status` section to mention `next_actions` suggestions (additive).
+- [x] Update `docs/JSON_API.md` `status` section to document `data.next_actions`.
+
+## 4. Tests
+- [x] Update golden snapshots affected by the new field (`tests/golden/schema_json_data.json`, status JSON golden).
+- [x] Run `cargo fmt`, `cargo clippy`, `cargo test --all --locked`.
+- [x] Run `openspec validate update-status-next-actions --strict --no-interactive`.

--- a/src/cli/commands/schema.rs
+++ b/src/cli/commands/schema.rs
@@ -29,7 +29,7 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                     "plan": { "data_fields": ["profile","targets","changes","summary"] },
                     "diff": { "data_fields": ["profile","targets","changes","summary"] },
                     "preview": { "data_fields": ["profile","targets","plan","diff?"] },
-                    "status": { "data_fields": ["profile","targets","drift","summary"] }
+                    "status": { "data_fields": ["profile","targets","drift","summary","next_actions?"] }
                 },
                 "path_conventions": {
                     "native": "path-like fields use OS-native separators",

--- a/tests/golden/schema_json_data.json
+++ b/tests/golden/schema_json_data.json
@@ -37,7 +37,8 @@
         "profile",
         "targets",
         "drift",
-        "summary"
+        "summary",
+        "next_actions?"
       ]
     }
   },

--- a/tests/golden/status_json_data.json
+++ b/tests/golden/status_json_data.json
@@ -21,6 +21,12 @@
       "target": "codex"
     }
   ],
+  "next_actions": [
+    "agentpack --target codex bootstrap --scope user --yes --json",
+    "agentpack --target codex deploy --apply --yes --json",
+    "agentpack --target codex evolve propose --yes --json",
+    "agentpack --target codex preview --diff --json"
+  ],
   "profile": "default",
   "summary": {
     "extra": 1,


### PR DESCRIPTION
Closes #189

Implements OpenSpec change `update-status-next-actions`.

- Add additive `data.next_actions` to `agentpack status --json` (omitted when empty).
- Print a small “Next actions” section in human `status` output.
- Update `agentpack schema` to document `status.next_actions?`.
- Update docs + golden snapshots.

Tests
- `cargo test --all --locked`
- `openspec validate update-status-next-actions --strict --no-interactive`
