### PR TITLE
docs: add Codex MCP wiring guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Agentpack is an AI-first local “asset control plane” for managing and deploy
 - Start here: `docs/QUICKSTART.md`
 - Daily workflow: `docs/WORKFLOWS.md`
 - CLI reference: `docs/CLI.md`
+- Codex MCP wiring: `docs/MCP.md`
 
 ## Installation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,7 @@ Agentpack 是一个 AI-first 的本地“资产控制平面（asset control plan
 - 推荐从：`docs/QUICKSTART.md` 开始
 - 日常工作流：`docs/WORKFLOWS.md`
 - CLI 参考：`docs/CLI.md`
+- Codex MCP 集成：`docs/MCP.md`
 
 ## 安装
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,90 @@
+# MCP (Codex integration)
+
+Agentpack provides an MCP server over stdio:
+
+```bash
+agentpack mcp serve
+```
+
+This lets MCP-capable clients (including Codex) call Agentpack as structured tools instead of shelling out and parsing text.
+
+## What tools are exposed?
+
+Minimum tool set:
+- read-only: `plan`, `diff`, `status`, `doctor`
+- mutating (explicit approval): `deploy_apply`, `rollback`
+
+Tool results reuse Agentpack’s stable `--json` envelope as the canonical payload (also returned as serialized JSON text).
+
+Mutating tools are approval-gated:
+- `deploy_apply` and `rollback` require `yes=true`, otherwise they return `E_CONFIRM_REQUIRED`.
+
+## Codex configuration
+
+Codex MCP servers are configured in `~/.codex/config.toml` under a `[mcp_servers.<name>]` table.
+
+Add an `agentpack` server entry:
+
+```toml
+[mcp_servers.agentpack]
+command = "agentpack"
+args = ["mcp", "serve"]
+
+# Strongly recommended: set the working directory to your project root.
+# Agentpack detects project overlays from the process CWD.
+cwd = "/path/to/your/project"
+
+# Optional: if you use a non-default Agentpack home.
+# env = { AGENTPACK_HOME = "/path/to/.agentpack" }
+
+# Optional: limit which tools Codex can call.
+# enabled_tools = ["plan", "diff", "status", "doctor", "deploy_apply", "rollback"]
+
+enabled = true
+```
+
+Notes:
+- `agentpack mcp serve` does **not** support `--json` (stdout is reserved for MCP protocol messages).
+- If `agentpack` is not on Codex’s PATH, set `command` to an absolute path to the `agentpack` binary.
+
+For Codex-side MCP configuration details, see:
+- https://developers.openai.com/codex/mcp/
+
+## Common pitfalls
+
+### Wrong working directory (project overlays don’t apply)
+
+Agentpack determines the active project context (and thus project overlays) from the MCP server process working directory.
+
+Fix:
+- Set `cwd` to the intended project root in `~/.codex/config.toml`, or
+- Start Codex from the project root and avoid overriding `cwd`.
+
+### Wrong Agentpack home / config repo
+
+Agentpack uses `AGENTPACK_HOME` to locate the config repo and snapshots:
+- config repo default: `$AGENTPACK_HOME/repo`
+- snapshots: `$AGENTPACK_HOME/state/snapshots`
+
+Fix:
+- Set `env = { AGENTPACK_HOME = "..." }` in your MCP server entry, or
+- Pass the `repo` argument to tools that support it.
+
+### Mutations are refused without explicit approval
+
+Mutating tools require `yes=true`:
+- `deploy_apply` → `E_CONFIRM_REQUIRED` unless `yes=true`
+- `rollback` → `E_CONFIRM_REQUIRED` unless `yes=true`
+
+Even with approval:
+- `deploy_apply` may still refuse with `E_ADOPT_CONFIRM_REQUIRED` unless `adopt=true` and you explicitly want to overwrite unmanaged files.
+
+### Debugging (stdio transport)
+
+If a client reports that the MCP server is “unresponsive”, verify it can start cleanly:
+
+```bash
+agentpack mcp serve
+```
+
+The process should not print anything except MCP protocol messages to stdout.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -181,3 +181,7 @@ It installs:
 - Claude Code: a set of `/ap-*` slash commands (plan/deploy/status/propose, etc.)
 
 See `BOOTSTRAP.md` for details.
+
+## 10) MCP (Codex integration)
+
+If you want Codex to call Agentpack as an MCP tool server (instead of calling the CLI directly), see `MCP.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,9 @@ If you just want to start using Agentpack, begin with **Quickstart**.
 9) **Troubleshooting**: `TROUBLESHOOTING.md`
 - Common error codes, conflicts, permissions, Windows path gotchas, etc.
 
+10) **MCP (Codex integration)**: `MCP.md`
+- Configure `agentpack mcp serve` as an MCP server in Codex.
+
 ## Contracts & references (automation + contributors)
 
 - **SPEC (implementation-aligned source of truth)**: `SPEC.md`

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -181,3 +181,7 @@ Agentpack 默认在 `~/.agentpack/repo` 创建/读取配置仓库（可用 `AGEN
 - Claude Code：一组 `/ap-*` slash commands（计划/部署/状态/提案等）
 
 更多见：`BOOTSTRAP.md`。
+
+## 10) MCP（Codex 集成）
+
+如果你希望 Codex 通过 MCP 调用 Agentpack（而不是直接跑 CLI 并解析输出），见：`../MCP.md`。

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -41,6 +41,9 @@
 9) **排障**：`TROUBLESHOOTING.md`
 - 常见错误码、冲突、权限、Windows 路径问题等
 
+10) **MCP（Codex 集成）**：`../MCP.md`
+- 在 Codex 中把 `agentpack mcp serve` 配置成 MCP server。
+
 ## 参考/契约（给自动化与贡献者）
 
 - **SPEC（实现对齐的唯一权威）**：`SPEC.md`

--- a/openspec/changes/add-mcp-server/tasks.md
+++ b/openspec/changes/add-mcp-server/tasks.md
@@ -24,9 +24,9 @@
 - [x] Ensure missing approval returns `E_CONFIRM_REQUIRED` and does not write
 
 ## 5. Docs (P2-4-4)
-- [ ] Add `docs/MCP.md` with Codex configuration examples and common pitfalls
-- [ ] Update `docs/SPEC.md` to document MCP server entrypoint + tool contract
-- [ ] Link `docs/MCP.md` from README / Quickstart (advanced usage)
+- [x] Add `docs/MCP.md` with Codex configuration examples and common pitfalls
+- [x] Update `docs/SPEC.md` to document MCP server entrypoint + tool contract
+- [x] Link `docs/MCP.md` from README / Quickstart (advanced usage)
 
 ## 6. Archive
 - [ ] After shipping: `openspec archive add-mcp-server --yes`


### PR DESCRIPTION
## Summary
- Adds `docs/MCP.md` with Codex `~/.codex/config.toml` examples and common pitfalls.
- Links the doc from README + Quickstart (EN + zh-CN).

Closes #224
