### PR TITLE
feat(tui): add read-only tui command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,8 +9,10 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
+ "crossterm",
  "dirs",
  "hex",
+ "ratatui",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -20,6 +22,12 @@ dependencies = [
  "time",
  "walkdir",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -93,6 +101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,12 +171,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -173,12 +240,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -213,6 +337,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +372,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "generic-array"
@@ -272,6 +423,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -286,6 +442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,16 +458,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown",
+ "portable-atomic",
+ "thiserror",
+]
 
 [[package]]
 name = "libc"
@@ -324,10 +537,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "memchr"
@@ -336,10 +588,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -358,6 +631,35 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "powerfmt"
@@ -390,6 +692,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags",
+ "compact_str",
+ "hashbrown",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags",
+ "hashbrown",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +772,15 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -414,6 +797,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +816,18 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -496,16 +897,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -559,7 +1024,9 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -593,6 +1060,29 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -638,6 +1128,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +1151,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ categories = ["command-line-utilities", "development-tools"]
 anyhow = "1.0.100"
 clap = { version = "4.5.49", features = ["derive"] }
 clap_complete = "4.5.65"
+crossterm = { version = "0.29.0", optional = true }
+ratatui = { version = "0.30.0", default-features = false, features = ["crossterm"], optional = true }
 serde = { version = "1.0.218", features = ["derive"] }
 serde_json = "1.0.143"
 serde_yaml = "0.9.34"
@@ -25,6 +27,9 @@ tempfile = "3.20.0"
 time = { version = "0.3.41", features = ["formatting", "macros"] }
 dirs = "6.0.0"
 similar = "2.7.0"
+
+[features]
+tui = ["dep:crossterm", "dep:ratatui"]
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -19,7 +19,7 @@ This document captures the design decisions for adding an optional, lightweight 
 ## Command shape
 
 - Subcommand: `agentpack tui`
-- When built **without** TUI support, `agentpack tui` SHOULD fail fast with a clear message (e.g. “this build was compiled without the `tui` feature”).
+- The TUI is feature-gated; build with `--features tui` to enable the command.
 
 ## Feature gate & dependency strategy
 
@@ -41,3 +41,13 @@ This document captures the design decisions for adding an optional, lightweight 
   - At minimum: compile-check via existing “all features” linting.
   - Once TUI tests exist: add a test job that runs with `--all-features` (or at least `--features tui`).
 - Release artifacts MAY ship with `tui` enabled, but the crate feature default remains off.
+
+## Usage
+
+The TUI requires an interactive terminal (TTY).
+
+### Key bindings
+
+- Quit: `q` or `Esc`
+- Switch tabs: `1`/`2`/`3` (or `p`/`d`/`s`, or `←`/`→`)
+- Scroll: `↑`/`↓` (or `j`/`k`), `PgUp`/`PgDn`, `Home`/`End`

--- a/openspec/changes/add-tui-readonly/tasks.md
+++ b/openspec/changes/add-tui-readonly/tasks.md
@@ -5,11 +5,11 @@
 - [x] `openspec validate add-tui-readonly --strict --no-interactive`
 
 ## 3. Implementation (read-only TUI)
-- [ ] Add an optional `tui` Cargo feature and gate TUI-only dependencies behind it.
-- [ ] Add `agentpack tui` subcommand (only present when built with `tui` feature).
-- [ ] Implement read-only UI with three views (plan/diff/status) by reusing existing engine/CLI logic.
-- [ ] Add at least one integration test for the non-UI core wiring/logic (UI details are out of scope).
-- [ ] Document basic usage/exit keys in `docs/TUI.md` (update as needed).
+- [x] Add an optional `tui` Cargo feature and gate TUI-only dependencies behind it.
+- [x] Add `agentpack tui` subcommand (only present when built with `tui` feature).
+- [x] Implement read-only UI with three views (plan/diff/status) by reusing existing engine/CLI logic.
+- [x] Add at least one integration test for the non-UI core wiring/logic (UI details are out of scope).
+- [x] Document basic usage/exit keys in `docs/TUI.md` (update as needed).
 
 ## 4. Archive (after deploy)
 - [ ] Archive the change via `openspec archive add-tui-readonly --yes` in a separate PR after the implementation is merged.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -140,6 +140,10 @@ pub enum Commands {
         only: Vec<StatusOnly>,
     },
 
+    /// Browse plan/diff/status in a terminal UI (requires `tui` feature)
+    #[cfg(feature = "tui")]
+    Tui,
+
     /// Check local environment and target paths
     Doctor {
         /// Idempotently add `.agentpack.manifest.json` to `.gitignore` for detected repos
@@ -361,6 +365,8 @@ impl Cli {
             Commands::Diff => "diff",
             Commands::Deploy { .. } => "deploy",
             Commands::Status { .. } => "status",
+            #[cfg(feature = "tui")]
+            Commands::Tui => "tui",
             Commands::Doctor { .. } => "doctor",
             Commands::Remote { .. } => "remote",
             Commands::Sync { .. } => "sync",

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -25,6 +25,8 @@ pub(crate) mod schema;
 pub(crate) mod score;
 pub(crate) mod status;
 pub(crate) mod sync;
+#[cfg(feature = "tui")]
+pub(crate) mod tui;
 pub(crate) mod update;
 
 pub(crate) struct Ctx<'a> {

--- a/src/cli/commands/tui.rs
+++ b/src/cli/commands/tui.rs
@@ -1,0 +1,240 @@
+use std::io::IsTerminal as _;
+use std::time::Duration;
+
+use anyhow::Context as _;
+
+use crate::engine::Engine;
+use crate::user_error::UserError;
+
+use super::Ctx;
+
+pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
+    if ctx.cli.json {
+        return Err(anyhow::Error::new(UserError::new(
+            "E_CONFIG_INVALID",
+            "`tui` does not support --json output".to_string(),
+        )));
+    }
+
+    if !std::io::stdout().is_terminal() {
+        anyhow::bail!("tui requires a TTY");
+    }
+
+    let engine = Engine::load(ctx.cli.repo.as_deref(), ctx.cli.machine.as_deref())?;
+    let views =
+        crate::tui_core::collect_read_only_text_views(&engine, &ctx.cli.profile, &ctx.cli.target)?;
+
+    run_ui(views.plan, views.diff, views.status)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum View {
+    Plan,
+    Diff,
+    Status,
+}
+
+#[derive(Debug)]
+struct ViewText {
+    title: &'static str,
+    text: String,
+    scroll_y: u16,
+}
+
+#[derive(Debug)]
+struct App {
+    active: View,
+    plan: ViewText,
+    diff: ViewText,
+    status: ViewText,
+    last_content_height: u16,
+}
+
+impl App {
+    fn active_tab_index(&self) -> usize {
+        match self.active {
+            View::Plan => 0,
+            View::Diff => 1,
+            View::Status => 2,
+        }
+    }
+
+    fn active_view_mut(&mut self) -> &mut ViewText {
+        match self.active {
+            View::Plan => &mut self.plan,
+            View::Diff => &mut self.diff,
+            View::Status => &mut self.status,
+        }
+    }
+}
+
+fn run_ui(plan: String, diff: String, status: String) -> anyhow::Result<()> {
+    use crossterm::execute;
+    use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+    use ratatui::Terminal;
+    use ratatui::backend::CrosstermBackend;
+
+    crossterm::terminal::enable_raw_mode().context("enable raw mode")?;
+
+    let mut stdout = std::io::stdout();
+    execute!(stdout, EnterAlternateScreen).context("enter alt screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("create terminal")?;
+
+    let mut app = App {
+        active: View::Plan,
+        plan: ViewText {
+            title: "Plan",
+            text: plan,
+            scroll_y: 0,
+        },
+        diff: ViewText {
+            title: "Diff",
+            text: diff,
+            scroll_y: 0,
+        },
+        status: ViewText {
+            title: "Status",
+            text: status,
+            scroll_y: 0,
+        },
+        last_content_height: 0,
+    };
+
+    let result = run_event_loop(&mut terminal, &mut app);
+
+    crossterm::terminal::disable_raw_mode().ok();
+    execute!(terminal.backend_mut(), LeaveAlternateScreen).ok();
+    terminal.show_cursor().ok();
+
+    result
+}
+
+fn run_event_loop<B: ratatui::backend::Backend>(
+    terminal: &mut ratatui::Terminal<B>,
+    app: &mut App,
+) -> anyhow::Result<()> {
+    use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+
+    loop {
+        terminal
+            .draw(|f| draw_ui(f, app))
+            .map_err(|e| anyhow::anyhow!("draw: {e}"))?;
+
+        if !event::poll(Duration::from_millis(250)).context("poll event")? {
+            continue;
+        }
+
+        match event::read().context("read event")? {
+            Event::Key(k) if k.kind == KeyEventKind::Press => match k.code {
+                KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                KeyCode::Char('1') | KeyCode::Char('p') => app.active = View::Plan,
+                KeyCode::Char('2') | KeyCode::Char('d') => app.active = View::Diff,
+                KeyCode::Char('3') | KeyCode::Char('s') => app.active = View::Status,
+                KeyCode::Left => {
+                    app.active = match app.active {
+                        View::Plan => View::Status,
+                        View::Diff => View::Plan,
+                        View::Status => View::Diff,
+                    };
+                }
+                KeyCode::Right => {
+                    app.active = match app.active {
+                        View::Plan => View::Diff,
+                        View::Diff => View::Status,
+                        View::Status => View::Plan,
+                    };
+                }
+                KeyCode::Up | KeyCode::Char('k') => scroll_by(app, -1),
+                KeyCode::Down | KeyCode::Char('j') => scroll_by(app, 1),
+                KeyCode::PageUp => {
+                    scroll_by(app, -(app.last_content_height as i32).saturating_sub(1))
+                }
+                KeyCode::PageDown => {
+                    scroll_by(app, (app.last_content_height as i32).saturating_sub(1))
+                }
+                KeyCode::Home => app.active_view_mut().scroll_y = 0,
+                KeyCode::End => scroll_to_end(app),
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+}
+
+fn scroll_by(app: &mut App, delta: i32) {
+    let view = app.active_view_mut();
+    if delta == 0 {
+        return;
+    }
+    if delta < 0 {
+        let delta = (-delta) as u16;
+        view.scroll_y = view.scroll_y.saturating_sub(delta);
+    } else {
+        view.scroll_y = view.scroll_y.saturating_add(delta as u16);
+    }
+}
+
+fn scroll_to_end(app: &mut App) {
+    let height = app.last_content_height.max(1) as usize;
+    let view = app.active_view_mut();
+    let lines = view.text.lines().count().max(1);
+    let max_scroll = lines.saturating_sub(height) as u16;
+    view.scroll_y = max_scroll;
+}
+
+fn draw_ui(f: &mut ratatui::Frame<'_>, app: &mut App) {
+    use ratatui::layout::{Constraint, Direction, Layout};
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Block, Borders, Paragraph, Tabs, Wrap};
+
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let titles = [
+        Line::from(Span::raw(" Plan ")),
+        Line::from(Span::raw(" Diff ")),
+        Line::from(Span::raw(" Status ")),
+    ];
+    let tabs = Tabs::new(titles)
+        .select(app.active_tab_index())
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
+    f.render_widget(tabs, chunks[0]);
+
+    let content_area = chunks[1];
+    app.last_content_height = content_area.height;
+
+    let view = match app.active {
+        View::Plan => &mut app.plan,
+        View::Diff => &mut app.diff,
+        View::Status => &mut app.status,
+    };
+
+    let lines = view.text.lines().count().max(1) as u16;
+    let max_scroll = lines.saturating_sub(content_area.height.max(1));
+    view.scroll_y = view.scroll_y.min(max_scroll);
+
+    let content = Paragraph::new(view.text.as_str())
+        .block(Block::default().borders(Borders::ALL).title(view.title))
+        .wrap(Wrap { trim: false })
+        .scroll((view.scroll_y, 0));
+    f.render_widget(content, content_area);
+
+    let help = Paragraph::new(
+        "q quit | 1/2/3 or p/d/s switch | ↑/↓ or j/k scroll | PgUp/PgDn page | Home/End",
+    )
+    .style(Style::default().fg(Color::DarkGray));
+    f.render_widget(help, chunks[2]);
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -92,6 +92,10 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
         Commands::Status { only } => {
             super::commands::status::run(&ctx, only)?;
         }
+        #[cfg(feature = "tui")]
+        Commands::Tui => {
+            super::commands::tui::run(&ctx)?;
+        }
         Commands::Doctor { fix } => {
             super::commands::doctor::run(&ctx, *fix)?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod store;
 pub mod target_adapters;
 pub mod target_manifest;
 pub mod targets;
+pub mod tui_core;
 pub mod user_error;
 pub mod validate;
 

--- a/src/tui_core.rs
+++ b/src/tui_core.rs
@@ -1,0 +1,483 @@
+use std::fmt::Write as _;
+
+use anyhow::Context as _;
+
+use crate::deploy::load_managed_paths_from_snapshot;
+use crate::deploy::plan as compute_plan;
+use crate::deploy::{DesiredState, ManagedPaths, TargetPath};
+use crate::engine::Engine;
+use crate::hash::sha256_hex;
+use crate::state::latest_snapshot;
+use crate::targets::TargetRoot;
+use crate::user_error::UserError;
+
+#[derive(Debug)]
+pub struct ReadOnlyTextViews {
+    pub warnings: Vec<String>,
+    pub plan: String,
+    pub diff: String,
+    pub status: String,
+}
+
+pub fn collect_read_only_text_views(
+    engine: &Engine,
+    profile: &str,
+    target_filter: &str,
+) -> anyhow::Result<ReadOnlyTextViews> {
+    let _targets = selected_targets(&engine.manifest, target_filter)?;
+
+    let render = engine.desired_state(profile, target_filter)?;
+    let desired = render.desired;
+    let mut warnings = render.warnings;
+    let roots = render.roots;
+
+    let managed_paths = managed_paths_for_plan(engine, &roots, target_filter, &mut warnings)?;
+    let plan = compute_plan(&desired, managed_paths.as_ref())?;
+
+    let plan_text = render_plan_text(&warnings, &plan)?;
+    let diff_text = render_diff_text(&warnings, &plan, &desired)?;
+    let status_text = render_status_text(&warnings, &desired, &roots)?;
+
+    Ok(ReadOnlyTextViews {
+        warnings,
+        plan: plan_text,
+        diff: diff_text,
+        status: status_text,
+    })
+}
+
+fn selected_targets(
+    manifest: &crate::config::Manifest,
+    target_filter: &str,
+) -> anyhow::Result<Vec<String>> {
+    let mut known: Vec<String> = manifest.targets.keys().cloned().collect();
+    known.sort();
+
+    match target_filter {
+        "all" => Ok(known),
+        "codex" | "claude_code" | "cursor" | "vscode" => {
+            if !manifest.targets.contains_key(target_filter) {
+                return Err(anyhow::Error::new(
+                    UserError::new(
+                        "E_CONFIG_INVALID",
+                        format!("target not configured: {target_filter}"),
+                    )
+                    .with_details(serde_json::json!( {
+                        "target": target_filter,
+                        "hint": "add the target under `targets:` in agentpack.yaml",
+                    })),
+                ));
+            }
+            Ok(vec![target_filter.to_string()])
+        }
+        other => Err(anyhow::Error::new(
+            UserError::new(
+                "E_TARGET_UNSUPPORTED",
+                format!("unsupported --target: {other}"),
+            )
+            .with_details(serde_json::json!( {
+                "target": other,
+                "allowed": ["all","codex","claude_code","cursor","vscode"],
+            })),
+        )),
+    }
+}
+
+fn managed_paths_for_plan(
+    engine: &Engine,
+    roots: &[TargetRoot],
+    target_filter: &str,
+    warnings: &mut Vec<String>,
+) -> anyhow::Result<Option<ManagedPaths>> {
+    let managed_paths_from_manifest =
+        crate::target_manifest::load_managed_paths_from_manifests(roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
+    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
+
+    if !managed_paths_from_manifest.is_empty() {
+        return Ok(Some(filter_managed(
+            managed_paths_from_manifest,
+            target_filter,
+        )));
+    }
+
+    let latest = latest_snapshot(&engine.home, &["deploy", "rollback"])?;
+    Ok(latest
+        .as_ref()
+        .map(load_managed_paths_from_snapshot)
+        .transpose()?
+        .map(|m| filter_managed(m, target_filter)))
+}
+
+fn filter_managed(managed: ManagedPaths, target_filter: &str) -> ManagedPaths {
+    managed
+        .into_iter()
+        .filter(|tp| target_filter == "all" || tp.target == target_filter)
+        .collect()
+}
+
+fn render_warnings(out: &mut String, warnings: &[String]) {
+    if warnings.is_empty() {
+        return;
+    }
+
+    for w in warnings {
+        let _ = writeln!(out, "Warning: {w}");
+    }
+    let _ = writeln!(out);
+}
+
+fn render_plan_text(
+    warnings: &[String],
+    plan: &crate::deploy::PlanResult,
+) -> anyhow::Result<String> {
+    let mut out = String::new();
+    render_warnings(&mut out, warnings);
+
+    writeln!(
+        out,
+        "Plan: +{} ~{} -{}",
+        plan.summary.create, plan.summary.update, plan.summary.delete
+    )
+    .context("write plan summary")?;
+    for c in &plan.changes {
+        writeln!(out, "{:?} {} {}", c.op, c.target, c.path).context("write plan change")?;
+    }
+
+    Ok(out)
+}
+
+fn render_diff_text(
+    warnings: &[String],
+    plan: &crate::deploy::PlanResult,
+    desired: &DesiredState,
+) -> anyhow::Result<String> {
+    let mut out = String::new();
+    render_warnings(&mut out, warnings);
+
+    if plan.changes.is_empty() {
+        writeln!(out, "(no changes)").context("write diff no-op")?;
+        return Ok(out);
+    }
+
+    for c in &plan.changes {
+        let path = std::path::PathBuf::from(&c.path);
+        let desired_key = TargetPath {
+            target: c.target.clone(),
+            path: path.clone(),
+        };
+
+        let before_text = if matches!(c.op, crate::deploy::Op::Create) {
+            Some(String::new())
+        } else {
+            crate::deploy::read_text(&path)?
+        };
+        let after_text = if matches!(c.op, crate::deploy::Op::Delete) {
+            Some(String::new())
+        } else {
+            desired
+                .get(&desired_key)
+                .and_then(|f| String::from_utf8(f.bytes.clone()).ok())
+        };
+
+        writeln!(out).context("write diff spacer")?;
+        writeln!(out, "=== {} {} ===", c.target, c.path).context("write diff header")?;
+        match (before_text, after_text) {
+            (Some(from), Some(to)) => {
+                out.push_str(&crate::diff::unified_diff(
+                    &from,
+                    &to,
+                    &format!("before: {}", c.path),
+                    &format!("after: {}", c.path),
+                ));
+            }
+            _ => {
+                writeln!(out, "(binary or non-utf8 content; diff omitted)")
+                    .context("write diff omitted")?;
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[derive(Default, Clone, Copy)]
+struct DriftSummary {
+    modified: u64,
+    missing: u64,
+    extra: u64,
+}
+
+#[derive(Debug)]
+struct DriftItem {
+    target: String,
+    root: Option<String>,
+    path: String,
+    kind: String,
+}
+
+fn best_root_idx(roots: &[TargetRoot], target: &str, path: &std::path::Path) -> Option<usize> {
+    roots
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.target == target)
+        .filter(|(_, r)| path.strip_prefix(&r.root).is_ok())
+        .max_by_key(|(_, r)| r.root.components().count())
+        .map(|(idx, _)| idx)
+}
+
+fn render_status_text(
+    warnings: &[String],
+    desired: &DesiredState,
+    roots: &[TargetRoot],
+) -> anyhow::Result<String> {
+    let mut warnings: Vec<String> = warnings.to_vec();
+
+    let mut manifests: Vec<Option<crate::target_manifest::TargetManifest>> =
+        vec![None; roots.len()];
+    for (idx, root) in roots.iter().enumerate() {
+        let path = crate::target_manifest::manifest_path(&root.root);
+        if !path.exists() {
+            continue;
+        }
+
+        let (manifest, manifest_warnings) =
+            crate::target_manifest::read_target_manifest_soft(&path, &root.target);
+        warnings.extend(manifest_warnings);
+        manifests[idx] = manifest;
+    }
+
+    let any_manifest = manifests.iter().any(Option::is_some);
+    if !any_manifest {
+        warnings.push(
+            "no target manifests found; drift may be inaccurate (run deploy --apply to write manifests)"
+                .to_string(),
+        );
+    }
+
+    let mut drift: Vec<DriftItem> = Vec::new();
+    let mut summary = DriftSummary::default();
+
+    if !any_manifest {
+        for (tp, desired_file) in desired {
+            let expected = format!("sha256:{}", sha256_hex(&desired_file.bytes));
+            let root = best_root_idx(roots, &tp.target, &tp.path)
+                .and_then(|idx| roots.get(idx))
+                .map(|r| r.root.as_path());
+            match std::fs::read(&tp.path) {
+                Ok(actual_bytes) => {
+                    let actual = format!("sha256:{}", sha256_hex(&actual_bytes));
+                    if actual != expected {
+                        summary.modified += 1;
+                        drift.push(DriftItem {
+                            target: tp.target.clone(),
+                            root: root.map(|p| p.to_string_lossy().to_string()),
+                            path: tp.path.to_string_lossy().to_string(),
+                            kind: "modified".to_string(),
+                        });
+                    }
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    summary.missing += 1;
+                    drift.push(DriftItem {
+                        target: tp.target.clone(),
+                        root: root.map(|p| p.to_string_lossy().to_string()),
+                        path: tp.path.to_string_lossy().to_string(),
+                        kind: "missing".to_string(),
+                    });
+                }
+                Err(err) => return Err(err).context("read deployed file"),
+            }
+        }
+    } else {
+        let mut desired_by_root: Vec<Vec<(&TargetPath, &crate::deploy::DesiredFile)>> =
+            vec![Vec::new(); roots.len()];
+        for (tp, desired_file) in desired {
+            let Some(root_idx) = best_root_idx(roots, &tp.target, &tp.path) else {
+                continue;
+            };
+            desired_by_root[root_idx].push((tp, desired_file));
+        }
+
+        for (idx, root) in roots.iter().enumerate() {
+            let Some(manifest) = &manifests[idx] else {
+                if desired_by_root[idx].is_empty() {
+                    continue;
+                }
+                warnings.push(format!(
+                    "no usable target manifest for {} {}; drift may be incomplete (run deploy --apply to write manifests)",
+                    root.target,
+                    root.root.display()
+                ));
+
+                for (tp, desired_file) in &desired_by_root[idx] {
+                    let expected = format!("sha256:{}", sha256_hex(&desired_file.bytes));
+                    match std::fs::read(&tp.path) {
+                        Ok(actual_bytes) => {
+                            let actual = format!("sha256:{}", sha256_hex(&actual_bytes));
+                            if actual != expected {
+                                summary.modified += 1;
+                                drift.push(DriftItem {
+                                    target: tp.target.clone(),
+                                    root: Some(root.root.to_string_lossy().to_string()),
+                                    path: tp.path.to_string_lossy().to_string(),
+                                    kind: "modified".to_string(),
+                                });
+                            }
+                        }
+                        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                            summary.missing += 1;
+                            drift.push(DriftItem {
+                                target: tp.target.clone(),
+                                root: Some(root.root.to_string_lossy().to_string()),
+                                path: tp.path.to_string_lossy().to_string(),
+                                kind: "missing".to_string(),
+                            });
+                        }
+                        Err(err) => return Err(err).context("read deployed file"),
+                    }
+                }
+                continue;
+            };
+
+            let mut managed_paths = crate::deploy::ManagedPaths::new();
+            for f in &manifest.managed_files {
+                let rel_path = std::path::Path::new(&f.path);
+                if rel_path.is_absolute()
+                    || rel_path
+                        .components()
+                        .any(|c| matches!(c, std::path::Component::ParentDir))
+                {
+                    warnings.push(format!(
+                        "target manifest ({}): skipped invalid entry path {:?} in {}",
+                        root.target,
+                        f.path,
+                        crate::target_manifest::manifest_path(&root.root).display(),
+                    ));
+                    continue;
+                }
+
+                managed_paths.insert(TargetPath {
+                    target: root.target.clone(),
+                    path: root.root.join(&f.path),
+                });
+            }
+
+            for tp in &managed_paths {
+                let expected = desired
+                    .get(tp)
+                    .map(|f| format!("sha256:{}", sha256_hex(&f.bytes)));
+                match std::fs::read(&tp.path) {
+                    Ok(actual_bytes) => {
+                        let actual = format!("sha256:{}", sha256_hex(&actual_bytes));
+                        if let Some(exp) = &expected {
+                            if &actual != exp {
+                                summary.modified += 1;
+                                drift.push(DriftItem {
+                                    target: tp.target.clone(),
+                                    root: Some(root.root.to_string_lossy().to_string()),
+                                    path: tp.path.to_string_lossy().to_string(),
+                                    kind: "modified".to_string(),
+                                });
+                            }
+                        } else {
+                            summary.extra += 1;
+                            drift.push(DriftItem {
+                                target: tp.target.clone(),
+                                root: Some(root.root.to_string_lossy().to_string()),
+                                path: tp.path.to_string_lossy().to_string(),
+                                kind: "extra".to_string(),
+                            });
+                        }
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                        if expected.is_some() {
+                            summary.missing += 1;
+                            drift.push(DriftItem {
+                                target: tp.target.clone(),
+                                root: Some(root.root.to_string_lossy().to_string()),
+                                path: tp.path.to_string_lossy().to_string(),
+                                kind: "missing".to_string(),
+                            });
+                        }
+                    }
+                    Err(err) => return Err(err).context("read deployed file"),
+                }
+            }
+
+            if !root.scan_extras {
+                continue;
+            }
+            if !root.root.exists() {
+                continue;
+            }
+
+            let mut files = crate::fs::list_files(&root.root)?;
+            files.sort();
+            for path in files {
+                if path.file_name().and_then(|s| s.to_str())
+                    == Some(crate::target_manifest::TARGET_MANIFEST_FILENAME)
+                {
+                    continue;
+                }
+
+                let tp = TargetPath {
+                    target: root.target.clone(),
+                    path: path.clone(),
+                };
+                if managed_paths.contains(&tp) {
+                    continue;
+                }
+
+                summary.extra += 1;
+                drift.push(DriftItem {
+                    target: tp.target.clone(),
+                    root: Some(root.root.to_string_lossy().to_string()),
+                    path: tp.path.to_string_lossy().to_string(),
+                    kind: "extra".to_string(),
+                });
+            }
+        }
+    }
+
+    drift.sort_by(|a, b| {
+        (
+            a.target.as_str(),
+            a.root.as_deref().unwrap_or(""),
+            a.path.as_str(),
+        )
+            .cmp(&(
+                b.target.as_str(),
+                b.root.as_deref().unwrap_or(""),
+                b.path.as_str(),
+            ))
+    });
+
+    let mut out = String::new();
+    render_warnings(&mut out, &warnings);
+    if drift.is_empty() {
+        writeln!(out, "No drift").context("write no drift")?;
+        return Ok(out);
+    }
+
+    writeln!(out, "Drift ({}):", drift.len()).context("write drift header")?;
+    writeln!(
+        out,
+        "Summary: modified={} missing={} extra={}",
+        summary.modified, summary.missing, summary.extra
+    )
+    .context("write drift summary")?;
+
+    let mut last_group: Option<(String, String)> = None;
+    for d in drift {
+        let root = d.root.as_deref().unwrap_or("<unknown>");
+        let group = (d.target.clone(), root.to_string());
+        if last_group.as_ref() != Some(&group) {
+            writeln!(out, "Root: {} ({})", root, d.target).context("write drift root")?;
+            last_group = Some(group);
+        }
+        writeln!(out, "- {} {}", d.kind, d.path).context("write drift item")?;
+    }
+
+    Ok(out)
+}

--- a/tests/tui_core.rs
+++ b/tests/tui_core.rs
@@ -1,0 +1,109 @@
+use std::path::Path;
+
+use agentpack::config::Manifest;
+use agentpack::engine::Engine;
+use agentpack::paths::{AgentpackHome, RepoPaths};
+use agentpack::project::ProjectContext;
+use agentpack::store::Store;
+
+fn write_manifest(repo_dir: &Path, codex_home: &Path) -> anyhow::Result<()> {
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{codex_home}'
+      write_agents_global: true
+      write_agents_repo_root: false
+      write_user_prompts: false
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: instructions:base
+    type: instructions
+    enabled: true
+    tags: ["base"]
+    targets: ["codex"]
+    source:
+      local_path:
+        path: modules/instructions/base
+"#,
+        codex_home = codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest)?;
+    Ok(())
+}
+
+fn write_file(repo_dir: &Path, rel_dir: &str, filename: &str, content: &str) -> anyhow::Result<()> {
+    let dir = repo_dir.join(rel_dir);
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(dir.join(filename), content)?;
+    Ok(())
+}
+
+fn make_home(tmp: &tempfile::TempDir) -> anyhow::Result<AgentpackHome> {
+    let root = tmp.path().join("agentpack_home");
+    let state_dir = root.join("state");
+    let home = AgentpackHome {
+        repo_dir: root.join("repo"),
+        cache_dir: root.join("cache"),
+        snapshots_dir: state_dir.join("snapshots"),
+        logs_dir: state_dir.join("logs"),
+        state_dir,
+        root,
+    };
+    std::fs::create_dir_all(&home.cache_dir)?;
+    std::fs::create_dir_all(&home.snapshots_dir)?;
+    std::fs::create_dir_all(&home.logs_dir)?;
+    Ok(home)
+}
+
+#[test]
+fn tui_core_can_collect_read_only_views() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let home = make_home(&tmp)?;
+
+    let repo_dir = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo_dir)?;
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home)?;
+
+    write_manifest(&repo_dir, &codex_home)?;
+    write_file(
+        &repo_dir,
+        "modules/instructions/base",
+        "AGENTS.md",
+        "# Test instructions\n",
+    )?;
+
+    let repo = RepoPaths::resolve(&home, Some(&repo_dir))?;
+    let manifest = Manifest::load(&repo.manifest_path)?;
+    let store = Store::new(&home);
+    let project = ProjectContext::detect(tmp.path())?;
+
+    let engine = Engine {
+        home,
+        repo,
+        manifest,
+        lockfile: None,
+        store,
+        project,
+        machine_id: "test-machine".to_string(),
+    };
+
+    let views = agentpack::tui_core::collect_read_only_text_views(&engine, "default", "codex")?;
+    assert!(views.plan.contains("Plan:"));
+    assert!(!views.diff.is_empty());
+    assert!(views.status.contains("No drift") || views.status.contains("Drift"));
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #215.

Implements OpenSpec change: `add-tui-readonly`.

## What
- Add optional `tui` Cargo feature with `ratatui` + `crossterm` deps.
- Add `agentpack tui` (feature-gated) with three read-only views: plan/diff/status.
- Add `agentpack::tui_core::collect_read_only_text_views(...)` for headless core rendering.
- Update `docs/TUI.md` with key bindings.

## Validation
- `just check`
- `openspec validate add-tui-readonly --strict --no-interactive`
