### PR TITLE
feat(targets): feature-gate target adapters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,12 @@ dirs = "6.0.0"
 similar = "2.7.0"
 
 [features]
+default = ["target-codex", "target-claude-code", "target-cursor", "target-vscode"]
 tui = ["dep:crossterm", "dep:ratatui"]
+target-codex = []
+target-claude-code = []
+target-cursor = []
+target-vscode = []
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -65,10 +65,11 @@ Details: typically includes `{version, supported}`.
 Meaning:
 - `--target` specifies an unsupported value, or
 - The manifest config contains an unknown target.
+- The target is not compiled into the running agentpack binary (feature-gated builds).
 Retryable: yes.
 Recommended action:
-- `--target` must be `all|codex|claude_code|cursor|vscode`
-- Manifest targets must be built-in targets (currently `codex`, `claude_code`, `cursor`, and `vscode`)
+- `--target` must be `all|codex|claude_code|cursor|vscode` (but feature-gated builds may support a subset; see `agentpack help --json` `data.targets[]`).
+- Manifest targets must be built-in targets that are compiled into the running binary.
 
 ### E_DESIRED_STATE_CONFLICT
 Meaning: multiple modules produced different content for the same `(target, path)`. Agentpack refuses to silently overwrite.

--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -49,7 +49,7 @@ Failure example:
 In `--json` mode, mutating commands require explicit `--yes`, otherwise they return `E_CONFIRM_REQUIRED`.
 
 You can use:
-- `agentpack help --json` to obtain the command list and which commands are `mutating`
+- `agentpack help --json` to obtain the command list, the mutating command set, and the compiled target set (`data.targets[]`)
 
 Common mutating commands (not exhaustive):
 - `deploy --apply`, `update`, `lock`, `fetch`, `add/remove`, `bootstrap`, `rollback`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -534,6 +534,7 @@ Notes:
   - `data.commands[]` (command catalog)
   - `data.mutating_commands[]` (command IDs that require `--yes` in `--json` mode)
   - `data.global_args[]` (global flags)
+  - `data.targets[]` (compiled-in target adapters)
 
 `agentpack schema`
 - prints a brief JSON schema summary (human mode)
@@ -562,6 +563,16 @@ JSON mode:
 - `tui` does not support `--json`; when `--json` is passed, it fails with `E_CONFIG_INVALID`.
 
 ## 5. Target adapter details
+
+Build-time target selection:
+- Target adapters can be compiled selectively via Cargo features:
+  - `target-codex`
+  - `target-claude-code`
+  - `target-cursor`
+  - `target-vscode`
+- Default builds include all built-in targets.
+- `agentpack help --json` includes `data.targets[]` listing targets compiled into the running binary.
+- Selecting a non-compiled target is treated as unsupported (`E_TARGET_UNSUPPORTED`).
 
 ### 5.1 `codex` target
 

--- a/src/cli/commands/help.rs
+++ b/src/cli/commands/help.rs
@@ -40,6 +40,7 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                 "global_args": global_args,
                 "commands": commands,
                 "mutating_commands": super::super::util::MUTATING_COMMAND_IDS,
+                "targets": crate::target_registry::COMPILED_TARGETS,
                 "notes": [
                     "recommended: doctor -> update -> preview -> deploy --apply",
                     "recommended: status -> evolve propose -> review -> deploy --apply",

--- a/src/cli/commands/schema.rs
+++ b/src/cli/commands/schema.rs
@@ -25,7 +25,7 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                     }
                 },
                 "commands": {
-                    "help": { "data_fields": ["global_args","commands","mutating_commands","notes"] },
+                    "help": { "data_fields": ["global_args","commands","mutating_commands","notes","targets"] },
                     "plan": { "data_fields": ["profile","targets","changes","summary"] },
                     "diff": { "data_fields": ["profile","targets","changes","summary"] },
                     "preview": { "data_fields": ["profile","targets","plan","diff?"] },

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -49,37 +49,7 @@ pub(crate) fn selected_targets(
     manifest: &Manifest,
     target_filter: &str,
 ) -> anyhow::Result<Vec<String>> {
-    let mut known: Vec<String> = manifest.targets.keys().cloned().collect();
-    known.sort();
-
-    match target_filter {
-        "all" => Ok(known),
-        "codex" | "claude_code" | "cursor" | "vscode" => {
-            if !manifest.targets.contains_key(target_filter) {
-                return Err(anyhow::Error::new(
-                    UserError::new(
-                        "E_CONFIG_INVALID",
-                        format!("target not configured: {target_filter}"),
-                    )
-                    .with_details(serde_json::json!({
-                        "target": target_filter,
-                        "hint": "add the target under `targets:` in agentpack.yaml",
-                    })),
-                ));
-            }
-            Ok(vec![target_filter.to_string()])
-        }
-        other => Err(anyhow::Error::new(
-            UserError::new(
-                "E_TARGET_UNSUPPORTED",
-                format!("unsupported --target: {other}"),
-            )
-            .with_details(serde_json::json!({
-                "target": other,
-                "allowed": ["all","codex","claude_code","cursor","vscode"],
-            })),
-        )),
-    }
+    crate::target_selection::selected_targets(manifest, target_filter)
 }
 
 pub(crate) fn filter_managed(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub mod state;
 pub mod store;
 pub mod target_adapters;
 pub mod target_manifest;
+pub mod target_registry;
+pub mod target_selection;
 pub mod targets;
 pub mod tui_apply;
 pub mod tui_core;

--- a/src/target_adapters.rs
+++ b/src/target_adapters.rs
@@ -15,11 +15,16 @@ pub trait TargetAdapter {
     ) -> anyhow::Result<()>;
 }
 
+#[cfg(feature = "target-codex")]
 struct CodexAdapter;
+#[cfg(feature = "target-claude-code")]
 struct ClaudeCodeAdapter;
+#[cfg(feature = "target-cursor")]
 struct CursorAdapter;
+#[cfg(feature = "target-vscode")]
 struct VscodeAdapter;
 
+#[cfg(feature = "target-codex")]
 impl TargetAdapter for CodexAdapter {
     fn id(&self) -> &'static str {
         "codex"
@@ -37,6 +42,7 @@ impl TargetAdapter for CodexAdapter {
     }
 }
 
+#[cfg(feature = "target-claude-code")]
 impl TargetAdapter for ClaudeCodeAdapter {
     fn id(&self) -> &'static str {
         "claude_code"
@@ -54,6 +60,7 @@ impl TargetAdapter for ClaudeCodeAdapter {
     }
 }
 
+#[cfg(feature = "target-cursor")]
 impl TargetAdapter for CursorAdapter {
     fn id(&self) -> &'static str {
         "cursor"
@@ -71,6 +78,7 @@ impl TargetAdapter for CursorAdapter {
     }
 }
 
+#[cfg(feature = "target-vscode")]
 impl TargetAdapter for VscodeAdapter {
     fn id(&self) -> &'static str {
         "vscode"
@@ -89,15 +97,23 @@ impl TargetAdapter for VscodeAdapter {
 }
 
 pub fn adapter_for(target: &str) -> Option<&'static dyn TargetAdapter> {
+    #[cfg(feature = "target-codex")]
     static CODEX: CodexAdapter = CodexAdapter;
+    #[cfg(feature = "target-claude-code")]
     static CLAUDE: ClaudeCodeAdapter = ClaudeCodeAdapter;
+    #[cfg(feature = "target-cursor")]
     static CURSOR: CursorAdapter = CursorAdapter;
+    #[cfg(feature = "target-vscode")]
     static VSCODE: VscodeAdapter = VscodeAdapter;
 
     match target {
+        #[cfg(feature = "target-codex")]
         "codex" => Some(&CODEX),
+        #[cfg(feature = "target-claude-code")]
         "claude_code" => Some(&CLAUDE),
+        #[cfg(feature = "target-cursor")]
         "cursor" => Some(&CURSOR),
+        #[cfg(feature = "target-vscode")]
         "vscode" => Some(&VSCODE),
         _ => None,
     }

--- a/src/target_registry.rs
+++ b/src/target_registry.rs
@@ -1,0 +1,21 @@
+pub const COMPILED_TARGETS: &[&str] = &[
+    #[cfg(feature = "target-codex")]
+    "codex",
+    #[cfg(feature = "target-claude-code")]
+    "claude_code",
+    #[cfg(feature = "target-cursor")]
+    "cursor",
+    #[cfg(feature = "target-vscode")]
+    "vscode",
+];
+
+pub fn is_compiled_target(target: &str) -> bool {
+    COMPILED_TARGETS.iter().any(|t| t == &target)
+}
+
+pub fn allowed_target_filters() -> Vec<&'static str> {
+    let mut out = Vec::with_capacity(COMPILED_TARGETS.len() + 1);
+    out.push("all");
+    out.extend(COMPILED_TARGETS);
+    out
+}

--- a/src/target_selection.rs
+++ b/src/target_selection.rs
@@ -1,0 +1,53 @@
+use crate::config::Manifest;
+use crate::user_error::UserError;
+
+pub fn selected_targets(manifest: &Manifest, target_filter: &str) -> anyhow::Result<Vec<String>> {
+    let mut known: Vec<String> = manifest.targets.keys().cloned().collect();
+    known.sort();
+
+    match target_filter {
+        "all" => {
+            let missing: Vec<String> = known
+                .iter()
+                .filter(|t| !crate::target_registry::is_compiled_target(t))
+                .cloned()
+                .collect();
+            if !missing.is_empty() {
+                return Err(anyhow::Error::new(
+                    UserError::new(
+                        "E_TARGET_UNSUPPORTED",
+                        "one or more configured targets are not compiled into this agentpack build",
+                    )
+                    .with_details(serde_json::json!({
+                        "target": "all",
+                        "missing": missing,
+                        "compiled": crate::target_registry::COMPILED_TARGETS,
+                    })),
+                ));
+            }
+            Ok(known)
+        }
+        t if crate::target_registry::is_compiled_target(t) => {
+            if !manifest.targets.contains_key(t) {
+                return Err(anyhow::Error::new(
+                    UserError::new("E_CONFIG_INVALID", format!("target not configured: {t}"))
+                        .with_details(serde_json::json!({
+                            "target": t,
+                            "hint": "add the target under `targets:` in agentpack.yaml",
+                        })),
+                ));
+            }
+            Ok(vec![t.to_string()])
+        }
+        other => Err(anyhow::Error::new(
+            UserError::new(
+                "E_TARGET_UNSUPPORTED",
+                format!("unsupported --target: {other}"),
+            )
+            .with_details(serde_json::json!({
+                "target": other,
+                "allowed": crate::target_registry::allowed_target_filters(),
+            })),
+        )),
+    }
+}

--- a/src/tui_apply.rs
+++ b/src/tui_apply.rs
@@ -46,7 +46,7 @@ pub fn apply_from_tui_in(
         )));
     }
 
-    let _targets = selected_targets(&engine.manifest, target_filter)?;
+    let _targets = crate::target_selection::selected_targets(&engine.manifest, target_filter)?;
     let render = engine.desired_state(profile, target_filter)?;
     let desired = render.desired;
     let mut warnings = render.warnings;
@@ -112,43 +112,6 @@ pub fn apply_from_tui_in(
     Ok(ApplyOutcome::Applied {
         snapshot_id: snapshot.id,
     })
-}
-
-fn selected_targets(
-    manifest: &crate::config::Manifest,
-    target_filter: &str,
-) -> anyhow::Result<Vec<String>> {
-    let mut known: Vec<String> = manifest.targets.keys().cloned().collect();
-    known.sort();
-
-    match target_filter {
-        "all" => Ok(known),
-        "codex" | "claude_code" | "cursor" | "vscode" => {
-            if !manifest.targets.contains_key(target_filter) {
-                return Err(anyhow::Error::new(
-                    UserError::new(
-                        "E_CONFIG_INVALID",
-                        format!("target not configured: {target_filter}"),
-                    )
-                    .with_details(serde_json::json!({
-                        "target": target_filter,
-                        "hint": "add the target under `targets:` in agentpack.yaml",
-                    })),
-                ));
-            }
-            Ok(vec![target_filter.to_string()])
-        }
-        other => Err(anyhow::Error::new(
-            UserError::new(
-                "E_TARGET_UNSUPPORTED",
-                format!("unsupported --target: {other}"),
-            )
-            .with_details(serde_json::json!({
-                "target": other,
-                "allowed": ["all","codex","claude_code","cursor","vscode"],
-            })),
-        )),
-    }
 }
 
 fn filter_managed(

--- a/tests/cli_help_schema.rs
+++ b/tests/cli_help_schema.rs
@@ -55,6 +55,17 @@ fn help_json_is_self_describing() {
             .iter()
             .any(|x| x == "deploy --apply")
     );
+
+    assert!(v["data"]["targets"].is_array());
+    let targets = v["data"]["targets"].as_array().unwrap();
+    #[cfg(feature = "target-codex")]
+    assert!(targets.iter().any(|t| t == "codex"));
+    #[cfg(feature = "target-claude-code")]
+    assert!(targets.iter().any(|t| t == "claude_code"));
+    #[cfg(feature = "target-cursor")]
+    assert!(targets.iter().any(|t| t == "cursor"));
+    #[cfg(feature = "target-vscode")]
+    assert!(targets.iter().any(|t| t == "vscode"));
 }
 
 #[test]

--- a/tests/cli_json_golden.rs
+++ b/tests/cli_json_golden.rs
@@ -55,6 +55,7 @@ fn assert_envelope_shape(v: &serde_json::Value, expected_command: &str, ok: bool
 }
 
 #[test]
+#[cfg(not(feature = "tui"))]
 fn help_json_data_matches_golden_snapshot() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let output = agentpack_in(tmp.path(), &["help", "--json"]);

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -598,5 +598,11 @@
     "recommended: doctor -> update -> preview -> deploy --apply",
     "recommended: status -> evolve propose -> review -> deploy --apply",
     "in --json mode, mutating commands require --yes"
+  ],
+  "targets": [
+    "codex",
+    "claude_code",
+    "cursor",
+    "vscode"
   ]
 }

--- a/tests/golden/schema_json_data.json
+++ b/tests/golden/schema_json_data.json
@@ -13,7 +13,8 @@
         "global_args",
         "commands",
         "mutating_commands",
-        "notes"
+        "notes",
+        "targets"
       ]
     },
     "plan": {


### PR DESCRIPTION
Closes #218.
Closes #217.

Implements per-target Cargo features (default enables all targets), makes target selection respect the compiled target set, and extends `agentpack help --json` with `data.targets[]`.

Follow-up: archive the OpenSpec change (`add-target-feature-flags`) in a separate PR.
