### PR TITLE
feat(mcp): implement read-only tools

### DIFF
--- a/openspec/changes/add-mcp-server/tasks.md
+++ b/openspec/changes/add-mcp-server/tasks.md
@@ -13,10 +13,10 @@
 - [x] Add integration test: spawn server, run initialize + tools/list + one tools/call
 
 ## 3. Implementation: read-only tools (P2-4-2)
-- [ ] Implement `plan` tool by routing to existing plan engine/CLI JSON output
-- [ ] Implement `diff` tool by routing to existing diff engine/CLI JSON output
-- [ ] Implement `status` tool by routing to existing status engine/CLI JSON output
-- [ ] Implement `doctor` tool by routing to existing doctor engine/CLI JSON output (no `--fix`)
+- [x] Implement `plan` tool by routing to existing plan engine/CLI JSON output
+- [x] Implement `diff` tool by routing to existing diff engine/CLI JSON output
+- [x] Implement `status` tool by routing to existing status engine/CLI JSON output
+- [x] Implement `doctor` tool by routing to existing doctor engine/CLI JSON output (no `--fix`)
 
 ## 4. Implementation: mutating tools (P2-4-3)
 - [ ] Implement `deploy_apply` tool (maps to `deploy --apply`; supports `adopt`; requires `yes=true`)


### PR DESCRIPTION
## Summary
- Implements MCP tools `plan`, `diff`, `status`, `doctor` by routing to the existing CLI `--json` output (subprocess), preserving stable envelopes/error codes.
- Updates MCP stdio integration test to validate successful tool calls.

## Notes
- This keeps MCP tool semantics aligned with CLI without duplicating business logic.

Closes #222
