### PR TITLE
feat(status): add --only drift filter

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -73,9 +73,10 @@ Common:
 
 ## status
 
-`agentpack status`
+`agentpack status [--only <missing|modified|extra>[,...]]`
 - Detects drift (missing/modified/extra) using `.agentpack.manifest.json`
 - If no manifests exist (first run or migration), it falls back to “desired vs FS” and emits a warning
+- `--only`: filter the reported drift list to a subset of kinds (repeatable or comma-separated)
 
 ## rollback
 

--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -119,6 +119,7 @@ Tip:
 - `profile, targets`
 - `drift: DriftItem[]`
 - `summary: {modified, missing, extra}` (additive)
+- `summary_total?: {modified, missing, extra}` (additive; present when `status --only` is used)
 - `next_actions?: string[]` (additive; suggested follow-up commands)
 
 `DriftItem`:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -403,10 +403,12 @@ Notes:
 
 ### 4.7 `status`
 
-`agentpack status`
+`agentpack status [--only <missing|modified|extra>[,...]]`
 - if the target root contains `.agentpack.manifest.json`: compute drift (`modified` / `missing` / `extra`) based on the manifest
 - if there is no manifest (or the manifest has an unsupported `schema_version`): fall back to comparing desired outputs vs filesystem, and emit a warning
 - if installed operator assets (bootstrap) are missing or outdated: emit a warning and suggest running `agentpack bootstrap`
+- `--only`: filters the drift list to the selected kinds (repeatable or comma-separated)
+- in `--json` mode, `data.summary_total` MAY be included when filtering is used (additive)
 - in `--json` mode, `data.next_actions` MAY be included (additive) to suggest common follow-up commands
 
 ### 4.8 `rollback`

--- a/docs/zh-CN/CLI.md
+++ b/docs/zh-CN/CLI.md
@@ -73,9 +73,10 @@ source spec：
 
 ## status
 
-`agentpack status`
+`agentpack status [--only <missing|modified|extra>[,...]]`
 - 基于 `.agentpack.manifest.json` 检测 drift（missing/modified/extra）
 - 若缺少 manifest（首次使用或旧版本迁移），会降级为“desired vs FS”的对比并给 warning
+- `--only`：只展示指定 kind 的 drift（可重复传参或用逗号分隔）
 
 ## rollback
 

--- a/openspec/changes/add-status-only-filter/.openspec.yaml
+++ b/openspec/changes/add-status-only-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-14

--- a/openspec/changes/add-status-only-filter/proposal.md
+++ b/openspec/changes/add-status-only-filter/proposal.md
@@ -1,0 +1,21 @@
+# Change: status --only drift filter
+
+## Why
+For heavy users, `agentpack status` drift can be large, and it’s common to want to focus on a subset quickly (e.g., only `missing` items).
+
+This change adds a small, script-friendly filter without changing existing default behavior.
+
+## What Changes
+- Add `agentpack status --only <missing|modified|extra>` (repeatable or comma-separated) to filter drift items.
+- In `--json` mode:
+  - keep `data.drift` but filter it when `--only` is set
+  - keep `data.summary` but have it reflect the filtered view
+  - add `data.summary_total` when filtering is used (additive-only)
+- Update docs and tests to lock the contract down.
+
+## Impact
+- Affected docs/specs: `docs/SPEC.md`, `docs/CLI.md` (+ zh-CN), `docs/JSON_API.md`, `openspec/specs/agentpack-cli/spec.md`.
+- Affected code: `src/cli/args.rs`, `src/cli/dispatch.rs`, `src/cli/commands/status.rs`, `src/cli/commands/schema.rs`.
+- Backward compatibility:
+  - no behavior change when `--only` is not provided
+  - additive-only JSON changes (`summary_total` only appears when filtering is used)

--- a/openspec/changes/add-status-only-filter/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-status-only-filter/specs/agentpack-cli/spec.md
@@ -1,0 +1,18 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: status supports --only drift filters
+The system SHALL support `agentpack status --only <missing|modified|extra>` to filter drift items by kind. The `--only` option SHALL accept repeated values and comma-separated lists.
+
+When invoked with `--json` and `--only` is set, the system SHALL include an additive `data.summary_total` capturing the unfiltered totals.
+
+#### Scenario: status --only missing filters drift and includes totals
+- **GIVEN** drift includes at least one `missing` item and at least one non-`missing` item
+- **WHEN** the user runs `agentpack status --only missing --json`
+- **THEN** every `data.drift[]` item has `kind = "missing"`
+- **AND** `data.summary.missing > 0`
+- **AND** `data.summary.modified = 0`
+- **AND** `data.summary.extra = 0`
+- **AND** `data.summary_total.missing > 0`
+- **AND** `data.summary_total.modified > 0` OR `data.summary_total.extra > 0`

--- a/openspec/changes/add-status-only-filter/tasks.md
+++ b/openspec/changes/add-status-only-filter/tasks.md
@@ -1,0 +1,21 @@
+## 1. Spec
+- [x] Update `docs/SPEC.md` to describe `status --only` and `summary_total` (additive).
+- [x] Update `docs/CLI.md` and `docs/zh-CN/CLI.md` to document the `--only` flag.
+- [x] Update `docs/JSON_API.md` to document `summary_total` behavior.
+
+## 2. Implementation
+- [x] Add `status --only` flag parsing (repeatable and comma-separated).
+- [x] Filter drift list and computed summary when `--only` is set.
+- [x] Add `summary_total` to `status --json` only when filtering is used.
+- [x] Update `schema --json` to document the additive `status.summary_total?` field.
+
+## 3. Tests
+- [x] Update `help --json` golden snapshot to include `status --only`.
+- [x] Update `schema --json` golden snapshot to include `status.summary_total?`.
+- [x] Add integration test covering `status --only` filtering + `summary_total`.
+
+## 4. Validation
+- [x] `openspec validate add-status-only-filter --strict --no-interactive`
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo test --all --locked`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -134,7 +134,11 @@ pub enum Commands {
     },
 
     /// Check drift between expected and deployed outputs
-    Status,
+    Status {
+        /// Filter drift items by kind (repeatable or comma-separated)
+        #[arg(long, value_enum, value_delimiter = ',')]
+        only: Vec<StatusOnly>,
+    },
 
     /// Check local environment and target paths
     Doctor {
@@ -290,6 +294,13 @@ pub enum ExplainCommands {
     Status,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum StatusOnly {
+    Missing,
+    Modified,
+    Extra,
+}
+
 #[derive(Debug, Clone, Copy, ValueEnum, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EvolveScope {
@@ -338,7 +349,7 @@ impl Cli {
             Commands::Plan => "plan",
             Commands::Diff => "diff",
             Commands::Deploy { .. } => "deploy",
-            Commands::Status => "status",
+            Commands::Status { .. } => "status",
             Commands::Doctor { .. } => "doctor",
             Commands::Remote { .. } => "remote",
             Commands::Sync { .. } => "sync",

--- a/src/cli/commands/schema.rs
+++ b/src/cli/commands/schema.rs
@@ -29,7 +29,7 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                     "plan": { "data_fields": ["profile","targets","changes","summary"] },
                     "diff": { "data_fields": ["profile","targets","changes","summary"] },
                     "preview": { "data_fields": ["profile","targets","plan","diff?"] },
-                    "status": { "data_fields": ["profile","targets","drift","summary","next_actions?"] }
+                    "status": { "data_fields": ["profile","targets","drift","summary","summary_total?","next_actions?"] }
                 },
                 "path_conventions": {
                     "native": "path-like fields use OS-native separators",

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -89,8 +89,8 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
         Commands::Deploy { apply, adopt } => {
             super::commands::deploy::run(&ctx, *apply, *adopt)?;
         }
-        Commands::Status => {
-            super::commands::status::run(&ctx)?;
+        Commands::Status { only } => {
+            super::commands::status::run(&ctx, only)?;
         }
         Commands::Doctor { fix } => {
             super::commands::doctor::run(&ctx, *fix)?;

--- a/tests/cli_status_only.rs
+++ b/tests/cli_status_only.rs
@@ -1,0 +1,169 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .env("AGENTPACK_MACHINE_ID", "test-machine")
+        .env("HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn git_in(dir: &Path, args: &[&str]) -> std::process::Output {
+    Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run git")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn write_manifest(repo_dir: &Path, codex_home: &Path) -> anyhow::Result<()> {
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{codex_home}'
+      write_agents_global: true
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: instructions:base
+    type: instructions
+    enabled: true
+    tags: ["base"]
+    targets: ["codex"]
+    source:
+      local_path:
+        path: modules/instructions/base
+
+  - id: prompt:hello
+    type: prompt
+    enabled: true
+    tags: ["base"]
+    targets: ["codex"]
+    source:
+      local_path:
+        path: modules/prompts/hello
+"#,
+        codex_home = codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest)
+        .map_err(|e| anyhow::anyhow!("write manifest: {e}"))?;
+    Ok(())
+}
+
+fn write_module(
+    repo_dir: &Path,
+    rel_dir: &str,
+    filename: &str,
+    content: &str,
+) -> anyhow::Result<()> {
+    let dir = repo_dir.join(rel_dir);
+    std::fs::create_dir_all(&dir).map_err(|e| anyhow::anyhow!("create module dir: {e}"))?;
+    std::fs::write(dir.join(filename), content)
+        .map_err(|e| anyhow::anyhow!("write module: {e}"))?;
+    Ok(())
+}
+
+fn init_workspace(tmp: &tempfile::TempDir) -> anyhow::Result<PathBuf> {
+    let workspace = tmp.path().join("workspace");
+    std::fs::create_dir_all(&workspace)?;
+
+    assert!(git_in(&workspace, &["init"]).status.success());
+    // Provide a stable origin for deterministic project_id derivation.
+    let _ = git_in(
+        &workspace,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/example.git",
+        ],
+    );
+
+    Ok(workspace)
+}
+
+#[test]
+fn status_only_filters_drift_and_includes_summary_total() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+    let workspace = init_workspace(&tmp)?;
+
+    let init = agentpack_in(home, &workspace, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    let codex_home = home.join("codex_home");
+    std::fs::create_dir_all(&codex_home)?;
+
+    write_module(
+        &repo_dir,
+        "modules/instructions/base",
+        "AGENTS.md",
+        "# Base instructions\n",
+    )?;
+    write_module(&repo_dir, "modules/prompts/hello", "hello.md", "Hello v1\n")?;
+    write_manifest(&repo_dir, &codex_home)?;
+
+    let deploy = agentpack_in(
+        home,
+        &workspace,
+        &["--target", "codex", "deploy", "--apply", "--yes", "--json"],
+    );
+    assert!(deploy.status.success());
+
+    // Create missing + modified + extra drift.
+    let _ = std::fs::remove_file(codex_home.join("AGENTS.md"));
+    std::fs::write(codex_home.join("prompts").join("hello.md"), "local drift\n")?;
+    std::fs::write(codex_home.join("prompts").join("extra.txt"), "extra\n")?;
+
+    let status = agentpack_in(
+        home,
+        &workspace,
+        &["--target", "codex", "status", "--only", "missing", "--json"],
+    );
+    assert!(status.status.success());
+
+    let v = parse_stdout_json(&status);
+    assert_eq!(v["command"], "status");
+    assert!(v["ok"].as_bool().unwrap_or(false));
+
+    let summary = &v["data"]["summary"];
+    assert_eq!(summary["modified"].as_u64().unwrap_or_default(), 0);
+    assert_eq!(summary["missing"].as_u64().unwrap_or_default(), 1);
+    assert_eq!(summary["extra"].as_u64().unwrap_or_default(), 0);
+
+    let total = &v["data"]["summary_total"];
+    assert_eq!(total["modified"].as_u64().unwrap_or_default(), 1);
+    assert_eq!(total["missing"].as_u64().unwrap_or_default(), 1);
+    assert_eq!(total["extra"].as_u64().unwrap_or_default(), 1);
+
+    let drift = v["data"]["drift"].as_array().expect("drift is array");
+    assert!(!drift.is_empty());
+    for item in drift {
+        assert_eq!(item["kind"], "missing");
+    }
+
+    Ok(())
+}

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -453,7 +453,14 @@
       "supports_json": true
     },
     {
-      "args": [],
+      "args": [
+        {
+          "id": "only",
+          "kind": "option",
+          "long": "only",
+          "required": false
+        }
+      ],
       "id": "status",
       "mutating": false,
       "path": [

--- a/tests/golden/schema_json_data.json
+++ b/tests/golden/schema_json_data.json
@@ -38,6 +38,7 @@
         "targets",
         "drift",
         "summary",
+        "summary_total?",
         "next_actions?"
       ]
     }


### PR DESCRIPTION
Closes #206.

## What
- Add `agentpack status --only <missing|modified|extra>` (repeatable or comma-separated) to filter drift kinds.
- In `--json` mode, when filtering is used:
  - `data.drift` is filtered
  - `data.summary` reflects the filtered view
  - `data.summary_total` is included to preserve unfiltered totals (additive-only)

## Spec
- OpenSpec change: `openspec/changes/add-status-only-filter/`

## Tests
- `cargo test --all --locked`
- New integration test: `tests/cli_status_only.rs`
- Updated golden snapshots: `tests/golden/help_json_data.json`, `tests/golden/schema_json_data.json`
