### PR TITLE
feat(status): stabilize next_actions ordering

### DIFF
--- a/tests/golden/status_json_data.json
+++ b/tests/golden/status_json_data.json
@@ -23,9 +23,9 @@
   ],
   "next_actions": [
     "agentpack --target codex bootstrap --scope user --yes --json",
+    "agentpack --target codex preview --diff --json",
     "agentpack --target codex deploy --apply --yes --json",
-    "agentpack --target codex evolve propose --yes --json",
-    "agentpack --target codex preview --diff --json"
+    "agentpack --target codex evolve propose --yes --json"
   ],
   "profile": "default",
   "summary": {


### PR DESCRIPTION
Closes #204.

- Dedup + stable ordering by action priority (bootstrap → preview → deploy → evolve).
- Avoid suggesting evolve when no manifests exist (first-deploy scenario).
- Update golden snapshot for status --json.