### PR TITLE
docs(spec): add target feature flags (OpenSpec)

### DIFF
--- a/openspec/changes/add-target-feature-flags/proposal.md
+++ b/openspec/changes/add-target-feature-flags/proposal.md
@@ -1,0 +1,23 @@
+# Change: Target adapter compile-time feature flags
+
+## Why
+Agentpack’s TargetAdapters evolve quickly as upstream tools change. Being able to compile a smaller binary with only the targets you need helps:
+- reduce build/dependency surface area,
+- speed up iteration and CI,
+- isolate target-specific churn,
+- and make it easier to add new targets without entangling unrelated adapters.
+
+## What Changes
+- Define per-target Cargo features:
+  - `target-codex`
+  - `target-claude-code`
+  - `target-cursor`
+  - `target-vscode`
+- Define a default feature set that includes all built-in targets (so `cargo build` preserves current behavior).
+- Require `agentpack help --json` to expose the compiled target set (additive field) so automation can discover what the running binary supports.
+- Define behavior when selecting a non-compiled target: fail with existing stable error code `E_TARGET_UNSUPPORTED` (in `--json` mode).
+
+## Impact
+- Affected OpenSpec capability: `openspec/specs/agentpack-cli/spec.md`
+- Compatibility: additive only for `schema_version=1`
+- Follow-up implementation work is tracked under: #218 (feature-gated adapters) and #219 (CI matrix)

--- a/openspec/changes/add-target-feature-flags/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-target-feature-flags/specs/agentpack-cli/spec.md
@@ -1,0 +1,47 @@
+# agentpack-cli (delta)
+
+## MODIFIED Requirements
+
+### Requirement: help --json is self-describing
+The system SHALL provide `agentpack help --json` which emits machine-consumable documentation, including:
+- a `commands` list describing available commands/subcommands,
+- `mutating_commands` listing mutating command IDs that require `--yes` in `--json` mode, and
+- `targets` listing compiled-in target adapters.
+
+Each item in `data.commands[]` SHALL include:
+- `id` (stable command id),
+- `path[]` (command path segments),
+- `mutating` (whether the base invocation mutates), and
+- `supports_json` (whether the command supports `--json` output).
+
+`data.commands[]` SHOULD include `args[]` describing command-specific arguments (excluding global args).
+
+The output SHOULD also include `global_args[]` describing global flags/options.
+
+#### Scenario: help --json returns command metadata
+- **WHEN** the user runs `agentpack help --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.commands` exists
+- **AND** `data.commands[0].supports_json` exists
+- **AND** `data.global_args` exists
+- **AND** `data.mutating_commands` exists
+- **AND** `data.targets` exists
+
+## ADDED Requirements
+
+### Requirement: Target adapters can be feature-gated at build time
+The system SHALL support building agentpack with a subset of target adapters enabled via Cargo features:
+- `target-codex`
+- `target-claude-code`
+- `target-cursor`
+- `target-vscode`
+
+The default feature set SHOULD include all built-in targets (to preserve the default user experience).
+
+If a user selects a target that is not compiled into the running binary, the CLI MUST treat it as unsupported.
+
+#### Scenario: selecting a non-compiled target fails with E_TARGET_UNSUPPORTED
+- **GIVEN** an agentpack binary built without `target-cursor`
+- **WHEN** the user runs `agentpack plan --target cursor --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_TARGET_UNSUPPORTED`

--- a/openspec/changes/add-target-feature-flags/tasks.md
+++ b/openspec/changes/add-target-feature-flags/tasks.md
@@ -1,0 +1,7 @@
+## 1. Spec
+- [x] 1.1 Define per-target Cargo feature names and the default feature set.
+- [x] 1.2 Require `help --json` to include the compiled target set (additive field).
+- [x] 1.3 Specify behavior when selecting a non-compiled target (`E_TARGET_UNSUPPORTED`).
+
+## 2. Validation
+- [x] 2.1 Run `openspec validate add-target-feature-flags --strict --no-interactive`.


### PR DESCRIPTION
Relates to #217.

Proposes per-target Cargo features and extends `agentpack help --json` to expose compiled targets (additive-only).

Implementation will follow in #218 and #219.
