### PR TITLE
feat(mcp): add stdio server skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,8 @@ dependencies = [
  "dirs",
  "hex",
  "ratatui",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -20,6 +22,7 @@ dependencies = [
  "similar",
  "tempfile",
  "time",
+ "tokio",
  "walkdir",
 ]
 
@@ -28,6 +31,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -86,6 +98,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +136,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytes"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,10 +157,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -194,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,8 +322,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -264,12 +351,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn",
 ]
@@ -346,6 +458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +508,95 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -442,6 +655,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,7 +709,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "indoc",
  "proc-macro2",
  "quote",
@@ -508,6 +745,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kasuari"
@@ -606,6 +853,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +910,24 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
@@ -775,6 +1049,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df440eaa43f8573491ed4a5899719b6d29099500774abba12214a095a4083ed"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef03779cccab8337dd8617c53fce5c98ec21794febc397531555472ca28f8c3"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +1144,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -860,6 +1215,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +1263,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +1304,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1050,6 +1428,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,6 +1572,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,10 +1648,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ tempfile = "3.20.0"
 time = { version = "0.3.41", features = ["formatting", "macros"] }
 dirs = "6.0.0"
 similar = "2.7.0"
+rmcp = { version = "0.11.0", features = ["transport-io"] }
+schemars = "1.0"
+tokio = { version = "1.43.0", features = ["rt", "macros"] }
 
 [features]
 default = ["target-codex", "target-claude-code", "target-cursor", "target-vscode"]

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -562,6 +562,24 @@ Apply:
 JSON mode:
 - `tui` does not support `--json`; when `--json` is passed, it fails with `E_CONFIG_INVALID`.
 
+### 4.18 `mcp serve` (MCP server, stdio)
+
+`agentpack mcp serve`
+
+Behavior:
+- Runs an MCP server over stdio (newline-delimited JSON-RPC).
+- Stdout is reserved for MCP protocol messages; logs and diagnostics MUST go to stderr.
+
+Tools (minimum set):
+- read-only: `plan`, `diff`, `status`, `doctor`
+- mutating (explicit approval): `deploy_apply`, `rollback`
+
+Tool results:
+- Tool results reuse Agentpack’s `--json` envelope as the canonical payload, returned as structured content and as serialized JSON text.
+
+JSON mode:
+- `mcp serve` does not support `--json`.
+
 ## 5. Target adapter details
 
 Build-time target selection:

--- a/openspec/changes/add-mcp-server/tasks.md
+++ b/openspec/changes/add-mcp-server/tasks.md
@@ -6,11 +6,11 @@
 - [x] Run `openspec validate add-mcp-server --strict --no-interactive`
 
 ## 2. Implementation: server skeleton (P2-4-1)
-- [ ] Add `agentpack mcp serve` entrypoint (stdio JSON-RPC loop, no stdout noise)
-- [ ] Implement MCP `initialize` + `initialized` handling with `tools` capability
-- [ ] Implement `tools/list` for the declared tools
-- [ ] Implement `tools/call` dispatcher (stubbed responses initially)
-- [ ] Add integration test: spawn server, run initialize + tools/list + one tools/call
+- [x] Add `agentpack mcp serve` entrypoint (stdio JSON-RPC loop, no stdout noise)
+- [x] Implement MCP `initialize` + `initialized` handling with `tools` capability
+- [x] Implement `tools/list` for the declared tools
+- [x] Implement `tools/call` dispatcher (stubbed responses initially)
+- [x] Add integration test: spawn server, run initialize + tools/list + one tools/call
 
 ## 3. Implementation: read-only tools (P2-4-2)
 - [ ] Implement `plan` tool by routing to existing plan engine/CLI JSON output

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -148,6 +148,12 @@ pub enum Commands {
         adopt: bool,
     },
 
+    /// MCP server (stdio)
+    Mcp {
+        #[command(subcommand)]
+        command: McpCommands,
+    },
+
     /// Check local environment and target paths
     Doctor {
         /// Idempotently add `.agentpack.manifest.json` to `.gitignore` for detected repos
@@ -302,6 +308,12 @@ pub enum RemoteCommands {
 }
 
 #[derive(Subcommand, Debug)]
+pub enum McpCommands {
+    /// Run the Agentpack MCP server over stdio
+    Serve,
+}
+
+#[derive(Subcommand, Debug)]
 pub enum ExplainCommands {
     /// Explain the current plan (module provenance and overlay layers)
     Plan,
@@ -371,6 +383,7 @@ impl Cli {
             Commands::Status { .. } => "status",
             #[cfg(feature = "tui")]
             Commands::Tui { .. } => "tui",
+            Commands::Mcp { .. } => "mcp",
             Commands::Doctor { .. } => "doctor",
             Commands::Remote { .. } => "remote",
             Commands::Sync { .. } => "sync",

--- a/src/cli/commands/help.rs
+++ b/src/cli/commands/help.rs
@@ -131,7 +131,7 @@ fn add_legacy_doctor_fix_variant(commands: &mut Vec<HelpCommand>) {
 }
 
 fn supports_json_for_command(command_id: &str) -> bool {
-    command_id != "completions"
+    !matches!(command_id, "completions" | "mcp serve" | "tui")
 }
 
 fn help_arg_from_clap(

--- a/src/cli/commands/mcp.rs
+++ b/src/cli/commands/mcp.rs
@@ -1,0 +1,36 @@
+use anyhow::Context as _;
+
+use rmcp::{ServiceExt, transport::stdio};
+
+use crate::user_error::UserError;
+
+use super::Ctx;
+
+pub(crate) fn run(ctx: &Ctx<'_>, command: &crate::cli::args::McpCommands) -> anyhow::Result<()> {
+    if ctx.cli.json {
+        return Err(anyhow::Error::new(UserError::new(
+            "E_CONFIG_INVALID",
+            "mcp serve does not support --json (stdout is reserved for MCP protocol messages)",
+        )));
+    }
+
+    match command {
+        crate::cli::args::McpCommands::Serve => serve(),
+    }
+}
+
+fn serve() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("create tokio runtime")?;
+
+    rt.block_on(async {
+        let server = crate::mcp::AgentpackMcp::new()
+            .serve(stdio())
+            .await
+            .context("start mcp server")?;
+        server.waiting().await.context("wait for shutdown")?;
+        Ok::<(), anyhow::Error>(())
+    })
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod fetch;
 pub(crate) mod help;
 pub(crate) mod init;
 pub(crate) mod lock;
+pub(crate) mod mcp;
 pub(crate) mod overlay;
 pub(crate) mod plan;
 pub(crate) mod preview;

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -8,10 +8,11 @@ use crate::paths::{AgentpackHome, RepoPaths};
 
 pub fn run() -> std::process::ExitCode {
     let cli = Cli::parse();
+    let force_human_errors = matches!(cli.command, Commands::Mcp { .. });
     match run_with(&cli) {
         Ok(()) => std::process::ExitCode::SUCCESS,
         Err(err) => {
-            if cli.json {
+            if cli.json && !force_human_errors {
                 print_anyhow_error(&cli, &err);
             } else if !print_user_error_human(&err) {
                 eprintln!("{err:#}");
@@ -95,6 +96,9 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
         #[cfg(feature = "tui")]
         Commands::Tui { adopt } => {
             super::commands::tui::run(&ctx, *adopt)?;
+        }
+        Commands::Mcp { command } => {
+            super::commands::mcp::run(&ctx, command)?;
         }
         Commands::Doctor { fix } => {
             super::commands::doctor::run(&ctx, *fix)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ids;
 pub mod lockfile;
 pub mod machine;
 pub mod markers;
+pub mod mcp;
 pub mod output;
 pub mod overlay;
 pub mod paths;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,290 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use rmcp::{
+    ErrorData as McpError, RoleServer, ServerHandler,
+    model::{
+        CallToolRequestParam, CallToolResult, Content, Implementation, JsonObject, ListToolsResult,
+        PaginatedRequestParam, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
+        ToolAnnotations,
+    },
+    service::RequestContext,
+};
+
+fn envelope_error(
+    command: &str,
+    code: &str,
+    message: &str,
+    details: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut err = serde_json::Map::from_iter([
+        (
+            "code".to_string(),
+            serde_json::Value::String(code.to_string()),
+        ),
+        (
+            "message".to_string(),
+            serde_json::Value::String(message.to_string()),
+        ),
+    ]);
+    if let Some(details) = details {
+        err.insert("details".to_string(), details);
+    }
+
+    serde_json::Value::Object(serde_json::Map::from_iter([
+        (
+            "schema_version".to_string(),
+            serde_json::Value::Number(1.into()),
+        ),
+        ("ok".to_string(), serde_json::Value::Bool(false)),
+        (
+            "command".to_string(),
+            serde_json::Value::String(command.to_string()),
+        ),
+        (
+            "version".to_string(),
+            serde_json::Value::String(env!("CARGO_PKG_VERSION").to_string()),
+        ),
+        (
+            "data".to_string(),
+            serde_json::Value::Object(serde_json::Map::new()),
+        ),
+        ("warnings".to_string(), serde_json::Value::Array(Vec::new())),
+        (
+            "errors".to_string(),
+            serde_json::Value::Array(vec![serde_json::Value::Object(err)]),
+        ),
+    ]))
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct CommonArgs {
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub profile: Option<String>,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub machine: Option<String>,
+    #[serde(default)]
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct StatusArgs {
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    #[serde(default)]
+    pub only: Option<Vec<StatusOnly>>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum StatusOnly {
+    Missing,
+    Modified,
+    Extra,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct DoctorArgs {
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct DeployApplyArgs {
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    #[serde(default)]
+    pub adopt: Option<bool>,
+    #[serde(default)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+pub struct RollbackArgs {
+    #[serde(default)]
+    pub repo: Option<String>,
+    pub to: String,
+    #[serde(default)]
+    pub yes: bool,
+}
+
+#[derive(Clone, Default)]
+pub struct AgentpackMcp;
+
+impl AgentpackMcp {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+fn tool_input_schema<T: schemars::JsonSchema + 'static>() -> Arc<JsonObject> {
+    Arc::new(rmcp::handler::server::tool::schema_for_type::<T>())
+}
+
+fn tool(
+    name: &'static str,
+    description: &'static str,
+    input_schema: Arc<JsonObject>,
+    read_only: bool,
+) -> Tool {
+    Tool::new(name, description, input_schema).annotate(
+        ToolAnnotations::new()
+            .read_only(read_only)
+            .destructive(!read_only),
+    )
+}
+
+fn deserialize_args<T: serde::de::DeserializeOwned + Default>(
+    args: Option<JsonObject>,
+) -> Result<T, McpError> {
+    let value = serde_json::Value::Object(args.unwrap_or_default());
+    serde_json::from_value(value).map_err(|e| McpError::invalid_params(e.to_string(), None))
+}
+
+impl ServerHandler for AgentpackMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2025_06_18,
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
+            server_info: Implementation {
+                name: env!("CARGO_CRATE_NAME").to_string(),
+                title: None,
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                icons: None,
+                website_url: None,
+            },
+            instructions: Some(
+                "Agentpack MCP server (stdio). Tools: plan, diff, status, doctor, deploy_apply, rollback."
+                    .to_string(),
+            ),
+        }
+    }
+
+    fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParam>,
+        _context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<ListToolsResult, McpError>> + Send + '_ {
+        std::future::ready(Ok(ListToolsResult {
+            tools: vec![
+                tool(
+                    "plan",
+                    "Compute plan (returns Agentpack JSON envelope).",
+                    tool_input_schema::<CommonArgs>(),
+                    true,
+                ),
+                tool(
+                    "diff",
+                    "Compute diff (returns Agentpack JSON envelope).",
+                    tool_input_schema::<CommonArgs>(),
+                    true,
+                ),
+                tool(
+                    "status",
+                    "Compute drift/status (returns Agentpack JSON envelope).",
+                    tool_input_schema::<StatusArgs>(),
+                    true,
+                ),
+                tool(
+                    "doctor",
+                    "Run doctor checks (returns Agentpack JSON envelope; read-only).",
+                    tool_input_schema::<DoctorArgs>(),
+                    true,
+                ),
+                tool(
+                    "deploy_apply",
+                    "Deploy with apply (requires yes=true).",
+                    tool_input_schema::<DeployApplyArgs>(),
+                    false,
+                ),
+                tool(
+                    "rollback",
+                    "Rollback to a snapshot id (requires yes=true).",
+                    tool_input_schema::<RollbackArgs>(),
+                    false,
+                ),
+            ],
+            next_cursor: None,
+            meta: None,
+        }))
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParam,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        match request.name.as_ref() {
+            "plan" => Ok(CallToolResult::structured_error(envelope_error(
+                "plan",
+                "E_UNEXPECTED",
+                "mcp tool not implemented yet",
+                None,
+            ))),
+            "diff" => Ok(CallToolResult::structured_error(envelope_error(
+                "diff",
+                "E_UNEXPECTED",
+                "mcp tool not implemented yet",
+                None,
+            ))),
+            "status" => Ok(CallToolResult::structured_error(envelope_error(
+                "status",
+                "E_UNEXPECTED",
+                "mcp tool not implemented yet",
+                None,
+            ))),
+            "doctor" => Ok(CallToolResult::structured_error(envelope_error(
+                "doctor",
+                "E_UNEXPECTED",
+                "mcp tool not implemented yet",
+                None,
+            ))),
+            "deploy_apply" => {
+                let args = deserialize_args::<DeployApplyArgs>(request.arguments)?;
+                if !args.yes {
+                    return Ok(CallToolResult::structured_error(envelope_error(
+                        "deploy",
+                        "E_CONFIRM_REQUIRED",
+                        "approval required: pass yes=true",
+                        Some(serde_json::json!({ "tool": "deploy_apply" })),
+                    )));
+                }
+                Ok(CallToolResult::structured_error(envelope_error(
+                    "deploy",
+                    "E_UNEXPECTED",
+                    "mcp tool not implemented yet",
+                    None,
+                )))
+            }
+            "rollback" => {
+                let args = deserialize_args::<RollbackArgs>(request.arguments)?;
+                if !args.yes {
+                    return Ok(CallToolResult::structured_error(envelope_error(
+                        "rollback",
+                        "E_CONFIRM_REQUIRED",
+                        "approval required: pass yes=true",
+                        Some(serde_json::json!({ "tool": "rollback", "to": args.to })),
+                    )));
+                }
+                Ok(CallToolResult::structured_error(envelope_error(
+                    "rollback",
+                    "E_UNEXPECTED",
+                    "mcp tool not implemented yet",
+                    None,
+                )))
+            }
+            other => Ok(CallToolResult {
+                content: vec![Content::text(format!("unknown tool: {other}"))],
+                structured_content: None,
+                is_error: Some(true),
+                meta: None,
+            }),
+        }
+    }
+}

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -258,6 +258,16 @@
       "supports_json": true
     },
     {
+      "args": [],
+      "id": "mcp serve",
+      "mutating": false,
+      "path": [
+        "mcp",
+        "serve"
+      ],
+      "supports_json": false
+    },
+    {
       "args": [
         {
           "id": "kind",

--- a/tests/mcp_server_stdio.rs
+++ b/tests/mcp_server_stdio.rs
@@ -1,0 +1,100 @@
+use std::io::{BufRead as _, BufReader, Write as _};
+use std::process::{Command, Stdio};
+
+fn read_json_line(reader: &mut BufReader<std::process::ChildStdout>) -> serde_json::Value {
+    let mut line = String::new();
+    let n = reader.read_line(&mut line).expect("read line");
+    assert!(n > 0, "unexpected EOF from mcp server");
+    serde_json::from_str(&line).expect("line is valid json")
+}
+
+#[test]
+fn mcp_server_stdio_handshake_and_tools_list_work() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+
+    let mut child = Command::new(bin)
+        .args(["mcp", "serve"])
+        .env("AGENTPACK_HOME", tmp.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn agentpack mcp serve");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    let stdout = child.stdout.take().expect("stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    // initialize
+    stdin
+        .write_all(
+            br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"agentpack-test","version":"0.0.0"}}}"#,
+        )
+        .expect("write initialize");
+    stdin.write_all(b"\n").expect("write newline");
+    stdin.flush().expect("flush");
+
+    let init = read_json_line(&mut stdout);
+    assert_eq!(init["jsonrpc"], "2.0");
+    assert_eq!(init["id"], 1);
+    assert!(init["result"]["capabilities"].is_object());
+    assert!(init["result"]["capabilities"]["tools"].is_object());
+    assert_eq!(init["result"]["serverInfo"]["name"], "agentpack");
+
+    // initialized notification
+    stdin
+        .write_all(br#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#)
+        .expect("write initialized");
+    stdin.write_all(b"\n").expect("write newline");
+    stdin.flush().expect("flush");
+
+    // tools/list
+    stdin
+        .write_all(br#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#)
+        .expect("write tools/list");
+    stdin.write_all(b"\n").expect("write newline");
+    stdin.flush().expect("flush");
+
+    let tools_list = read_json_line(&mut stdout);
+    assert_eq!(tools_list["jsonrpc"], "2.0");
+    assert_eq!(tools_list["id"], 2);
+    let tools = tools_list["result"]["tools"]
+        .as_array()
+        .expect("tools array");
+    let names: Vec<&str> = tools
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name"))
+        .collect();
+    for required in [
+        "plan",
+        "diff",
+        "status",
+        "doctor",
+        "deploy_apply",
+        "rollback",
+    ] {
+        assert!(names.contains(&required), "missing tool: {required}");
+    }
+
+    // tools/call (plan)
+    stdin
+        .write_all(br#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"plan","arguments":{}}}"#)
+        .expect("write tools/call");
+    stdin.write_all(b"\n").expect("write newline");
+    stdin.flush().expect("flush");
+
+    let plan = read_json_line(&mut stdout);
+    assert_eq!(plan["jsonrpc"], "2.0");
+    assert_eq!(plan["id"], 3);
+    assert!(plan["result"]["isError"].as_bool().unwrap_or(false));
+    assert!(plan["result"]["structuredContent"].is_object());
+    let text = plan["result"]["content"][0]["text"]
+        .as_str()
+        .expect("content text");
+    let envelope: serde_json::Value = serde_json::from_str(text).expect("envelope json");
+    assert_eq!(envelope["command"], "plan");
+
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
Closes #221.
Closes #220.

## Summary
- Adds `agentpack mcp serve` (stdio MCP server) with tool registry + call dispatcher.
- Tools are present but stubbed (return Agentpack JSON envelope via MCP `structuredContent` + text).
- Adds an integration test that drives MCP over stdio and validates handshake + tools/list + one tools/call.

## Notes
- Read-only and mutating tool behavior will be wired to the real engine/CLI in follow-up PRs (#222/#223).
