### PR TITLE
feat(overlay): overlay edit --kind patch

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -275,17 +275,15 @@ Patch layout:
 
 ### 3.3 Overlay editing commands (see CLI)
 
-`agentpack overlay edit <module_id> [--scope global|machine|project] [--sparse|--materialize]`:
+`agentpack overlay edit <module_id> [--scope global|machine|project] [--kind dir|patch] [--sparse|--materialize]`:
 - if the overlay does not exist: by default it copies the entire upstream module tree into the overlay directory (scope path mapping below)
 - opens the editor (`$EDITOR`)
 - after saving: changes take effect via deploy
 
 Implemented options:
+- `--kind patch`: create a patch overlay skeleton (metadata + `.agentpack/patches/`) without copying upstream files, and set `<overlay_dir>/.agentpack/overlay.json` to `overlay_kind=patch`.
 - `--sparse`: create a sparse overlay (write metadata only; do not copy upstream files; users add only changed files).
 - `--materialize`: “fill in” missing upstream files into the overlay directory (copy missing files only; never overwrite existing overlay edits).
-
-Planned (not implemented yet):
-- `--kind patch`: create a patch overlay skeleton (metadata + `.agentpack/patches/`) without copying upstream files, and set `<overlay_dir>/.agentpack/overlay.json` to `overlay_kind=patch`.
 
 `agentpack overlay rebase <module_id> [--scope global|machine|project] [--sparsify]`:
 - reads `<overlay_dir>/.agentpack/baseline.json` as merge base

--- a/openspec/changes/add-patch-overlay-edit/tasks.md
+++ b/openspec/changes/add-patch-overlay-edit/tasks.md
@@ -8,9 +8,9 @@
 - [x] `openspec validate add-patch-overlay-edit --strict --no-interactive`
 
 ## 4. Implementation (overlay edit)
-- [ ] Add `--kind dir|patch` (or equivalent) to `agentpack overlay edit`.
-- [ ] Create patch overlay skeleton: `.agentpack/overlay.json` with `overlay_kind=patch` + `.agentpack/patches/`.
-- [ ] Add integration tests for skeleton creation and metadata.
+- [x] Add `--kind dir|patch` (or equivalent) to `agentpack overlay edit`.
+- [x] Create patch overlay skeleton: `.agentpack/overlay.json` with `overlay_kind=patch` + `.agentpack/patches/`.
+- [x] Add integration tests for skeleton creation and metadata.
 
 ## 5. Archive (after deploy)
 - [ ] Archive the change via `openspec archive add-patch-overlay-edit --yes` in a separate PR after the implementation is merged.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -224,6 +224,13 @@ pub enum OverlayScope {
     Project,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OverlayEditKind {
+    Dir,
+    Patch,
+}
+
 #[derive(Subcommand, Debug)]
 pub enum OverlayCommands {
     /// Create an overlay skeleton and open an editor
@@ -233,6 +240,10 @@ pub enum OverlayCommands {
         /// Overlay scope to write into (default: global)
         #[arg(long, value_enum, default_value = "global")]
         scope: OverlayScope,
+
+        /// Overlay kind to create/edit (default: dir)
+        #[arg(long, value_enum, default_value = "dir")]
+        kind: OverlayEditKind,
 
         /// Use project overlay (DEPRECATED: use --scope project)
         #[arg(long)]

--- a/tests/cli_overlay_edit_patch_kind.rs
+++ b/tests/cli_overlay_edit_patch_kind.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+use std::process::Command;
+
+use agentpack::config::{LocalPathSource, Manifest, Module, ModuleType, Source};
+use agentpack::ids::module_fs_key;
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .env("EDITOR", "")
+        .output()
+        .expect("run agentpack")
+}
+
+#[test]
+fn overlay_edit_kind_patch_creates_patch_overlay_skeleton() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path();
+
+    let project_dir = home.join("project");
+    std::fs::create_dir_all(&project_dir)?;
+
+    let init = agentpack_in(home, &project_dir, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+
+    let module_root = repo_dir.join("modules").join("skill_test");
+    std::fs::create_dir_all(&module_root)?;
+    std::fs::write(module_root.join("SKILL.md"), "line1\nline2\n")?;
+
+    let manifest_path = repo_dir.join("agentpack.yaml");
+    let mut manifest = Manifest::load(&manifest_path)?;
+    manifest.modules.push(Module {
+        id: "skill_test".to_string(),
+        module_type: ModuleType::Skill,
+        enabled: true,
+        tags: Vec::new(),
+        targets: Vec::new(),
+        source: Source {
+            local_path: Some(LocalPathSource {
+                path: "modules/skill_test".to_string(),
+            }),
+            git: None,
+        },
+        metadata: Default::default(),
+    });
+    manifest.save(&manifest_path)?;
+
+    let edit = agentpack_in(
+        home,
+        &project_dir,
+        &[
+            "overlay",
+            "edit",
+            "skill_test",
+            "--scope",
+            "global",
+            "--kind",
+            "patch",
+        ],
+    );
+    assert!(edit.status.success(), "overlay edit should succeed");
+
+    let overlay_dir = repo_dir.join("overlays").join(module_fs_key("skill_test"));
+
+    assert!(overlay_dir.exists());
+    assert!(overlay_dir.join(".agentpack/baseline.json").exists());
+    assert!(overlay_dir.join(".agentpack/module_id").exists());
+    assert!(overlay_dir.join(".agentpack/patches").is_dir());
+
+    let raw = std::fs::read_to_string(overlay_dir.join(".agentpack/overlay.json"))?;
+    let meta: serde_json::Value = serde_json::from_str(&raw)?;
+    assert_eq!(meta["overlay_kind"], "patch");
+
+    // Patch overlays should not copy upstream files into the overlay root.
+    assert!(!overlay_dir.join("SKILL.md").exists());
+
+    Ok(())
+}

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -260,6 +260,12 @@
     {
       "args": [
         {
+          "id": "kind",
+          "kind": "option",
+          "long": "kind",
+          "required": false
+        },
+        {
           "id": "module_id",
           "kind": "option",
           "required": true


### PR DESCRIPTION
Closes #213.

## Summary
- Add `agentpack overlay edit --kind dir|patch`.
- `--kind patch` creates patch overlay metadata (`overlay_kind=patch`) and `.agentpack/patches/`, without copying upstream files.

## Testing
- `cargo test --all --locked`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `openspec validate add-patch-overlay-edit --strict --no-interactive`
