### PR TITLE
docs: align target lists with v0.5.0

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10,7 +10,7 @@
 ## Next (candidates for v0.6+)
 
 ### Targets & ecosystem
-- Add new targets (Cursor / VS Code, etc.), gated by: TargetAdapter + conformance tests.
+- Add more targets (JetBrains / Zed / etc.), gated by: TargetAdapter + conformance tests.
 - For each new target: mapping rules, examples, migration notes.
 
 ### UX & ergonomics

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -65,8 +65,8 @@ Meaning:
 - The manifest config contains an unknown target.
 Retryable: yes.
 Recommended action:
-- `--target` must be `all|codex|claude_code`
-- Manifest targets must be built-in targets (currently `codex` and `claude_code`)
+- `--target` must be `all|codex|claude_code|cursor|vscode`
+- Manifest targets must be built-in targets (currently `codex`, `claude_code`, `cursor`, and `vscode`)
 
 ### E_DESIRED_STATE_CONFLICT
 Meaning: multiple modules produced different content for the same `(target, path)`. Agentpack refuses to silently overwrite.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -82,8 +82,8 @@ Symptom:
 - `--target` uses an unsupported value, or the manifest config contains an unknown target
 
 Fix:
-- `--target` must be `all|codex|claude_code`
-- Manifest targets must be `codex` and/or `claude_code`
+- `--target` must be `all|codex|claude_code|cursor|vscode`
+- Manifest targets must be one of: `codex|claude_code|cursor|vscode`
 
 ## 7) Overlay errors
 

--- a/docs/zh-CN/TROUBLESHOOTING.md
+++ b/docs/zh-CN/TROUBLESHOOTING.md
@@ -82,8 +82,8 @@
 - `--target` 传了不支持值，或 manifest 里 targets 配了未知 target
 
 解决：
-- `--target` 只能是 `all|codex|claude_code`
-- manifest targets 只能包含 `codex` 与 `claude_code`
+- `--target` 只能是 `all|codex|claude_code|cursor|vscode`
+- manifest targets 只能包含：`codex|claude_code|cursor|vscode`
 
 ## 7) Overlay 相关
 


### PR DESCRIPTION
Closes #201.

- Fix stale target lists in docs to match v0.5.0 (codex|claude_code|cursor|vscode|all).