### PR TITLE
feat(tui): add safe apply with confirmation

### DIFF
--- a/docs/TUI.md
+++ b/docs/TUI.md
@@ -49,5 +49,6 @@ The TUI requires an interactive terminal (TTY).
 ### Key bindings
 
 - Quit: `q` or `Esc`
+- Apply: `a` (then `y` to confirm; `n`/`Esc` to cancel)
 - Switch tabs: `1`/`2`/`3` (or `p`/`d`/`s`, or `←`/`→`)
 - Scroll: `↑`/`↓` (or `j`/`k`), `PgUp`/`PgDn`, `Home`/`End`

--- a/openspec/changes/add-tui-safe-apply/tasks.md
+++ b/openspec/changes/add-tui-safe-apply/tasks.md
@@ -5,11 +5,11 @@
 - [x] `openspec validate add-tui-safe-apply --strict --no-interactive`
 
 ## 3. Implementation (TUI apply)
-- [ ] Add an explicit “apply” action to `agentpack tui` that performs the equivalent of `deploy --apply` for the current profile/target.
-- [ ] Require explicit confirmation in the UI before writing.
-- [ ] On apply failure, display stable error codes/messages (and details when present) in the UI.
-- [ ] Update `docs/TUI.md` with the apply keybinding and confirmation UX.
-- [ ] Add at least one test covering the “no silent writes” guarantee (headless core logic preferred; UI details out of scope).
+- [x] Add an explicit “apply” action to `agentpack tui` that performs the equivalent of `deploy --apply` for the current profile/target.
+- [x] Require explicit confirmation in the UI before writing.
+- [x] On apply failure, display stable error codes/messages (and details when present) in the UI.
+- [x] Update `docs/TUI.md` with the apply keybinding and confirmation UX.
+- [x] Add at least one test covering the “no silent writes” guarantee (headless core logic preferred; UI details out of scope).
 
 ## 4. Archive (after deploy)
 - [ ] Archive the change via `openspec archive add-tui-safe-apply --yes` in a separate PR after the implementation is merged.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -142,7 +142,11 @@ pub enum Commands {
 
     /// Browse plan/diff/status in a terminal UI (requires `tui` feature)
     #[cfg(feature = "tui")]
-    Tui,
+    Tui {
+        /// Allow overwriting existing unmanaged files (adopt updates)
+        #[arg(long)]
+        adopt: bool,
+    },
 
     /// Check local environment and target paths
     Doctor {
@@ -366,7 +370,7 @@ impl Cli {
             Commands::Deploy { .. } => "deploy",
             Commands::Status { .. } => "status",
             #[cfg(feature = "tui")]
-            Commands::Tui => "tui",
+            Commands::Tui { .. } => "tui",
             Commands::Doctor { .. } => "doctor",
             Commands::Remote { .. } => "remote",
             Commands::Sync { .. } => "sync",

--- a/src/cli/commands/tui.rs
+++ b/src/cli/commands/tui.rs
@@ -1,14 +1,16 @@
 use std::io::IsTerminal as _;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Context as _;
 
 use crate::engine::Engine;
+use crate::tui_apply::ApplyOutcome;
 use crate::user_error::UserError;
 
 use super::Ctx;
 
-pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
+pub(crate) fn run(ctx: &Ctx<'_>, adopt: bool) -> anyhow::Result<()> {
     if ctx.cli.json {
         return Err(anyhow::Error::new(UserError::new(
             "E_CONFIG_INVALID",
@@ -24,7 +26,16 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     let views =
         crate::tui_core::collect_read_only_text_views(&engine, &ctx.cli.profile, &ctx.cli.target)?;
 
-    run_ui(views.plan, views.diff, views.status)
+    let apply = ApplyConfig {
+        repo: ctx.cli.repo.clone(),
+        machine: ctx.cli.machine.clone(),
+        profile: ctx.cli.profile.clone(),
+        target: ctx.cli.target.clone(),
+        adopt,
+        dry_run: ctx.cli.dry_run,
+    };
+
+    run_ui(apply, views.plan, views.diff, views.status)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,12 +53,34 @@ struct ViewText {
 }
 
 #[derive(Debug)]
+struct ApplyConfig {
+    repo: Option<PathBuf>,
+    machine: Option<String>,
+    profile: String,
+    target: String,
+    adopt: bool,
+    dry_run: bool,
+}
+
+#[derive(Debug)]
+enum Modal {
+    ConfirmApply,
+    Message {
+        title: &'static str,
+        body: String,
+        is_error: bool,
+    },
+}
+
+#[derive(Debug)]
 struct App {
     active: View,
     plan: ViewText,
     diff: ViewText,
     status: ViewText,
     last_content_height: u16,
+    apply: ApplyConfig,
+    modal: Option<Modal>,
 }
 
 impl App {
@@ -68,7 +101,7 @@ impl App {
     }
 }
 
-fn run_ui(plan: String, diff: String, status: String) -> anyhow::Result<()> {
+fn run_ui(apply: ApplyConfig, plan: String, diff: String, status: String) -> anyhow::Result<()> {
     use crossterm::execute;
     use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
     use ratatui::Terminal;
@@ -99,6 +132,8 @@ fn run_ui(plan: String, diff: String, status: String) -> anyhow::Result<()> {
             scroll_y: 0,
         },
         last_content_height: 0,
+        apply,
+        modal: None,
     };
 
     let result = run_event_loop(&mut terminal, &mut app);
@@ -126,40 +161,148 @@ fn run_event_loop<B: ratatui::backend::Backend>(
         }
 
         match event::read().context("read event")? {
-            Event::Key(k) if k.kind == KeyEventKind::Press => match k.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
-                KeyCode::Char('1') | KeyCode::Char('p') => app.active = View::Plan,
-                KeyCode::Char('2') | KeyCode::Char('d') => app.active = View::Diff,
-                KeyCode::Char('3') | KeyCode::Char('s') => app.active = View::Status,
-                KeyCode::Left => {
-                    app.active = match app.active {
-                        View::Plan => View::Status,
-                        View::Diff => View::Plan,
-                        View::Status => View::Diff,
-                    };
+            Event::Key(k) if k.kind == KeyEventKind::Press => {
+                if let Some(modal) = app.modal.take() {
+                    match modal {
+                        Modal::ConfirmApply => match k.code {
+                            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                                app.modal = None;
+                                apply_confirmed(app);
+                            }
+                            KeyCode::Char('n')
+                            | KeyCode::Char('N')
+                            | KeyCode::Esc
+                            | KeyCode::Char('q') => {
+                                app.modal = None;
+                            }
+                            _ => {
+                                app.modal = Some(Modal::ConfirmApply);
+                            }
+                        },
+                        Modal::Message { .. } => {
+                            // Any key closes the message.
+                            app.modal = None;
+                        }
+                    }
+                    continue;
                 }
-                KeyCode::Right => {
-                    app.active = match app.active {
-                        View::Plan => View::Diff,
-                        View::Diff => View::Status,
-                        View::Status => View::Plan,
-                    };
+
+                match k.code {
+                    KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                    KeyCode::Char('1') | KeyCode::Char('p') => app.active = View::Plan,
+                    KeyCode::Char('2') | KeyCode::Char('d') => app.active = View::Diff,
+                    KeyCode::Char('3') | KeyCode::Char('s') => app.active = View::Status,
+                    KeyCode::Char('a') => {
+                        if app.apply.dry_run {
+                            app.modal = Some(Modal::Message {
+                                title: "Info",
+                                body: "Dry-run is enabled; apply is disabled.".to_string(),
+                                is_error: false,
+                            });
+                        } else {
+                            app.modal = Some(Modal::ConfirmApply);
+                        }
+                    }
+                    KeyCode::Left => {
+                        app.active = match app.active {
+                            View::Plan => View::Status,
+                            View::Diff => View::Plan,
+                            View::Status => View::Diff,
+                        };
+                    }
+                    KeyCode::Right => {
+                        app.active = match app.active {
+                            View::Plan => View::Diff,
+                            View::Diff => View::Status,
+                            View::Status => View::Plan,
+                        };
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => scroll_by(app, -1),
+                    KeyCode::Down | KeyCode::Char('j') => scroll_by(app, 1),
+                    KeyCode::PageUp => {
+                        scroll_by(app, -(app.last_content_height as i32).saturating_sub(1))
+                    }
+                    KeyCode::PageDown => {
+                        scroll_by(app, (app.last_content_height as i32).saturating_sub(1))
+                    }
+                    KeyCode::Home => app.active_view_mut().scroll_y = 0,
+                    KeyCode::End => scroll_to_end(app),
+                    _ => {}
                 }
-                KeyCode::Up | KeyCode::Char('k') => scroll_by(app, -1),
-                KeyCode::Down | KeyCode::Char('j') => scroll_by(app, 1),
-                KeyCode::PageUp => {
-                    scroll_by(app, -(app.last_content_height as i32).saturating_sub(1))
-                }
-                KeyCode::PageDown => {
-                    scroll_by(app, (app.last_content_height as i32).saturating_sub(1))
-                }
-                KeyCode::Home => app.active_view_mut().scroll_y = 0,
-                KeyCode::End => scroll_to_end(app),
-                _ => {}
-            },
+            }
             _ => {}
         }
     }
+}
+
+fn apply_confirmed(app: &mut App) {
+    let result = crate::tui_apply::apply_from_tui(
+        app.apply.repo.as_deref(),
+        app.apply.machine.as_deref(),
+        &app.apply.profile,
+        &app.apply.target,
+        app.apply.adopt,
+        true,
+    );
+
+    match result {
+        Ok(ApplyOutcome::Applied { snapshot_id }) => {
+            let _ = refresh_views(app);
+            app.modal = Some(Modal::Message {
+                title: "Applied",
+                body: format!("Snapshot: {snapshot_id}"),
+                is_error: false,
+            });
+        }
+        Ok(ApplyOutcome::NoChanges) => {
+            app.modal = Some(Modal::Message {
+                title: "No changes",
+                body: "Nothing to apply.".to_string(),
+                is_error: false,
+            });
+        }
+        Err(err) => {
+            app.modal = Some(Modal::Message {
+                title: "Apply failed",
+                body: format_anyhow_error(&err),
+                is_error: true,
+            });
+        }
+    }
+}
+
+fn refresh_views(app: &mut App) -> anyhow::Result<()> {
+    let engine = Engine::load(app.apply.repo.as_deref(), app.apply.machine.as_deref())?;
+    let views = crate::tui_core::collect_read_only_text_views(
+        &engine,
+        &app.apply.profile,
+        &app.apply.target,
+    )?;
+
+    app.plan.text = views.plan;
+    app.diff.text = views.diff;
+    app.status.text = views.status;
+    app.plan.scroll_y = 0;
+    app.diff.scroll_y = 0;
+    app.status.scroll_y = 0;
+
+    Ok(())
+}
+
+fn format_anyhow_error(err: &anyhow::Error) -> String {
+    let Some(user_err) = err.chain().find_map(|e| e.downcast_ref::<UserError>()) else {
+        return format!("{err:#}");
+    };
+
+    let mut out = format!("error[{}]: {}", user_err.code, user_err.message);
+    if let Some(details) = user_err.details.as_ref() {
+        if let Ok(pretty) = serde_json::to_string_pretty(details) {
+            out.push_str("\n\n");
+            out.push_str(&pretty);
+        }
+    }
+
+    out
 }
 
 fn scroll_by(app: &mut App, delta: i32) {
@@ -187,7 +330,7 @@ fn draw_ui(f: &mut ratatui::Frame<'_>, app: &mut App) {
     use ratatui::layout::{Constraint, Direction, Layout};
     use ratatui::style::{Color, Modifier, Style};
     use ratatui::text::{Line, Span};
-    use ratatui::widgets::{Block, Borders, Paragraph, Tabs, Wrap};
+    use ratatui::widgets::{Block, Borders, Clear, Paragraph, Tabs, Wrap};
 
     let area = f.area();
     let chunks = Layout::default()
@@ -232,9 +375,74 @@ fn draw_ui(f: &mut ratatui::Frame<'_>, app: &mut App) {
         .scroll((view.scroll_y, 0));
     f.render_widget(content, content_area);
 
-    let help = Paragraph::new(
-        "q quit | 1/2/3 or p/d/s switch | ↑/↓ or j/k scroll | PgUp/PgDn page | Home/End",
-    )
-    .style(Style::default().fg(Color::DarkGray));
+    let help_text = if app.apply.dry_run {
+        "q quit | 1/2/3 or p/d/s switch | ↑/↓ or j/k scroll | PgUp/PgDn page | Home/End".to_string()
+    } else {
+        "q quit | a apply | 1/2/3 or p/d/s switch | ↑/↓ or j/k scroll | PgUp/PgDn page | Home/End"
+            .to_string()
+    };
+    let help = Paragraph::new(help_text).style(Style::default().fg(Color::DarkGray));
     f.render_widget(help, chunks[2]);
+
+    if let Some(modal) = app.modal.as_ref() {
+        let overlay_area = centered_rect(80, 40, area);
+        f.render_widget(Clear, overlay_area);
+
+        match modal {
+            Modal::ConfirmApply => {
+                let body =
+                    "Apply changes?\n\nPress 'y' to apply, or 'n'/'Esc' to cancel.".to_string();
+                let modal = Paragraph::new(body)
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .title("Confirm apply"),
+                    )
+                    .wrap(Wrap { trim: false });
+                f.render_widget(modal, overlay_area);
+            }
+            Modal::Message {
+                title,
+                body,
+                is_error,
+            } => {
+                let style = if *is_error {
+                    Style::default().fg(Color::Red)
+                } else {
+                    Style::default()
+                };
+                let modal = Paragraph::new(body.as_str())
+                    .style(style)
+                    .block(Block::default().borders(Borders::ALL).title(*title))
+                    .wrap(Wrap { trim: false });
+                f.render_widget(modal, overlay_area);
+            }
+        }
+    }
+}
+
+fn centered_rect(
+    percent_x: u16,
+    percent_y: u16,
+    r: ratatui::layout::Rect,
+) -> ratatui::layout::Rect {
+    use ratatui::layout::{Constraint, Direction, Layout};
+
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
 }

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -93,8 +93,8 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
             super::commands::status::run(&ctx, only)?;
         }
         #[cfg(feature = "tui")]
-        Commands::Tui => {
-            super::commands::tui::run(&ctx)?;
+        Commands::Tui { adopt } => {
+            super::commands::tui::run(&ctx, *adopt)?;
         }
         Commands::Doctor { fix } => {
             super::commands::doctor::run(&ctx, *fix)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod store;
 pub mod target_adapters;
 pub mod target_manifest;
 pub mod targets;
+pub mod tui_apply;
 pub mod tui_core;
 pub mod user_error;
 pub mod validate;

--- a/src/tui_apply.rs
+++ b/src/tui_apply.rs
@@ -1,0 +1,196 @@
+use std::path::Path;
+
+use crate::deploy::load_managed_paths_from_snapshot;
+use crate::deploy::plan as compute_plan;
+use crate::engine::Engine;
+use crate::state::latest_snapshot;
+use crate::targets::TargetRoot;
+use crate::user_error::UserError;
+
+#[derive(Debug)]
+pub enum ApplyOutcome {
+    Applied { snapshot_id: String },
+    NoChanges,
+}
+
+pub fn apply_from_tui(
+    repo_override: Option<&Path>,
+    machine_override: Option<&str>,
+    profile: &str,
+    target_filter: &str,
+    adopt: bool,
+    confirmed: bool,
+) -> anyhow::Result<ApplyOutcome> {
+    if !confirmed {
+        return Err(anyhow::Error::new(UserError::new(
+            "E_CONFIRM_REQUIRED",
+            "refusing to apply without explicit confirmation",
+        )));
+    }
+
+    let engine = Engine::load(repo_override, machine_override)?;
+    apply_from_tui_in(&engine, profile, target_filter, adopt, confirmed)
+}
+
+pub fn apply_from_tui_in(
+    engine: &Engine,
+    profile: &str,
+    target_filter: &str,
+    adopt: bool,
+    confirmed: bool,
+) -> anyhow::Result<ApplyOutcome> {
+    if !confirmed {
+        return Err(anyhow::Error::new(UserError::new(
+            "E_CONFIRM_REQUIRED",
+            "refusing to apply without explicit confirmation",
+        )));
+    }
+
+    let _targets = selected_targets(&engine.manifest, target_filter)?;
+    let render = engine.desired_state(profile, target_filter)?;
+    let desired = render.desired;
+    let mut warnings = render.warnings;
+    let roots = render.roots;
+    let managed_paths_from_manifest =
+        crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
+    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
+    let managed_paths = if !managed_paths_from_manifest.is_empty() {
+        Some(filter_managed(managed_paths_from_manifest, target_filter))
+    } else {
+        latest_snapshot(&engine.home, &["deploy", "rollback"])?
+            .as_ref()
+            .map(load_managed_paths_from_snapshot)
+            .transpose()?
+            .map(|m| filter_managed(m, target_filter))
+    };
+    let plan = compute_plan(&desired, managed_paths.as_ref())?;
+
+    let adopt_updates: Vec<&crate::deploy::PlanChange> = plan
+        .changes
+        .iter()
+        .filter(|c| matches!(c.update_kind, Some(crate::deploy::UpdateKind::AdoptUpdate)))
+        .collect();
+    if !adopt_updates.is_empty() && !adopt {
+        let mut sample_paths: Vec<String> = adopt_updates.iter().map(|c| c.path.clone()).collect();
+        sample_paths.sort();
+        sample_paths.truncate(20);
+
+        return Err(anyhow::Error::new(
+            UserError::new(
+                "E_ADOPT_CONFIRM_REQUIRED",
+                "refusing to overwrite unmanaged existing files without --adopt",
+            )
+            .with_details(serde_json::json!({
+                "flag": "--adopt",
+                "adopt_updates": adopt_updates.len(),
+                "sample_paths": sample_paths,
+            })),
+        ));
+    }
+
+    let needs_manifests = manifests_missing_for_desired(&roots, &desired);
+
+    if plan.changes.is_empty() && !needs_manifests {
+        return Ok(ApplyOutcome::NoChanges);
+    }
+
+    let lockfile_path = if engine.repo.lockfile_path.exists() {
+        Some(engine.repo.lockfile_path.as_path())
+    } else {
+        None
+    };
+    let snapshot = crate::apply::apply_plan(
+        &engine.home,
+        "deploy",
+        &plan,
+        &desired,
+        lockfile_path,
+        &roots,
+    )?;
+
+    Ok(ApplyOutcome::Applied {
+        snapshot_id: snapshot.id,
+    })
+}
+
+fn selected_targets(
+    manifest: &crate::config::Manifest,
+    target_filter: &str,
+) -> anyhow::Result<Vec<String>> {
+    let mut known: Vec<String> = manifest.targets.keys().cloned().collect();
+    known.sort();
+
+    match target_filter {
+        "all" => Ok(known),
+        "codex" | "claude_code" | "cursor" | "vscode" => {
+            if !manifest.targets.contains_key(target_filter) {
+                return Err(anyhow::Error::new(
+                    UserError::new(
+                        "E_CONFIG_INVALID",
+                        format!("target not configured: {target_filter}"),
+                    )
+                    .with_details(serde_json::json!({
+                        "target": target_filter,
+                        "hint": "add the target under `targets:` in agentpack.yaml",
+                    })),
+                ));
+            }
+            Ok(vec![target_filter.to_string()])
+        }
+        other => Err(anyhow::Error::new(
+            UserError::new(
+                "E_TARGET_UNSUPPORTED",
+                format!("unsupported --target: {other}"),
+            )
+            .with_details(serde_json::json!({
+                "target": other,
+                "allowed": ["all","codex","claude_code","cursor","vscode"],
+            })),
+        )),
+    }
+}
+
+fn filter_managed(
+    managed: crate::deploy::ManagedPaths,
+    target_filter: &str,
+) -> crate::deploy::ManagedPaths {
+    managed
+        .into_iter()
+        .filter(|tp| target_filter == "all" || tp.target == target_filter)
+        .collect()
+}
+
+fn best_root_idx(roots: &[TargetRoot], target: &str, path: &Path) -> Option<usize> {
+    roots
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.target == target)
+        .filter(|(_, r)| path.strip_prefix(&r.root).is_ok())
+        .max_by_key(|(_, r)| r.root.components().count())
+        .map(|(idx, _)| idx)
+}
+
+fn manifests_missing_for_desired(
+    roots: &[TargetRoot],
+    desired: &crate::deploy::DesiredState,
+) -> bool {
+    if roots.is_empty() {
+        return false;
+    }
+
+    let mut used: Vec<bool> = vec![false; roots.len()];
+    for tp in desired.keys() {
+        if let Some(idx) = best_root_idx(roots, &tp.target, &tp.path) {
+            used[idx] = true;
+        }
+    }
+
+    for (idx, root) in roots.iter().enumerate() {
+        if used[idx] && !crate::target_manifest::manifest_path(&root.root).exists() {
+            return true;
+        }
+    }
+
+    false
+}

--- a/tests/tui_safe_apply.rs
+++ b/tests/tui_safe_apply.rs
@@ -1,0 +1,116 @@
+use std::path::Path;
+
+use agentpack::config::Manifest;
+use agentpack::engine::Engine;
+use agentpack::paths::{AgentpackHome, RepoPaths};
+use agentpack::project::ProjectContext;
+use agentpack::store::Store;
+use agentpack::user_error::UserError;
+
+fn write_manifest(repo_dir: &Path, codex_home: &Path) -> anyhow::Result<()> {
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{codex_home}'
+      write_agents_global: true
+      write_agents_repo_root: false
+      write_user_prompts: false
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: instructions:base
+    type: instructions
+    enabled: true
+    tags: ["base"]
+    targets: ["codex"]
+    source:
+      local_path:
+        path: modules/instructions/base
+"#,
+        codex_home = codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest)?;
+    Ok(())
+}
+
+fn write_file(repo_dir: &Path, rel_dir: &str, filename: &str, content: &str) -> anyhow::Result<()> {
+    let dir = repo_dir.join(rel_dir);
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(dir.join(filename), content)?;
+    Ok(())
+}
+
+fn make_home(tmp: &tempfile::TempDir) -> anyhow::Result<AgentpackHome> {
+    let root = tmp.path().join("agentpack_home");
+    let state_dir = root.join("state");
+    let home = AgentpackHome {
+        repo_dir: root.join("repo"),
+        cache_dir: root.join("cache"),
+        snapshots_dir: state_dir.join("snapshots"),
+        logs_dir: state_dir.join("logs"),
+        state_dir,
+        root,
+    };
+    std::fs::create_dir_all(&home.cache_dir)?;
+    std::fs::create_dir_all(&home.snapshots_dir)?;
+    std::fs::create_dir_all(&home.logs_dir)?;
+    Ok(home)
+}
+
+#[test]
+fn tui_apply_requires_explicit_confirmation_and_does_not_write() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let home = make_home(&tmp)?;
+
+    let repo_dir = tmp.path().join("repo");
+    std::fs::create_dir_all(&repo_dir)?;
+
+    let codex_home = tmp.path().join("codex_home");
+    std::fs::create_dir_all(&codex_home)?;
+
+    write_manifest(&repo_dir, &codex_home)?;
+    write_file(
+        &repo_dir,
+        "modules/instructions/base",
+        "AGENTS.md",
+        "# Test instructions\n",
+    )?;
+
+    let repo = RepoPaths::resolve(&home, Some(&repo_dir))?;
+    let manifest = Manifest::load(&repo.manifest_path)?;
+    let store = Store::new(&home);
+    let project = ProjectContext::detect(tmp.path())?;
+
+    let engine = Engine {
+        home,
+        repo,
+        manifest,
+        lockfile: None,
+        store,
+        project,
+        machine_id: "test-machine".to_string(),
+    };
+
+    let err = agentpack::tui_apply::apply_from_tui_in(&engine, "default", "codex", false, false)
+        .expect_err("expected confirm-required error");
+    let user_err = err
+        .chain()
+        .find_map(|e| e.downcast_ref::<UserError>())
+        .expect("UserError present");
+    assert_eq!(user_err.code, "E_CONFIRM_REQUIRED");
+
+    assert_eq!(std::fs::read_dir(&codex_home)?.count(), 0);
+    assert_eq!(std::fs::read_dir(&engine.home.snapshots_dir)?.count(), 0);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #216.

Implements OpenSpec change: `add-tui-safe-apply`.

## What
- Add `a` (apply) action to `agentpack tui`, with an explicit confirmation modal.
- Add `--adopt` support for parity with `deploy --apply`.
- Surface stable error codes + pretty-printed details on apply failures.
- Add headless test to guarantee no writes without confirmation.

## Validation
- `just check`
- `openspec validate add-tui-safe-apply --strict --no-interactive`
