### PR TITLE
docs(spec): patch overlay edit (OpenSpec)

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -284,6 +284,9 @@ Implemented options:
 - `--sparse`: create a sparse overlay (write metadata only; do not copy upstream files; users add only changed files).
 - `--materialize`: “fill in” missing upstream files into the overlay directory (copy missing files only; never overwrite existing overlay edits).
 
+Planned (not implemented yet):
+- `--kind patch`: create a patch overlay skeleton (metadata + `.agentpack/patches/`) without copying upstream files, and set `<overlay_dir>/.agentpack/overlay.json` to `overlay_kind=patch`.
+
 `agentpack overlay rebase <module_id> [--scope global|machine|project] [--sparsify]`:
 - reads `<overlay_dir>/.agentpack/baseline.json` as merge base
 - performs 3-way merge for files modified in the overlay (merge upstream updates into overlay edits)

--- a/openspec/changes/add-patch-overlay-edit/.openspec.yaml
+++ b/openspec/changes/add-patch-overlay-edit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-14

--- a/openspec/changes/add-patch-overlay-edit/README.md
+++ b/openspec/changes/add-patch-overlay-edit/README.md
@@ -1,0 +1,3 @@
+# add-patch-overlay-edit
+
+Add overlay edit flag to create patch overlay skeleton

--- a/openspec/changes/add-patch-overlay-edit/proposal.md
+++ b/openspec/changes/add-patch-overlay-edit/proposal.md
@@ -1,0 +1,15 @@
+# Change: Patch overlay edit
+
+## Why
+Patch overlays are optimized for “edit a few lines” workflows, but today users must create the patch-overlay layout manually.
+
+Adding an explicit `overlay edit` flag makes patch overlays discoverable, consistent, and less error-prone.
+
+## What Changes
+- Add a flag to `agentpack overlay edit` to create a patch overlay skeleton (metadata + `.agentpack/patches/`).
+- Define how this flag interacts with existing `--sparse` / `--materialize` behavior.
+
+## Impact
+- Affected CLI contract: `agentpack overlay edit`
+- Affected docs: `docs/SPEC.md` (overlay edit semantics)
+- Backward compatibility: default behavior remains directory overlays; patch overlays are opt-in.

--- a/openspec/changes/add-patch-overlay-edit/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-patch-overlay-edit/specs/agentpack-cli/spec.md
@@ -1,0 +1,25 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: overlay edit supports creating patch overlays
+The system SHALL support creating a patch overlay skeleton via `agentpack overlay edit <moduleId> --kind patch`, which creates the overlay directory and required patch-overlay metadata without copying upstream files.
+
+When invoked with `--kind patch`, the command SHALL:
+- ensure the overlay directory exists,
+- ensure `.agentpack/baseline.json` exists,
+- ensure `.agentpack/module_id` exists,
+- write `.agentpack/overlay.json` with `overlay_kind=patch`, and
+- ensure `.agentpack/patches/` exists.
+
+When invoked with `--kind patch`, the command MUST NOT copy upstream files into the overlay directory.
+
+#### Scenario: overlay edit --kind patch creates patch overlay skeleton
+- **GIVEN** a module `<moduleId>` exists and resolves to an upstream root
+- **WHEN** the user runs `agentpack overlay edit <moduleId> --scope global --kind patch`
+- **THEN** the overlay directory exists
+- **AND** it contains `.agentpack/baseline.json`
+- **AND** it contains `.agentpack/module_id`
+- **AND** it contains `.agentpack/overlay.json` with `overlay_kind=patch`
+- **AND** it contains `.agentpack/patches/`
+- **AND** it does not contain copied upstream files by default

--- a/openspec/changes/add-patch-overlay-edit/tasks.md
+++ b/openspec/changes/add-patch-overlay-edit/tasks.md
@@ -1,0 +1,16 @@
+## 1. Spec (OpenSpec)
+- [x] Define `agentpack overlay edit --kind patch` behavior in the delta spec under `openspec/changes/add-patch-overlay-edit/specs/agentpack-cli/spec.md`.
+
+## 2. Docs (implementation contract)
+- [x] Update `docs/SPEC.md` overlay edit section to document patch overlay skeleton creation.
+
+## 3. Validation
+- [x] `openspec validate add-patch-overlay-edit --strict --no-interactive`
+
+## 4. Implementation (overlay edit)
+- [ ] Add `--kind dir|patch` (or equivalent) to `agentpack overlay edit`.
+- [ ] Create patch overlay skeleton: `.agentpack/overlay.json` with `overlay_kind=patch` + `.agentpack/patches/`.
+- [ ] Add integration tests for skeleton creation and metadata.
+
+## 5. Archive (after deploy)
+- [ ] Archive the change via `openspec archive add-patch-overlay-edit --yes` in a separate PR after the implementation is merged.


### PR DESCRIPTION
Supports backlog item #213 by defining the contract for `agentpack overlay edit --kind patch`.

## Summary
- Add OpenSpec change `openspec/changes/add-patch-overlay-edit/`.
- Update `docs/SPEC.md` to document the flag as planned (not implemented yet).

## Validation
- `openspec validate add-patch-overlay-edit --strict --no-interactive`
