### PR TITLE
fix(bootstrap): make /ap-plan run plan

### DIFF
--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -62,7 +62,16 @@ If you want full customization:
 - Package your own operator assets as normal modules (`skill`/`command`) managed via the manifest, or
 - Use overlays after bootstrap to override the written files (recommended if you want to store “your own variant” in the config repo).
 
-## 6) Claude Code mutating command safety
+## 6) Claude Code `allowed-tools`
+
+Claude Code slash commands shipped by bootstrap include YAML frontmatter `allowed-tools` to restrict tool access.
+
+Design principles:
+- Prefer the minimal set of `Bash("...")` entries required by the command.
+- Keep commands single-purpose (e.g. `/ap-plan` only allows `agentpack plan --json`).
+- Mutating commands should include explicit approval semantics (`--yes --json`) and be guarded (see next section).
+
+## 7) Claude Code mutating command safety
 
 Mutating Claude Code operator commands (e.g., `/ap-update`, `/ap-deploy`, `/ap-evolve`) are shipped with:
 - `disable-model-invocation: true`

--- a/docs/zh-CN/BOOTSTRAP.md
+++ b/docs/zh-CN/BOOTSTRAP.md
@@ -62,7 +62,16 @@ Bootstrap 使用内置模板（随版本更新）：
 - 你可以把这些内容做成普通 module（`skill`/`command`），由 manifest 管理；
 - 或者在 bootstrap 后用 overlays 覆盖模板写入的文件（更推荐作为“你自己的版本”沉淀进 config repo）。
 
-## 6) Claude Code 写入类命令的安全性
+## 6) Claude Code `allowed-tools`
+
+Bootstrap 写入的 Claude Code slash commands 会在 YAML frontmatter 中声明 `allowed-tools`，用于限制工具权限。
+
+设计原则：
+ - 尽量只声明该命令所需的最小 `Bash("...")` 集合。
+- 保持命令单一职责（例如 `/ap-plan` 只允许 `agentpack plan --json`）。
+- 写入类命令应显式体现批准语义（`--yes --json`），并配合额外护栏（见下一节）。
+
+## 7) Claude Code 写入类命令的安全性
 
 对于会产生写入的 Claude Code operator commands（例如 `/ap-update`、`/ap-deploy`、`/ap-evolve`），模板会带上：
 - `disable-model-invocation: true`

--- a/templates/claude/commands/ap-plan.md
+++ b/templates/claude/commands/ap-plan.md
@@ -1,17 +1,13 @@
 ---
-description: "Preview Agentpack changes (preview) for this repo"
+description: "Show Agentpack plan for this repo"
 agentpack_version: "{{AGENTPACK_VERSION}}"
 allowed-tools:
-  - Bash("agentpack preview --json")
-  - Bash("agentpack preview --diff --json")
+  - Bash("agentpack plan --json")
 ---
 
-Run a safe preview of what Agentpack would change for the current project.
+Compute the plan (what would change) without writing files.
 
 !bash
-agentpack preview --json
+agentpack plan --json
 
-If you need per-file hashes:
-
-!bash
-agentpack preview --diff --json
+If you need diff details, run `/ap-diff` or `/ap-preview`.

--- a/tests/cli_init_bootstrap.rs
+++ b/tests/cli_init_bootstrap.rs
@@ -19,5 +19,20 @@ fn init_bootstrap_installs_operator_assets_into_config_repo() {
         repo.join(".codex/skills/agentpack-operator/SKILL.md")
             .exists()
     );
-    assert!(repo.join(".claude/commands/ap-plan.md").exists());
+
+    let ap_plan = repo.join(".claude/commands/ap-plan.md");
+    assert!(ap_plan.exists());
+    let ap_plan_text = std::fs::read_to_string(&ap_plan).expect("read ap-plan.md");
+    assert!(
+        ap_plan_text.contains("agentpack plan --json"),
+        "expected /ap-plan to run agentpack plan --json"
+    );
+    assert!(
+        ap_plan_text.contains("allowed-tools:"),
+        "missing allowed-tools"
+    );
+    assert!(
+        !ap_plan_text.contains("agentpack preview --json"),
+        "/ap-plan should not run preview"
+    );
 }


### PR DESCRIPTION
Closes #208.

## What
- Fix Claude `/ap-plan` template to run `agentpack plan --json` (it previously duplicated `/ap-preview`).
- Document Claude Code `allowed-tools` principles in `docs/BOOTSTRAP.md` (EN + zh-CN).
- Tighten bootstrap smoke test to assert `/ap-plan` actually runs `agentpack plan --json` and declares `allowed-tools`.

## Tests
- `cargo test --all --locked`
