### PR TITLE
chore(claude): disable model invocation for mutating commands

### DIFF
--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -57,3 +57,10 @@ Bootstrap uses built-in templates (updated with releases):
 If you want full customization:
 - Package your own operator assets as normal modules (`skill`/`command`) managed via the manifest, or
 - Use overlays after bootstrap to override the written files (recommended if you want to store “your own variant” in the config repo).
+
+## 6) Claude Code mutating command safety
+
+Mutating Claude Code operator commands (e.g., `/ap-update`, `/ap-deploy`, `/ap-evolve`) are shipped with:
+- `disable-model-invocation: true`
+
+This reduces accidental programmatic invocation by the model while keeping explicit user-invoked actions available. Agentpack still enforces `--yes` for mutating operations in `--json` mode as the final guardrail.

--- a/docs/zh-CN/BOOTSTRAP.md
+++ b/docs/zh-CN/BOOTSTRAP.md
@@ -57,3 +57,10 @@ Bootstrap 使用内置模板（随版本更新）：
 如果你希望完全自定义：
 - 你可以把这些内容做成普通 module（`skill`/`command`），由 manifest 管理；
 - 或者在 bootstrap 后用 overlays 覆盖模板写入的文件（更推荐作为“你自己的版本”沉淀进 config repo）。
+
+## 6) Claude Code 写入类命令的安全性
+
+对于会产生写入的 Claude Code operator commands（例如 `/ap-update`、`/ap-deploy`、`/ap-evolve`），模板会带上：
+- `disable-model-invocation: true`
+
+这样可以降低模型在未显式请求时程序化触发写入操作的风险；同时 Agentpack 仍会在 `--json` 模式下对写入命令强制要求 `--yes`，作为最后一道护栏。

--- a/templates/claude/commands/ap-deploy.md
+++ b/templates/claude/commands/ap-deploy.md
@@ -1,5 +1,6 @@
 ---
 description: "Apply Agentpack changes for this repo (deploy --apply)"
+disable-model-invocation: true
 agentpack_version: "{{AGENTPACK_VERSION}}"
 allowed-tools:
   - Bash("agentpack deploy --apply --yes --json")

--- a/templates/claude/commands/ap-evolve.md
+++ b/templates/claude/commands/ap-evolve.md
@@ -1,5 +1,6 @@
 ---
 description: "Propose overlay updates from drift (evolve propose)"
+disable-model-invocation: true
 agentpack_version: "{{AGENTPACK_VERSION}}"
 allowed-tools:
   - Bash("agentpack evolve propose --dry-run --json")

--- a/templates/claude/commands/ap-update.md
+++ b/templates/claude/commands/ap-update.md
@@ -1,5 +1,6 @@
 ---
 description: "Update Agentpack sources (lock + fetch)"
+disable-model-invocation: true
 agentpack_version: "{{AGENTPACK_VERSION}}"
 allowed-tools:
   - Bash("agentpack update --yes --json")


### PR DESCRIPTION
Closes #194

- Add `disable-model-invocation: true` to mutating Claude Code operator command templates:
  - `templates/claude/commands/ap-update.md`
  - `templates/claude/commands/ap-deploy.md`
  - `templates/claude/commands/ap-evolve.md`
- Document the choice in `docs/BOOTSTRAP.md` (+ zh-CN).

Tests
- `cargo test --all --locked`
