### PR TITLE
feat(overlay): apply patch overlays

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -97,6 +97,14 @@ Retryable: yes (after resolving conflicts).
 Recommended action: open the conflict-marked files under the overlay directory, resolve, then re-run `agentpack overlay rebase` (or commit overlay changes directly).
 Details: includes `{conflicts, summary, overlay_dir, scope, ...}`.
 
+### E_OVERLAY_PATCH_APPLY_FAILED
+Meaning: patch overlay application failed during desired-state generation (the patch could not be applied cleanly).
+Retryable: yes (after regenerating/fixing the patch).
+Recommended action:
+- regenerate the patch against current upstream (or lower overlays) content, or
+- switch to a directory overlay for that file.
+Details: includes `{module_id, scope, overlay_dir, patch_file, relpath, stderr, ...}`.
+
 ## Non-stable / fallback error codes
 
 ### E_UNEXPECTED

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -259,10 +259,15 @@ Overlay uses a “file override” model:
 - overlay directory structure mirrors the upstream module
 - same-path files override upstream
 
-Planned (not implemented yet): patch overlays
+Patch overlays
 - overlays may declare `overlay_kind: "dir" | "patch"` (default = `dir`)
+  - `overlay_kind` is stored at `<overlay_dir>/.agentpack/overlay.json`
+  - format: `{ "overlay_kind": "dir" | "patch" }`
 - `overlay_kind=patch` stores unified diff patch files under `.agentpack/patches/` and applies them to upstream UTF-8 text files during desired-state generation
+  - patch overlays only support UTF-8 text files
+  - each `.patch` MUST represent a single-file unified diff, and its header path MUST match the patch filename-derived `<relpath>`
 - a single overlay directory MUST NOT mix directory override files and patch artifacts (treat as configuration error)
+- on patch apply failure, commands return stable error code `E_OVERLAY_PATCH_APPLY_FAILED`
 
 Patch layout:
 - `<overlay_dir>/.agentpack/patches/<relpath>.patch`
@@ -305,7 +310,8 @@ Additional (v0.3+):
 ### 3.4 Overlay metadata (`.agentpack/`)
 
 - Overlay skeleton writes `<overlay_dir>/.agentpack/baseline.json` for overlay drift warnings (not deployed).
-- (planned) Patch overlays store patch files under `<overlay_dir>/.agentpack/patches/` (not deployed).
+- Overlay skeleton writes `<overlay_dir>/.agentpack/overlay.json` for `overlay_kind` (not deployed).
+- Patch overlays store patch files under `<overlay_dir>/.agentpack/patches/` (not deployed).
 - `.agentpack/` is a reserved metadata directory: it is never deployed to target roots and must not appear in module outputs.
 
 ## 4. CLI commands (v0.5.0)

--- a/openspec/changes/add-patch-overlays/proposal.md
+++ b/openspec/changes/add-patch-overlays/proposal.md
@@ -8,15 +8,15 @@ Patch overlays aim to reduce overlay noise by storing only the textual diff agai
 - explicit, deterministic overlay precedence
 - safe rebase semantics (3-way merge against a known baseline)
 
-## What Changes (this PR scope)
-This change defines the **format and contract** for patch overlays (no implementation yet):
+## What Changes (this change scope)
+This change defines the **format and contract** for patch overlays and implements patch application during desired-state generation:
 - Introduce an overlay kind indicator: `overlay_kind: "dir" | "patch"` (default = `dir` for existing overlays).
 - Define patch storage layout under `.agentpack/patches/` within an overlay directory.
 - Define applicability constraints (text-only, UTF-8) and non-goals (no binary patching).
 - Define behavior when both dir and patch artifacts are present (kind conflict).
+- Apply patch overlays during desired-state generation (plan/diff/deploy), returning a stable error code on failure.
 
 ## Non-goals
-- Implement patch application in deploy/render (handled in follow-up items).
 - Implement patch overlay rebase (handled in follow-up items).
 - Add new CLI surface area (e.g. `overlay edit --kind patch` handled in follow-up).
 

--- a/openspec/changes/add-patch-overlays/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-patch-overlays/specs/agentpack-cli/spec.md
@@ -2,6 +2,19 @@
 
 ## ADDED Requirements
 
+### Requirement: patch overlays declare overlay_kind via metadata
+For patch overlays, the overlay directory SHALL declare `overlay_kind=patch` via JSON metadata at:
+`<overlay_dir>/.agentpack/overlay.json`
+
+With format:
+`{ "overlay_kind": "dir" | "patch" }`
+
+#### Scenario: overlay_kind is read from overlay.json
+- **GIVEN** an overlay directory exists
+- **AND** `<overlay_dir>/.agentpack/overlay.json` contains `{ "overlay_kind": "patch" }`
+- **WHEN** the user runs `agentpack plan`
+- **THEN** patch overlay application is enabled for that overlay directory
+
 ### Requirement: patch overlay directory layout
 For `overlay_kind=patch`, the overlay directory SHALL store patches under:
 `<overlay_dir>/.agentpack/patches/<relpath>.patch`
@@ -16,3 +29,13 @@ If both patch artifacts (`.agentpack/patches/...`) and directory override files 
 - **GIVEN** a module file at relative path `skills/foo/SKILL.md`
 - **WHEN** a patch overlay is used
 - **THEN** the patch is stored at `.agentpack/patches/skills/foo/SKILL.md.patch`
+
+### Requirement: patch overlay apply failures return stable error code
+When a patch overlay cannot be applied cleanly during desired-state generation, the CLI MUST fail with stable error code `E_OVERLAY_PATCH_APPLY_FAILED`.
+
+#### Scenario: patch does not apply
+- **GIVEN** an overlay directory with `overlay_kind=patch`
+- **AND** the overlay contains a patch file that does not apply cleanly to the upstream file
+- **WHEN** the user runs `agentpack plan --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_OVERLAY_PATCH_APPLY_FAILED`

--- a/openspec/changes/add-patch-overlays/specs/agentpack/spec.md
+++ b/openspec/changes/add-patch-overlays/specs/agentpack/spec.md
@@ -7,6 +7,12 @@ The system SHALL support an overlay kind indicator with values:
 - `dir` (directory overlays; current behavior)
 - `patch` (patch-based overlays)
 
+The overlay kind indicator SHALL be stored as JSON metadata at:
+`<overlay_dir>/.agentpack/overlay.json`
+
+With format:
+`{ "overlay_kind": "dir" | "patch" }`
+
 If `overlay_kind` is not specified for an existing overlay, it SHALL be treated as `dir` (backward compatible).
 
 For `patch` overlays, the overlay directory SHALL NOT contain normal override files (except metadata under `.agentpack/`); instead it SHALL contain patch artifacts under `.agentpack/patches/`.

--- a/openspec/changes/add-patch-overlays/tasks.md
+++ b/openspec/changes/add-patch-overlays/tasks.md
@@ -6,3 +6,12 @@
 
 ## 3. Validation
 - [x] `openspec validate add-patch-overlays --strict --no-interactive`
+
+## 4. Implementation (patch apply)
+- [x] Apply `.agentpack/patches/<relpath>.patch` during desired-state generation when `overlay_kind=patch`.
+- [x] Reject binary/non-UTF8 patch overlays (text-only).
+- [x] Return stable error code `E_OVERLAY_PATCH_APPLY_FAILED` when patch application fails.
+- [x] Add integration tests for patch overlay application + failure mode.
+
+## 5. Archive (after deploy)
+- [ ] Archive the change via `openspec archive add-patch-overlays --yes` in a separate PR after the implementation is merged.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -681,8 +681,21 @@ impl Engine {
             &module.id, "project", &upstream, &project,
         )?);
 
-        let overlays: [&Path; 3] = [&global, &machine, &project];
-        crate::overlay::compose_module_tree(&upstream, &overlays, &dst)?;
+        let overlays = [
+            crate::overlay::OverlayLayer {
+                scope: "global",
+                dir: &global,
+            },
+            crate::overlay::OverlayLayer {
+                scope: "machine",
+                dir: &machine,
+            },
+            crate::overlay::OverlayLayer {
+                scope: "project",
+                dir: &project,
+            },
+        ];
+        crate::overlay::compose_module_tree(&module.id, &upstream, &overlays, &dst)?;
         validate_materialized_module(&module.module_type, &module.id, &dst)
             .context("validate module")?;
 

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use anyhow::Context as _;
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
+use walkdir::WalkDir;
 
 use crate::config::GitSource;
 use crate::config::{Manifest, Module, SourceKind};
@@ -20,6 +21,29 @@ use crate::user_error::UserError;
 pub struct OverlaySkeleton {
     pub dir: PathBuf,
     pub created: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct OverlayLayer<'a> {
+    pub scope: &'a str,
+    pub dir: &'a Path,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum OverlayKind {
+    Dir,
+    Patch,
+}
+
+fn default_overlay_kind() -> OverlayKind {
+    OverlayKind::Dir
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OverlayMeta {
+    #[serde(default = "default_overlay_kind")]
+    overlay_kind: OverlayKind,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -101,6 +125,9 @@ pub fn materialize_overlay_from_upstream(
     if !overlay_module_id_path(overlay_dir).exists() {
         write_overlay_module_id(module_id, overlay_dir)?;
     }
+    if !overlay_meta_path(overlay_dir).exists() {
+        write_overlay_meta_default_dir(overlay_dir)?;
+    }
 
     Ok(())
 }
@@ -141,6 +168,9 @@ fn ensure_overlay_skeleton_impl(
     if !overlay_module_id_path(overlay_dir).exists() {
         write_overlay_module_id(module_id, overlay_dir)?;
     }
+    if !overlay_meta_path(overlay_dir).exists() {
+        write_overlay_meta_default_dir(overlay_dir)?;
+    }
 
     Ok(OverlaySkeleton {
         dir: overlay_dir.to_path_buf(),
@@ -149,19 +179,404 @@ fn ensure_overlay_skeleton_impl(
 }
 
 pub fn compose_module_tree(
+    module_id: &str,
     upstream_root: &Path,
-    overlays: &[&Path],
+    overlays: &[OverlayLayer<'_>],
     out_dir: &Path,
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(out_dir).context("create module out dir")?;
     copy_tree(upstream_root, out_dir).context("copy upstream")?;
     for overlay in overlays {
-        if overlay.exists() {
-            copy_tree(overlay, out_dir)
-                .with_context(|| format!("apply overlay {}", overlay.display()))?;
+        if !overlay.dir.exists() {
+            continue;
+        }
+
+        let meta = read_overlay_meta(overlay.dir)?;
+        let override_files = list_files(overlay.dir)
+            .with_context(|| format!("list overlay files {}", overlay.dir.display()))?;
+        let patch_files = list_patch_files(overlay.dir)
+            .with_context(|| format!("list patch files {}", overlay.dir.display()))?;
+
+        let has_overrides = !override_files.is_empty();
+        let has_patches = !patch_files.is_empty();
+
+        if has_overrides && has_patches {
+            return Err(anyhow::Error::new(
+                UserError::new(
+                    "E_CONFIG_INVALID",
+                    format!(
+                        "overlay kind conflict for module {module_id} ({scope}): cannot mix directory override files and patch artifacts",
+                        scope = overlay.scope
+                    ),
+                )
+                .with_details(serde_json::json!({
+                    "module_id": module_id,
+                    "scope": overlay.scope,
+                    "overlay_dir": overlay.dir.to_string_lossy(),
+                    "override_files": override_files.iter().map(|p| path_relative_posix(overlay.dir, p)).collect::<Vec<_>>(),
+                    "patch_files": patch_files.iter().map(|p| path_relative_posix(overlay.dir, p)).collect::<Vec<_>>(),
+                    "hint": "use a single overlay kind per overlay directory (dir OR patch)",
+                })),
+            ));
+        }
+
+        match meta.overlay_kind {
+            OverlayKind::Dir => {
+                if has_patches {
+                    return Err(anyhow::Error::new(
+                        UserError::new(
+                            "E_CONFIG_INVALID",
+                            format!(
+                                "overlay_kind=dir but patch artifacts exist for module {module_id} ({scope})",
+                                scope = overlay.scope
+                            ),
+                        )
+                        .with_details(serde_json::json!({
+                            "module_id": module_id,
+                            "scope": overlay.scope,
+                            "overlay_dir": overlay.dir.to_string_lossy(),
+                            "hint": "set overlay_kind=patch (in .agentpack/overlay.json) or remove .agentpack/patches",
+                        })),
+                    ));
+                }
+
+                copy_tree(overlay.dir, out_dir)
+                    .with_context(|| format!("apply overlay {}", overlay.dir.display()))?;
+            }
+            OverlayKind::Patch => {
+                if has_overrides {
+                    return Err(anyhow::Error::new(
+                        UserError::new(
+                            "E_CONFIG_INVALID",
+                            format!(
+                                "overlay_kind=patch but directory override files exist for module {module_id} ({scope})",
+                                scope = overlay.scope
+                            ),
+                        )
+                        .with_details(serde_json::json!({
+                            "module_id": module_id,
+                            "scope": overlay.scope,
+                            "overlay_dir": overlay.dir.to_string_lossy(),
+                            "hint": "move edits into .agentpack/patches/*.patch or set overlay_kind=dir",
+                        })),
+                    ));
+                }
+
+                apply_patch_overlays(module_id, overlay.scope, overlay.dir, out_dir, &patch_files)?;
+            }
         }
     }
     Ok(())
+}
+
+fn list_patch_files(overlay_dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let patches_dir = overlay_dir.join(".agentpack").join("patches");
+    if !patches_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut out = Vec::new();
+    for entry in WalkDir::new(&patches_dir).follow_links(false) {
+        let entry = entry?;
+        if entry.file_type().is_dir() {
+            continue;
+        }
+        if entry
+            .path()
+            .extension()
+            .and_then(|s| s.to_str())
+            .is_some_and(|s| s.eq_ignore_ascii_case("patch"))
+        {
+            out.push(entry.into_path());
+        }
+    }
+
+    out.sort();
+    Ok(out)
+}
+
+fn apply_patch_overlays(
+    module_id: &str,
+    scope: &str,
+    overlay_dir: &Path,
+    out_dir: &Path,
+    patch_files: &[PathBuf],
+) -> anyhow::Result<()> {
+    let patches_root = overlay_dir.join(".agentpack").join("patches");
+
+    for patch_file in patch_files {
+        let rel_patch = patch_file.strip_prefix(&patches_root).unwrap_or(patch_file);
+        let rel_patch_posix = rel_patch.to_string_lossy().replace('\\', "/");
+        let Some(rel_target) = rel_patch_posix.strip_suffix(".patch") else {
+            continue;
+        };
+
+        if !validate_posix_relpath(rel_target) {
+            return Err(anyhow::Error::new(
+                UserError::new(
+                    "E_CONFIG_INVALID",
+                    format!(
+                        "invalid patch relpath for module {module_id} ({scope}): {rel_target}",
+                        scope = scope
+                    ),
+                )
+                .with_details(serde_json::json!({
+                    "module_id": module_id,
+                    "scope": scope,
+                    "overlay_dir": overlay_dir.to_string_lossy(),
+                    "patch_file": patch_file.to_string_lossy(),
+                    "relpath": rel_target,
+                    "hint": "patch filenames must map to a safe relpath under the upstream module root",
+                })),
+            ));
+        }
+
+        let target_path = join_posix(out_dir, rel_target);
+        let target_bytes = std::fs::read(&target_path).map_err(|err| {
+            anyhow::Error::new(
+                UserError::new(
+                    "E_CONFIG_INVALID",
+                    format!(
+                        "patch target is missing for module {module_id} ({scope}): {rel_target}",
+                        scope = scope
+                    ),
+                )
+                .with_details(serde_json::json!({
+                    "module_id": module_id,
+                    "scope": scope,
+                    "overlay_dir": overlay_dir.to_string_lossy(),
+                    "patch_file": patch_file.to_string_lossy(),
+                    "relpath": rel_target,
+                    "target_path": target_path.to_string_lossy(),
+                    "cause": err.to_string(),
+                    "hint": "patch overlays currently only support patching existing upstream files",
+                })),
+            )
+        })?;
+
+        if std::str::from_utf8(&target_bytes).is_err() {
+            return Err(anyhow::Error::new(
+                UserError::new(
+                    "E_CONFIG_INVALID",
+                    format!(
+                        "patch overlays only support UTF-8 text files: {rel_target} (module {module_id}, {scope})",
+                        scope = scope
+                    ),
+                )
+                .with_details(serde_json::json!({
+                    "module_id": module_id,
+                    "scope": scope,
+                    "relpath": rel_target,
+                    "target_path": target_path.to_string_lossy(),
+                    "hint": "use a directory overlay for binary/non-UTF8 files",
+                })),
+            ));
+        }
+
+        let patch_bytes = std::fs::read(patch_file)
+            .with_context(|| format!("read patch {}", patch_file.display()))?;
+        let patch_text = std::str::from_utf8(&patch_bytes).map_err(|err| {
+            anyhow::Error::new(
+                UserError::new(
+                    "E_CONFIG_INVALID",
+                    format!(
+                        "patch file is not UTF-8 for module {module_id} ({scope}): {}",
+                        patch_file.display(),
+                        scope = scope
+                    ),
+                )
+                .with_details(serde_json::json!({
+                    "module_id": module_id,
+                    "scope": scope,
+                    "patch_file": patch_file.to_string_lossy(),
+                    "error": err.to_string(),
+                })),
+            )
+        })?;
+
+        validate_patch_text_matches_file(
+            module_id,
+            scope,
+            overlay_dir,
+            patch_file,
+            patch_text,
+            rel_target,
+        )?;
+
+        let out = Command::new("git")
+            .arg("apply")
+            .arg("--whitespace=nowarn")
+            .arg(patch_file)
+            .current_dir(out_dir)
+            .output()
+            .context("git apply")?;
+
+        if !out.status.success() {
+            return Err(anyhow::Error::new(
+                UserError::new(
+                    "E_OVERLAY_PATCH_APPLY_FAILED",
+                    format!(
+                        "failed to apply patch overlay for module {module_id} ({scope}): {rel_target}",
+                        scope = scope
+                    ),
+                )
+                .with_details(serde_json::json!({
+                    "module_id": module_id,
+                    "scope": scope,
+                    "overlay_dir": overlay_dir.to_string_lossy(),
+                    "patch_file": patch_file.to_string_lossy(),
+                    "relpath": rel_target,
+                    "stderr": String::from_utf8_lossy(&out.stderr),
+                    "hint": "regenerate the patch against the current upstream (or lower overlays) content",
+                })),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_patch_text_matches_file(
+    module_id: &str,
+    scope: &str,
+    overlay_dir: &Path,
+    patch_file: &Path,
+    patch_text: &str,
+    expected_relpath: &str,
+) -> anyhow::Result<()> {
+    if patch_text.contains("GIT binary patch") {
+        return Err(anyhow::Error::new(
+            UserError::new(
+                "E_CONFIG_INVALID",
+                format!(
+                    "patch overlays do not support binary patches (module {module_id}, {scope})",
+                    scope = scope
+                ),
+            )
+            .with_details(serde_json::json!({
+                "module_id": module_id,
+                "scope": scope,
+                "overlay_dir": overlay_dir.to_string_lossy(),
+                "patch_file": patch_file.to_string_lossy(),
+                "relpath": expected_relpath,
+                "hint": "use a directory overlay for binary files",
+            })),
+        ));
+    }
+
+    let mut old_lines = Vec::new();
+    let mut new_lines = Vec::new();
+    for line in patch_text.lines() {
+        if let Some(rest) = line.strip_prefix("--- ") {
+            old_lines.push(rest);
+        } else if let Some(rest) = line.strip_prefix("+++ ") {
+            new_lines.push(rest);
+        }
+    }
+
+    if old_lines.len() != 1 || new_lines.len() != 1 {
+        return Err(anyhow::Error::new(
+            UserError::new(
+                "E_CONFIG_INVALID",
+                format!(
+                    "invalid patch file (expected a single unified diff) for module {module_id} ({scope})",
+                    scope = scope
+                ),
+            )
+            .with_details(serde_json::json!({
+                "module_id": module_id,
+                "scope": scope,
+                "overlay_dir": overlay_dir.to_string_lossy(),
+                "patch_file": patch_file.to_string_lossy(),
+                "relpath": expected_relpath,
+                "hint": "generate patches using `git diff --no-index -- <upstream-file> <edited-file>` and store the output in .agentpack/patches/<relpath>.patch",
+            })),
+        ));
+    }
+
+    let old_path = parse_patch_header_path(old_lines[0]);
+    let new_path = parse_patch_header_path(new_lines[0]);
+    if old_path == "/dev/null" || new_path == "/dev/null" {
+        return Err(anyhow::Error::new(
+            UserError::new(
+                "E_CONFIG_INVALID",
+                format!(
+                    "patch overlays do not currently support file create/delete (module {module_id}, {scope})",
+                    scope = scope
+                ),
+            )
+            .with_details(serde_json::json!({
+                "module_id": module_id,
+                "scope": scope,
+                "overlay_dir": overlay_dir.to_string_lossy(),
+                "patch_file": patch_file.to_string_lossy(),
+                "relpath": expected_relpath,
+                "hint": "use a directory overlay for create/delete operations",
+            })),
+        ));
+    }
+
+    let old_norm = strip_ab_prefix(old_path);
+    let new_norm = strip_ab_prefix(new_path);
+    if old_norm != expected_relpath || new_norm != expected_relpath {
+        return Err(anyhow::Error::new(
+            UserError::new(
+                "E_CONFIG_INVALID",
+                format!(
+                    "patch file paths do not match filename-derived relpath for module {module_id} ({scope})",
+                    scope = scope
+                ),
+            )
+            .with_details(serde_json::json!({
+                "module_id": module_id,
+                "scope": scope,
+                "overlay_dir": overlay_dir.to_string_lossy(),
+                "patch_file": patch_file.to_string_lossy(),
+                "expected_relpath": expected_relpath,
+                "patch_old_path": old_norm,
+                "patch_new_path": new_norm,
+                "hint": "ensure the patch header uses the same path as the patch file name (e.g. --- a/<relpath> / +++ b/<relpath>)",
+            })),
+        ));
+    }
+
+    Ok(())
+}
+
+fn parse_patch_header_path(value: &str) -> &str {
+    // diff -u may append timestamps after a tab; git diff usually does not.
+    value.split_whitespace().next().unwrap_or("")
+}
+
+fn strip_ab_prefix(path: &str) -> String {
+    path.strip_prefix("a/")
+        .or_else(|| path.strip_prefix("b/"))
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn validate_posix_relpath(relpath: &str) -> bool {
+    if relpath.is_empty() || relpath.starts_with('/') {
+        return false;
+    }
+    relpath
+        .split('/')
+        .all(|seg| !seg.is_empty() && seg != "." && seg != "..")
+}
+
+fn join_posix(root: &Path, rel_posix: &str) -> PathBuf {
+    let mut out = root.to_path_buf();
+    for part in rel_posix.split('/') {
+        out.push(part);
+    }
+    out
+}
+
+fn path_relative_posix(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
 }
 
 pub fn resolve_upstream_module_root(
@@ -769,6 +1184,10 @@ fn overlay_module_id_path(overlay_dir: &Path) -> PathBuf {
     overlay_dir.join(".agentpack").join("module_id")
 }
 
+fn overlay_meta_path(overlay_dir: &Path) -> PathBuf {
+    overlay_dir.join(".agentpack").join("overlay.json")
+}
+
 fn write_overlay_module_id(module_id: &str, overlay_dir: &Path) -> anyhow::Result<()> {
     let meta_dir = overlay_dir.join(".agentpack");
     std::fs::create_dir_all(&meta_dir).context("create overlay metadata dir")?;
@@ -780,6 +1199,54 @@ fn write_overlay_module_id(module_id: &str, overlay_dir: &Path) -> anyhow::Resul
     }
     write_atomic(&path, content.as_bytes()).with_context(|| format!("write {}", path.display()))?;
     Ok(())
+}
+
+fn write_overlay_meta_default_dir(overlay_dir: &Path) -> anyhow::Result<()> {
+    let meta_dir = overlay_dir.join(".agentpack");
+    std::fs::create_dir_all(&meta_dir).context("create overlay metadata dir")?;
+
+    let path = overlay_meta_path(overlay_dir);
+    let meta = OverlayMeta {
+        overlay_kind: OverlayKind::Dir,
+    };
+
+    let mut out = serde_json::to_string_pretty(&meta).context("serialize overlay meta")?;
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+
+    write_atomic(&path, out.as_bytes()).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+fn read_overlay_meta(overlay_dir: &Path) -> anyhow::Result<OverlayMeta> {
+    let path = overlay_meta_path(overlay_dir);
+    if !path.exists() {
+        return Ok(OverlayMeta {
+            overlay_kind: OverlayKind::Dir,
+        });
+    }
+
+    let raw = std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    let meta: OverlayMeta = serde_json::from_str(&raw).map_err(|err| {
+        anyhow::Error::new(
+            UserError::new(
+                "E_CONFIG_INVALID",
+                format!(
+                    "invalid overlay metadata (expected JSON) at {}: {}",
+                    path.display(),
+                    err
+                ),
+            )
+            .with_details(serde_json::json!({
+                "overlay_dir": overlay_dir.to_string_lossy(),
+                "meta_path": path.to_string_lossy(),
+                "hint": "delete the file to fall back to overlay_kind=dir, or fix it to include {\"overlay_kind\": \"dir\"|\"patch\"}",
+            })),
+        )
+    })?;
+
+    Ok(meta)
 }
 
 fn write_overlay_baseline(

--- a/tests/cli_patch_overlays_apply.rs
+++ b/tests/cli_patch_overlays_apply.rs
@@ -1,0 +1,200 @@
+use std::path::Path;
+use std::process::Command;
+
+use agentpack::ids::module_fs_key;
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .env("HOME", home)
+        .env("EDITOR", "")
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn init_git(dir: &Path) {
+    assert!(
+        Command::new("git")
+            .current_dir(dir)
+            .args(["init"])
+            .output()
+            .expect("git init")
+            .status
+            .success()
+    );
+}
+
+#[test]
+fn patch_overlays_apply_during_deploy() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    let workspace = home.join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    init_git(&workspace);
+
+    let init = agentpack_in(home, &workspace, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    let skill_dir = repo_dir.join("modules/skills/my-skill");
+    std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: my-skill\ndescription: Example Skill for tests\n---\n\n# my-skill\n",
+    )
+    .expect("write SKILL.md");
+
+    std::fs::write(
+        repo_dir.join("agentpack.yaml"),
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  claude_code:
+    mode: files
+    scope: project
+    options:
+      write_repo_commands: false
+      write_user_commands: false
+      write_repo_skills: true
+      write_user_skills: false
+
+modules:
+  - id: skill:my-skill
+    type: skill
+    tags: ["base"]
+    targets: ["claude_code"]
+    source:
+      local_path:
+        path: "modules/skills/my-skill"
+"#,
+    )
+    .expect("write manifest");
+
+    let overlay_dir = repo_dir
+        .join("overlays")
+        .join(module_fs_key("skill:my-skill"));
+    std::fs::create_dir_all(overlay_dir.join(".agentpack/patches")).expect("create patch dir");
+    std::fs::write(
+        overlay_dir.join(".agentpack/overlay.json"),
+        "{\n  \"overlay_kind\": \"patch\"\n}\n",
+    )
+    .expect("write overlay meta");
+    std::fs::write(
+        overlay_dir.join(".agentpack/patches/SKILL.md.patch"),
+        "--- a/SKILL.md\n+++ b/SKILL.md\n@@ -1,6 +1,6 @@\n ---\n name: my-skill\n-description: Example Skill for tests\n+description: Patched Skill for tests\n ---\n \n # my-skill\n",
+    )
+    .expect("write patch");
+
+    let out = agentpack_in(
+        home,
+        &workspace,
+        &[
+            "--target",
+            "claude_code",
+            "deploy",
+            "--apply",
+            "--yes",
+            "--json",
+        ],
+    );
+    assert!(out.status.success(), "deploy should succeed");
+
+    let deployed = std::fs::read_to_string(workspace.join(".claude/skills/my-skill/SKILL.md"))
+        .expect("read deployed skill");
+    assert!(
+        deployed.contains("description: Patched Skill for tests"),
+        "expected patched content"
+    );
+}
+
+#[test]
+fn patch_overlay_apply_failure_returns_stable_error_code() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    let workspace = home.join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    init_git(&workspace);
+
+    let init = agentpack_in(home, &workspace, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    let skill_dir = repo_dir.join("modules/skills/my-skill");
+    std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: my-skill\ndescription: Example Skill for tests\n---\n\n# my-skill\n",
+    )
+    .expect("write SKILL.md");
+
+    std::fs::write(
+        repo_dir.join("agentpack.yaml"),
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  claude_code:
+    mode: files
+    scope: project
+    options:
+      write_repo_commands: false
+      write_user_commands: false
+      write_repo_skills: true
+      write_user_skills: false
+
+modules:
+  - id: skill:my-skill
+    type: skill
+    tags: ["base"]
+    targets: ["claude_code"]
+    source:
+      local_path:
+        path: "modules/skills/my-skill"
+"#,
+    )
+    .expect("write manifest");
+
+    let overlay_dir = repo_dir
+        .join("overlays")
+        .join(module_fs_key("skill:my-skill"));
+    std::fs::create_dir_all(overlay_dir.join(".agentpack/patches")).expect("create patch dir");
+    std::fs::write(
+        overlay_dir.join(".agentpack/overlay.json"),
+        "{\n  \"overlay_kind\": \"patch\"\n}\n",
+    )
+    .expect("write overlay meta");
+    // Wrong context line to force apply failure.
+    std::fs::write(
+        overlay_dir.join(".agentpack/patches/SKILL.md.patch"),
+        "--- a/SKILL.md\n+++ b/SKILL.md\n@@ -1,6 +1,6 @@\n ---\n name: my-skill\n-description: DOES NOT MATCH\n+description: Patched Skill for tests\n ---\n \n # my-skill\n",
+    )
+    .expect("write patch");
+
+    let out = agentpack_in(
+        home,
+        &workspace,
+        &["--target", "claude_code", "plan", "--json"],
+    );
+    assert!(!out.status.success(), "plan should fail on patch apply");
+
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_OVERLAY_PATCH_APPLY_FAILED");
+}


### PR DESCRIPTION
Closes #211.

## Summary
- Implement patch overlays (overlay_kind=patch) applied during desired-state generation.
- Add stable error code E_OVERLAY_PATCH_APPLY_FAILED for patch apply failures.

## Notes
- overlay_kind metadata: <overlay_dir>/.agentpack/overlay.json
- patch layout: <overlay_dir>/.agentpack/patches/<relpath>.patch

## Testing
- cargo test --all --locked
- cargo clippy --all-targets --all-features -- -D warnings
- openspec validate add-patch-overlays --strict --no-interactive
