### PR TITLE
chore(openspec): propose policy lint

### DIFF
--- a/openspec/changes/add-policy-lint/proposal.md
+++ b/openspec/changes/add-policy-lint/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Organizations want a CI-friendly way to enforce “AI coding asset hygiene” without changing personal-user defaults.
+
+The governance layer is opt-in (`agentpack policy ...`) and should provide a first, safe step: a read-only lint command that reports violations in a machine-readable way.
+
+## What changes
+
+- Add a new CLI namespace: `agentpack policy ...`
+- Add `agentpack policy lint` (read-only) with `--json` output suitable for CI gating.
+- Introduce a stable error code for lint failures (policy violations).
+
+## Scope (initial checks)
+
+`policy lint` will initially check:
+- **Skill frontmatter completeness**: every `SKILL.md` must include YAML frontmatter with required fields (at least `name` and `description`).
+- **Claude command allowed-tools**: command markdown that uses the bash tool must declare `allowed-tools` that includes `Bash(...)`.
+- **Dangerous defaults**: disallow “mutating agentpack commands” being used without explicit `--json --yes` semantics in automation-oriented command files.
+
+## Non-goals
+
+- No changes to core commands (`plan/diff/deploy/...`) or their behavior.
+- No mandatory governance config file for existing users.
+- No network access requirements (lint should be best-effort and CI-friendly; missing optional dependencies may be reported as issues).
+
+## Impact
+
+- New opt-in command namespace (`agentpack policy ...`).
+- New stable error code for policy violations in `--json` mode.
+- New tests and documentation for the governance lint contract.

--- a/openspec/changes/add-policy-lint/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-policy-lint/specs/agentpack-cli/spec.md
@@ -1,0 +1,27 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: Provide a policy lint command (opt-in governance)
+The system SHALL provide an opt-in governance namespace as a CLI subcommand:
+
+`agentpack policy ...`
+
+The system SHALL provide a read-only lint command:
+
+`agentpack policy lint`
+
+The command MUST NOT perform writes and MUST NOT change behavior of existing core commands.
+
+#### Scenario: policy lint succeeds when there are no violations
+- **WHEN** the user runs `agentpack policy lint --json`
+- **AND** there are no policy violations detected
+- **THEN** stdout is valid JSON with `ok=true`
+
+#### Scenario: policy lint fails with a stable error code when violations exist
+- **WHEN** the user runs `agentpack policy lint --json`
+- **AND** there is at least one policy violation detected
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals a stable policy-violation code (e.g., `E_POLICY_VIOLATIONS`)
+- **AND** the output includes machine-readable details about the violations

--- a/openspec/changes/add-policy-lint/tasks.md
+++ b/openspec/changes/add-policy-lint/tasks.md
@@ -1,0 +1,21 @@
+## 1. Spec (contract)
+- [ ] Define `agentpack policy lint` behavior (human + `--json`)
+- [ ] Define policy lint output shape (issues list + summary)
+- [ ] Define stable error code for policy violations (`E_POLICY_VIOLATIONS` or equivalent)
+- [ ] Run `openspec validate add-policy-lint --strict --no-interactive`
+
+## 2. Implementation (CLI)
+- [ ] Add `policy` subcommand and `policy lint`
+- [ ] Implement lint checks (skills, commands, dangerous defaults)
+- [ ] Ensure `--json` is machine-readable and stable
+- [ ] Add tests (unit + integration)
+- [ ] Update `agentpack help --json` golden snapshot if command list changes
+
+## 3. Docs
+- [ ] Update `docs/SPEC.md` to document `policy lint`
+- [ ] Update `docs/ERROR_CODES.md` with the new stable error code
+- [ ] Update docs index as needed (`docs/README.md`)
+
+## 4. Archive
+- [ ] After shipping: `openspec archive add-policy-lint --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
## Summary
- Adds OpenSpec change `add-policy-lint` describing the opt-in `agentpack policy lint` contract.

Refs #227
