### PR TITLE
docs: expand quickstart for multi-tool setups

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -4,6 +4,32 @@
 
 Goal: get from 0 → your first successful deploy, and understand the key safety guardrails (no accidental deletes/overwrites).
 
+## TL;DR: the daily loop
+
+The shortest path you’ll repeat day-to-day:
+
+1. `agentpack init`
+2. `agentpack add ...` (repeat as needed)
+3. `agentpack update`
+4. `agentpack preview --diff`
+5. `agentpack deploy --apply`
+6. `agentpack status`
+7. `agentpack rollback --to <snapshot_id>` (only when you need to undo)
+
+## Typical setups (multi-tool, multi-scope)
+
+Common “heavy user” setups (pick one to start):
+
+1) **Codex (user) + Claude Code (project)**
+- Use Codex for global/user-level assets (skills, prompts, global `AGENTS.md`).
+- Use Claude Code for repo/project-level assets (slash commands under `.claude/commands`).
+
+2) **Codex (user + project)**
+- Use Codex for both user assets and repo-local assets (repo skills, repo `AGENTS.md`).
+
+3) **VS Code (project) + Cursor (project)**
+- Use VS Code + Cursor for repo-local instructions/config, shared via git with your project.
+
 ## 0) Install
 
 - Rust users:
@@ -47,6 +73,7 @@ Optional: install operator assets (Codex operator skill + Claude commands):
 Common minimal recommendations:
 - Codex: write user skills, repo skills, global/repo `AGENTS.md`, and user prompts (prompts are user-scope only)
 - Claude Code: write repo commands + user commands (skills are off by default; enable if needed)
+- Cursor / VS Code: typically project-scope (commit the generated files into the repo when appropriate)
 
 Run a self-check:
 - `agentpack doctor`
@@ -125,6 +152,15 @@ When you want to customize an upstream module locally (and still be able to merg
 
 - Create/edit an overlay (default: global scope):
   - `agentpack overlay edit <module_id>`
+
+- Multi-machine setups:
+  - Use **machine overlays** for per-machine differences (e.g., different install locations, different tool homes):
+    - `agentpack overlay edit <module_id> --scope machine`
+  - The machine id defaults to auto-detection; override via `--machine <id>` when needed.
+
+- Multi-project setups:
+  - Use **project overlays** for per-project tweaks that shouldn’t affect other repos:
+    - `agentpack overlay edit <module_id> --scope project`
 
 - Recommended: create a sparse overlay (don’t copy the entire upstream tree; keep only changed files):
   - `agentpack overlay edit <module_id> --sparse`

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -4,6 +4,32 @@
 
 本指南的目标：从 0 到第一次成功部署（deploy），并理解最核心的安全边界（不误删、不误覆盖）。
 
+## TL;DR：日常循环（daily loop）
+
+你日常会重复的最短路径：
+
+1. `agentpack init`
+2. `agentpack add ...`（按需重复）
+3. `agentpack update`
+4. `agentpack preview --diff`
+5. `agentpack deploy --apply`
+6. `agentpack status`
+7. `agentpack rollback --to <snapshot_id>`（需要撤销时才用）
+
+## 典型组合（多工具、多 scope）
+
+常见的“重度用户”组合（先选一个开始即可）：
+
+1) **Codex（user）+ Claude Code（project）**
+- Codex 管理 user 级资产（skills、prompts、global `AGENTS.md`）
+- Claude Code 管理 repo/project 级资产（`.claude/commands` 下的 slash commands）
+
+2) **Codex（user + project）**
+- Codex 同时管理 user 与 repo 本地资产（repo skills、repo `AGENTS.md`）
+
+3) **VS Code（project）+ Cursor（project）**
+- VS Code + Cursor 管理 repo 本地的规则/指令等（通常跟随项目一起提交到 git）
+
 ## 0) 安装
 
 - Rust 用户：
@@ -47,6 +73,7 @@ Agentpack 默认在 `~/.agentpack/repo` 创建/读取配置仓库（可用 `AGEN
 常见最小建议：
 - Codex：写 user skills、repo skills、global/repo AGENTS.md、user prompts（prompts 只支持 user scope）
 - Claude Code：写 repo commands + user commands（skills 默认先关闭，按需开启）
+- Cursor / VS Code：通常用 project scope（必要时把生成文件提交到 repo）
 
 先跑一次自检：
 - `agentpack doctor`
@@ -125,6 +152,15 @@ Agentpack 默认在 `~/.agentpack/repo` 创建/读取配置仓库（可用 `AGEN
 
 - 创建并编辑 overlay（默认 global scope）：
   - `agentpack overlay edit <module_id>`
+
+- 多机器场景：
+  - 用 **machine overlay** 表达“只在某台机器生效”的差异（例如安装位置不同、工具 home 不同）：
+    - `agentpack overlay edit <module_id> --scope machine`
+  - machine id 默认自动检测；必要时用 `--machine <id>` 覆盖。
+
+- 多项目场景：
+  - 用 **project overlay** 表达“只对当前 repo 生效”的改动：
+    - `agentpack overlay edit <module_id> --scope project`
 
 - 更推荐的做法：创建稀疏 overlay（不复制整棵上游树，只放改动文件）：
   - `agentpack overlay edit <module_id> --sparse`


### PR DESCRIPTION
Closes #202.

- Add TL;DR daily loop command sequence.
- Document 3 common multi-tool/multi-scope setups.
- Add quick guidance on machine/project overlays.