### PR TITLE
docs(spec): add tui safe apply (OpenSpec)

### DIFF
--- a/openspec/changes/add-tui-safe-apply/.openspec.yaml
+++ b/openspec/changes/add-tui-safe-apply/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-15

--- a/openspec/changes/add-tui-safe-apply/README.md
+++ b/openspec/changes/add-tui-safe-apply/README.md
@@ -1,0 +1,3 @@
+# add-tui-safe-apply
+
+Add safe apply flow to tui with explicit confirmation

--- a/openspec/changes/add-tui-safe-apply/proposal.md
+++ b/openspec/changes/add-tui-safe-apply/proposal.md
@@ -1,0 +1,16 @@
+# Change: TUI safe apply
+
+## Why
+The read-only TUI is useful for browsing `plan` / `diff` / `status`, but users still need to jump back to the CLI to run `deploy --apply`.
+
+Adding a safe, explicitly-confirmed apply flow inside the TUI improves the “browse → decide → apply” loop without weakening Agentpack’s safety model.
+
+## What Changes
+- Extend `agentpack tui` to support triggering an apply (equivalent semantics to `deploy --apply`) from within the UI.
+- Require explicit confirmation in the UI before any writes occur.
+- On failure, surface stable error codes and details in the UI for actionable debugging.
+
+## Impact
+- Affected CLI contract: `agentpack tui` (new mutating action via UI).
+- Affected code: TUI event loop + deploy/apply wiring.
+- Backward compatibility: default behavior remains read-only unless the user explicitly confirms an apply action.

--- a/openspec/changes/add-tui-safe-apply/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-tui-safe-apply/specs/agentpack-cli/spec.md
@@ -1,0 +1,24 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: tui supports safe apply with explicit confirmation
+When built with the `tui` feature enabled, the system SHALL allow users to trigger an apply from within `agentpack tui`, equivalent in semantics to `agentpack deploy --apply` for the current `--profile` / `--target` selection.
+
+The TUI apply flow MUST:
+- require explicit confirmation inside the UI before performing any writes, and
+- avoid any silent writes.
+
+If apply fails due to a user-facing error, the TUI SHALL display the stable error code and message, and SHOULD display `details` when present.
+
+#### Scenario: user cancels apply
+- **GIVEN** the user is running `agentpack tui`
+- **WHEN** the user triggers apply
+- **AND** the user declines confirmation
+- **THEN** no filesystem writes occur
+
+#### Scenario: apply fails and error code is shown
+- **GIVEN** the user is running `agentpack tui`
+- **WHEN** the user triggers apply and confirms
+- **AND** apply fails with a stable error code (e.g. `E_ADOPT_CONFIRM_REQUIRED`)
+- **THEN** the UI displays the error code and message

--- a/openspec/changes/add-tui-safe-apply/tasks.md
+++ b/openspec/changes/add-tui-safe-apply/tasks.md
@@ -1,0 +1,15 @@
+## 1. Spec (OpenSpec)
+- [x] Define `agentpack tui` safe apply behavior in the delta spec under `openspec/changes/add-tui-safe-apply/specs/agentpack-cli/spec.md`.
+
+## 2. Validation
+- [x] `openspec validate add-tui-safe-apply --strict --no-interactive`
+
+## 3. Implementation (TUI apply)
+- [ ] Add an explicit “apply” action to `agentpack tui` that performs the equivalent of `deploy --apply` for the current profile/target.
+- [ ] Require explicit confirmation in the UI before writing.
+- [ ] On apply failure, display stable error codes/messages (and details when present) in the UI.
+- [ ] Update `docs/TUI.md` with the apply keybinding and confirmation UX.
+- [ ] Add at least one test covering the “no silent writes” guarantee (headless core logic preferred; UI details out of scope).
+
+## 4. Archive (after deploy)
+- [ ] Archive the change via `openspec archive add-tui-safe-apply --yes` in a separate PR after the implementation is merged.


### PR DESCRIPTION
Relates to #216 (parent epic: #181).

## What
- Add OpenSpec change `add-tui-safe-apply` defining the safe apply flow (explicit confirmation + no silent writes) for `agentpack tui`.

## Validation
- `openspec validate add-tui-safe-apply --strict --no-interactive`
