### PR TITLE
docs(spec): define patch overlay format (OpenSpec)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -258,7 +258,15 @@ Where:
 Overlay uses a “file override” model:
 - overlay directory structure mirrors the upstream module
 - same-path files override upstream
-- (future) patch/diff overlays (e.g. 3-way merge based) are possible but not implemented yet
+
+Planned (not implemented yet): patch overlays
+- overlays may declare `overlay_kind: "dir" | "patch"` (default = `dir`)
+- `overlay_kind=patch` stores unified diff patch files under `.agentpack/patches/` and applies them to upstream UTF-8 text files during desired-state generation
+- a single overlay directory MUST NOT mix directory override files and patch artifacts (treat as configuration error)
+
+Patch layout:
+- `<overlay_dir>/.agentpack/patches/<relpath>.patch`
+  - `<relpath>` is the POSIX-style path within the upstream module root (no absolute paths; no `..`)
 
 ### 3.3 Overlay editing commands (see CLI)
 
@@ -297,6 +305,7 @@ Additional (v0.3+):
 ### 3.4 Overlay metadata (`.agentpack/`)
 
 - Overlay skeleton writes `<overlay_dir>/.agentpack/baseline.json` for overlay drift warnings (not deployed).
+- (planned) Patch overlays store patch files under `<overlay_dir>/.agentpack/patches/` (not deployed).
 - `.agentpack/` is a reserved metadata directory: it is never deployed to target roots and must not appear in module outputs.
 
 ## 4. CLI commands (v0.5.0)

--- a/openspec/changes/add-patch-overlays/.openspec.yaml
+++ b/openspec/changes/add-patch-overlays/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-14

--- a/openspec/changes/add-patch-overlays/proposal.md
+++ b/openspec/changes/add-patch-overlays/proposal.md
@@ -1,0 +1,25 @@
+# Change: Patch-based overlays (spec + format)
+
+## Why
+Directory overlays work well for “replace a whole file”, but for small edits they introduce churn and hard-to-review diffs (copying entire upstream files into overlays).
+
+Patch overlays aim to reduce overlay noise by storing only the textual diff against upstream, while preserving:
+- backward compatibility with existing directory overlays
+- explicit, deterministic overlay precedence
+- safe rebase semantics (3-way merge against a known baseline)
+
+## What Changes (this PR scope)
+This change defines the **format and contract** for patch overlays (no implementation yet):
+- Introduce an overlay kind indicator: `overlay_kind: "dir" | "patch"` (default = `dir` for existing overlays).
+- Define patch storage layout under `.agentpack/patches/` within an overlay directory.
+- Define applicability constraints (text-only, UTF-8) and non-goals (no binary patching).
+- Define behavior when both dir and patch artifacts are present (kind conflict).
+
+## Non-goals
+- Implement patch application in deploy/render (handled in follow-up items).
+- Implement patch overlay rebase (handled in follow-up items).
+- Add new CLI surface area (e.g. `overlay edit --kind patch` handled in follow-up).
+
+## Impact
+- Affected docs/specs: `docs/SPEC.md`, `openspec/specs/agentpack/spec.md`, `openspec/specs/agentpack-cli/spec.md`.
+- Backward compatibility: existing overlays without `overlay_kind` remain directory overlays.

--- a/openspec/changes/add-patch-overlays/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-patch-overlays/specs/agentpack-cli/spec.md
@@ -1,0 +1,18 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: patch overlay directory layout
+For `overlay_kind=patch`, the overlay directory SHALL store patches under:
+`<overlay_dir>/.agentpack/patches/<relpath>.patch`
+
+Where:
+- `<relpath>` is the POSIX-style relative path within the upstream module root (no absolute paths; no `..`).
+- Each patch file represents a unified diff against the corresponding upstream file.
+
+If both patch artifacts (`.agentpack/patches/...`) and directory override files are present in the same overlay directory, the system SHOULD treat it as a configuration error (kind conflict).
+
+#### Scenario: patch file path is derived from upstream relpath
+- **GIVEN** a module file at relative path `skills/foo/SKILL.md`
+- **WHEN** a patch overlay is used
+- **THEN** the patch is stored at `.agentpack/patches/skills/foo/SKILL.md.patch`

--- a/openspec/changes/add-patch-overlays/specs/agentpack/spec.md
+++ b/openspec/changes/add-patch-overlays/specs/agentpack/spec.md
@@ -1,0 +1,19 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: overlay_kind supports patch overlays
+The system SHALL support an overlay kind indicator with values:
+- `dir` (directory overlays; current behavior)
+- `patch` (patch-based overlays)
+
+If `overlay_kind` is not specified for an existing overlay, it SHALL be treated as `dir` (backward compatible).
+
+For `patch` overlays, the overlay directory SHALL NOT contain normal override files (except metadata under `.agentpack/`); instead it SHALL contain patch artifacts under `.agentpack/patches/`.
+
+Patch overlays SHALL be text-only: patches apply to UTF-8 files; binary/non-UTF8 patching is out of scope and MUST be rejected by the implementation.
+
+#### Scenario: existing overlay defaults to dir
+- **GIVEN** an overlay directory exists without an explicit `overlay_kind`
+- **WHEN** desired state is computed
+- **THEN** the overlay is treated as a directory overlay (`dir`)

--- a/openspec/changes/add-patch-overlays/tasks.md
+++ b/openspec/changes/add-patch-overlays/tasks.md
@@ -1,0 +1,8 @@
+## 1. Spec (OpenSpec)
+- [x] Add patch overlay requirements to `openspec/specs/agentpack/spec.md` and `openspec/specs/agentpack-cli/spec.md` (delta).
+
+## 2. Docs (implementation contract)
+- [x] Update `docs/SPEC.md` overlays section to define patch overlay layout and precedence rules.
+
+## 3. Validation
+- [x] `openspec validate add-patch-overlays --strict --no-interactive`


### PR DESCRIPTION
Closes #210.

## What
- Adds OpenSpec change `add-patch-overlays` defining patch overlay format and constraints.
- Updates `docs/SPEC.md` overlay section with a **planned (not implemented yet)** patch overlay layout.

## Notes
- This PR is spec-only. Implementation will follow in #211/#212/#213.

## Validation
- `openspec validate add-patch-overlays --strict --no-interactive`
