### PR TITLE
feat(cli): add policy lint

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -106,6 +106,14 @@ Recommended action:
 - switch to a directory overlay for that file.
 Details: includes `{module_id, scope, overlay_dir, patch_file, relpath, stderr, ...}`.
 
+### E_POLICY_VIOLATIONS
+Meaning: `policy lint` detected one or more governance policy violations.
+Retryable: yes (after fixing the violations).
+Recommended action:
+- Run `agentpack policy lint --json` to get machine-readable issues (suitable for CI gating).
+- Fix the reported issues and rerun until `ok=true`.
+Details: includes `{root, root_posix, issues, summary}` where `issues[]` items include `{rule, path, path_posix, message, details?}`.
+
 ## Non-stable / fallback error codes
 
 ### E_UNEXPECTED

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -55,6 +55,22 @@ Governance commands are designed to run in CI:
 - `agentpack policy lint` is read-only and returns machine-readable `--json` output.
 - A failing lint SHOULD be used as a CI gate for org-managed repos.
 
+## Policy lint (v1 scope)
+
+Run policy lint against a repository (default: `$AGENTPACK_HOME/repo`):
+
+```bash
+agentpack policy lint --json
+```
+
+In CI, it is common to lint the current checkout:
+
+```bash
+agentpack --repo . policy lint --json
+```
+
+If violations are found, the command exits non-zero and returns `E_POLICY_VIOLATIONS` in `errors[0].code` (details include an issues list).
+
 ## Future roadmap (high-level)
 
 The governance layer may evolve in stages:

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ If you just want to start using Agentpack, begin with **Quickstart**.
 - Release process: `RELEASING.md`
 - Dependency & security checks: `SECURITY_CHECKS.md`
 - GitHub setup checklist (manual / admin-only): `GITHUB_SETUP.md`
-- Governance layer (opt-in): `GOVERNANCE.md`
+- Governance layer (opt-in): `GOVERNANCE.md` (includes `agentpack policy lint`)
 - Product docs (background/roadmap): `PRD.md`, `BACKLOG.md`
 - Unified spec + epics + backlog (Codex-ready): `Agentpack_Spec_Epics_Backlog_CodexReady.md`
 - Executable workplan (for Codex CLI): `CODEX_WORKPLAN.md`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -40,6 +40,7 @@ When `--json` is enabled, common actionable failures must return stable error co
 - `E_OVERLAY_BASELINE_MISSING`: overlay baseline metadata is missing (cannot rebase safely).
 - `E_OVERLAY_BASELINE_UNSUPPORTED`: baseline has no locatable merge base (cannot rebase safely).
 - `E_OVERLAY_REBASE_CONFLICT`: overlay rebase produced conflicts requiring manual resolution.
+- `E_POLICY_VIOLATIONS`: `policy lint` found one or more governance policy violations.
 
 See: `ERROR_CODES.md`.
 
@@ -579,6 +580,26 @@ Tool results:
 
 JSON mode:
 - `mcp serve` does not support `--json`.
+
+### 4.19 `policy lint` (governance, read-only)
+
+`agentpack policy lint`
+
+Behavior:
+- Read-only governance command (opt-in) for CI-friendly “asset hygiene” checks.
+- Lints a repository root selected via `--repo <path>` (default: `$AGENTPACK_HOME/repo`).
+- Initial checks (additive over time):
+  - Skill frontmatter completeness: every `SKILL.md` MUST include YAML frontmatter with non-empty `name` and `description`.
+  - Claude command allowed-tools: command markdown that uses the bash tool MUST declare `allowed-tools` that includes `Bash(...)`.
+  - Dangerous defaults: command markdown that uses the bash tool MUST invoke mutating agentpack commands with `--json` and `--yes`.
+
+Exit codes:
+- Succeeds (exit 0) when no violations are found.
+- Exits non-zero when at least one policy violation is found.
+
+JSON mode:
+- On success: `command="policy.lint"`, `ok=true`, and `data` contains `{root, root_posix, issues, summary}` (issues will be empty).
+- On violations: `ok=false`, `errors[0].code="E_POLICY_VIOLATIONS"`, and `errors[0].details` contains `{root, root_posix, issues, summary}` (note: `data` is `{}` on failure).
 
 ## 5. Target adapter details
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -57,7 +57,7 @@
 
 - 发布流程：`RELEASING.md`
 - 依赖与安全检查：`SECURITY_CHECKS.md`
-- 治理层（opt-in）：`../GOVERNANCE.md`
+- 治理层（opt-in）：`../GOVERNANCE.md`（包含 `agentpack policy lint`）
 - 产品文档（历史背景/规划）：`PRD.md`、`BACKLOG.md`
 - 可执行工作单（给 Codex CLI 直接干活）：`CODEX_WORKPLAN.md`
 

--- a/openspec/changes/add-policy-lint/tasks.md
+++ b/openspec/changes/add-policy-lint/tasks.md
@@ -1,20 +1,20 @@
 ## 1. Spec (contract)
-- [ ] Define `agentpack policy lint` behavior (human + `--json`)
-- [ ] Define policy lint output shape (issues list + summary)
-- [ ] Define stable error code for policy violations (`E_POLICY_VIOLATIONS` or equivalent)
-- [ ] Run `openspec validate add-policy-lint --strict --no-interactive`
+- [x] Define `agentpack policy lint` behavior (human + `--json`)
+- [x] Define policy lint output shape (issues list + summary)
+- [x] Define stable error code for policy violations (`E_POLICY_VIOLATIONS` or equivalent)
+- [x] Run `openspec validate add-policy-lint --strict --no-interactive`
 
 ## 2. Implementation (CLI)
-- [ ] Add `policy` subcommand and `policy lint`
-- [ ] Implement lint checks (skills, commands, dangerous defaults)
-- [ ] Ensure `--json` is machine-readable and stable
-- [ ] Add tests (unit + integration)
-- [ ] Update `agentpack help --json` golden snapshot if command list changes
+- [x] Add `policy` subcommand and `policy lint`
+- [x] Implement lint checks (skills, commands, dangerous defaults)
+- [x] Ensure `--json` is machine-readable and stable
+- [x] Add tests (unit + integration)
+- [x] Update `agentpack help --json` golden snapshot if command list changes
 
 ## 3. Docs
-- [ ] Update `docs/SPEC.md` to document `policy lint`
-- [ ] Update `docs/ERROR_CODES.md` with the new stable error code
-- [ ] Update docs index as needed (`docs/README.md`)
+- [x] Update `docs/SPEC.md` to document `policy lint`
+- [x] Update `docs/ERROR_CODES.md` with the new stable error code
+- [x] Update docs index as needed (`docs/README.md`)
 
 ## 4. Archive
 - [ ] After shipping: `openspec archive add-policy-lint --yes`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -154,6 +154,12 @@ pub enum Commands {
         command: McpCommands,
     },
 
+    /// Governance policy tools (opt-in)
+    Policy {
+        #[command(subcommand)]
+        command: PolicyCommands,
+    },
+
     /// Check local environment and target paths
     Doctor {
         /// Idempotently add `.agentpack.manifest.json` to `.gitignore` for detected repos
@@ -314,6 +320,12 @@ pub enum McpCommands {
 }
 
 #[derive(Subcommand, Debug)]
+pub enum PolicyCommands {
+    /// Lint operator assets and policy constraints (read-only)
+    Lint,
+}
+
+#[derive(Subcommand, Debug)]
 pub enum ExplainCommands {
     /// Explain the current plan (module provenance and overlay layers)
     Plan,
@@ -384,6 +396,7 @@ impl Cli {
             #[cfg(feature = "tui")]
             Commands::Tui { .. } => "tui",
             Commands::Mcp { .. } => "mcp",
+            Commands::Policy { .. } => "policy",
             Commands::Doctor { .. } => "doctor",
             Commands::Remote { .. } => "remote",
             Commands::Sync { .. } => "sync",

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod lock;
 pub(crate) mod mcp;
 pub(crate) mod overlay;
 pub(crate) mod plan;
+pub(crate) mod policy;
 pub(crate) mod preview;
 pub(crate) mod record;
 pub(crate) mod remote;

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -1,0 +1,51 @@
+use anyhow::Context as _;
+
+use crate::output::{JsonEnvelope, print_json};
+use crate::user_error::UserError;
+
+use super::super::args::PolicyCommands;
+use super::Ctx;
+
+pub(crate) fn run(ctx: &Ctx<'_>, command: &PolicyCommands) -> anyhow::Result<()> {
+    match command {
+        PolicyCommands::Lint => lint(ctx),
+    }
+}
+
+fn lint(ctx: &Ctx<'_>) -> anyhow::Result<()> {
+    let report = crate::policy::lint(&ctx.repo.repo_dir).context("policy lint")?;
+    let violations = report.summary.violations;
+
+    if ctx.cli.json {
+        if violations == 0 {
+            let data = serde_json::to_value(&report).context("serialize policy lint report")?;
+            let envelope = JsonEnvelope::ok("policy.lint", data);
+            print_json(&envelope)?;
+            return Ok(());
+        }
+
+        return Err(anyhow::Error::new(
+            UserError::new(
+                "E_POLICY_VIOLATIONS",
+                format!("policy lint found {violations} violation(s)"),
+            )
+            .with_details(serde_json::to_value(&report).context("serialize policy lint report")?),
+        ));
+    }
+
+    if violations == 0 {
+        println!(
+            "policy lint: ok ({} file(s) scanned)",
+            report.summary.files_scanned
+        );
+        return Ok(());
+    }
+
+    Err(anyhow::Error::new(
+        UserError::new(
+            "E_POLICY_VIOLATIONS",
+            format!("policy lint found {violations} violation(s)"),
+        )
+        .with_details(serde_json::to_value(&report).context("serialize policy lint report")?),
+    ))
+}

--- a/src/cli/dispatch.rs
+++ b/src/cli/dispatch.rs
@@ -100,6 +100,9 @@ fn run_with(cli: &Cli) -> anyhow::Result<()> {
         Commands::Mcp { command } => {
             super::commands::mcp::run(&ctx, command)?;
         }
+        Commands::Policy { command } => {
+            super::commands::policy::run(&ctx, command)?;
+        }
         Commands::Doctor { fix } => {
             super::commands::doctor::run(&ctx, *fix)?;
         }

--- a/src/cli/human.rs
+++ b/src/cli/human.rs
@@ -5,44 +5,90 @@ pub(crate) fn print_user_error_human(err: &anyhow::Error) -> bool {
         return false;
     };
 
-    if user_err.code != "E_DESIRED_STATE_CONFLICT" {
-        return false;
+    match user_err.code.as_str() {
+        "E_DESIRED_STATE_CONFLICT" => {
+            eprintln!("error[{}]: {}", user_err.code, user_err.message);
+
+            let Some(details) = user_err.details.as_ref() else {
+                return true;
+            };
+
+            let target = details
+                .get("target")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<unknown>");
+            let path = details
+                .get("path")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<unknown>");
+            let existing_sha = details.pointer("/existing/sha256").and_then(|v| v.as_str());
+            let new_sha = details.pointer("/new/sha256").and_then(|v| v.as_str());
+            let existing_modules =
+                summarize_json_string_array(details.pointer("/existing/module_ids"), 4);
+            let new_modules = summarize_json_string_array(details.pointer("/new/module_ids"), 4);
+
+            eprintln!("  target: {target}");
+            eprintln!("  path: {path}");
+            if let Some(sha) = existing_sha {
+                eprintln!("  existing sha256: {sha}");
+            }
+            eprintln!("  existing modules: {existing_modules}");
+            if let Some(sha) = new_sha {
+                eprintln!("  new sha256: {sha}");
+            }
+            eprintln!("  new modules: {new_modules}");
+            eprintln!(
+                "hint: ensure only one module owns each target/path, or make the contents identical."
+            );
+
+            true
+        }
+        "E_POLICY_VIOLATIONS" => {
+            eprintln!("error[{}]: {}", user_err.code, user_err.message);
+
+            let Some(details) = user_err.details.as_ref() else {
+                return true;
+            };
+
+            let root = details
+                .get("root")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<unknown>");
+            let violations = details
+                .pointer("/summary/violations")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            eprintln!("  root: {root}");
+            eprintln!("  violations: {violations}");
+
+            let Some(issues) = details.get("issues").and_then(|v| v.as_array()) else {
+                return true;
+            };
+            for issue in issues {
+                let rule = issue
+                    .get("rule")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>");
+                let path = issue
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>");
+                let message = issue
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>");
+                let line = issue.pointer("/details/line").and_then(|v| v.as_u64());
+                if let Some(line) = line {
+                    eprintln!("  - [{rule}] {path}:{line}: {message}");
+                } else {
+                    eprintln!("  - [{rule}] {path}: {message}");
+                }
+            }
+
+            true
+        }
+        _ => false,
     }
-
-    eprintln!("error[{}]: {}", user_err.code, user_err.message);
-
-    let Some(details) = user_err.details.as_ref() else {
-        return true;
-    };
-
-    let target = details
-        .get("target")
-        .and_then(|v| v.as_str())
-        .unwrap_or("<unknown>");
-    let path = details
-        .get("path")
-        .and_then(|v| v.as_str())
-        .unwrap_or("<unknown>");
-    let existing_sha = details.pointer("/existing/sha256").and_then(|v| v.as_str());
-    let new_sha = details.pointer("/new/sha256").and_then(|v| v.as_str());
-    let existing_modules = summarize_json_string_array(details.pointer("/existing/module_ids"), 4);
-    let new_modules = summarize_json_string_array(details.pointer("/new/module_ids"), 4);
-
-    eprintln!("  target: {target}");
-    eprintln!("  path: {path}");
-    if let Some(sha) = existing_sha {
-        eprintln!("  existing sha256: {sha}");
-    }
-    eprintln!("  existing modules: {existing_modules}");
-    if let Some(sha) = new_sha {
-        eprintln!("  new sha256: {sha}");
-    }
-    eprintln!("  new modules: {new_modules}");
-    eprintln!(
-        "hint: ensure only one module owns each target/path, or make the contents identical."
-    );
-
-    true
 }
 
 fn summarize_json_string_array(value: Option<&serde_json::Value>, max: usize) -> String {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,6 @@ mod commands;
 mod dispatch;
 mod human;
 mod json;
-mod util;
+pub(crate) mod util;
 
 pub use dispatch::run;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod mcp;
 pub mod output;
 pub mod overlay;
 pub mod paths;
+pub mod policy;
 pub mod project;
 pub mod source;
 pub mod state;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,542 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use serde::Serialize;
+use walkdir::WalkDir;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyLintIssue {
+    pub rule: String,
+    pub path: String,
+    pub path_posix: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyLintSummary {
+    pub violations: usize,
+    pub files_scanned: usize,
+    pub skill_files: usize,
+    pub claude_command_files: usize,
+    pub rules: BTreeMap<String, usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PolicyLintReport {
+    pub root: String,
+    pub root_posix: String,
+    pub issues: Vec<PolicyLintIssue>,
+    pub summary: PolicyLintSummary,
+}
+
+const CLAUDE_COMMAND_DIRS: &[&str] = &[
+    ".claude/commands",
+    "templates/claude/commands",
+    "modules/claude-commands",
+];
+
+const IGNORED_DIR_NAMES: &[&str] = &[".agentpack", ".git", "node_modules", "target"];
+
+pub fn lint(root: &Path) -> anyhow::Result<PolicyLintReport> {
+    let root_str = root.to_string_lossy().to_string();
+    if !root.exists() {
+        anyhow::bail!("policy lint root does not exist: {root_str}");
+    }
+
+    let mut issues = Vec::new();
+
+    let skill_files = find_skill_files(root).context("find SKILL.md files")?;
+    for path in &skill_files {
+        lint_skill_file(root, path, &mut issues);
+    }
+
+    let claude_command_files = find_claude_command_files(root);
+    for path in &claude_command_files {
+        lint_claude_command_file(root, path, &mut issues);
+    }
+
+    issues.sort_by(|a, b| {
+        (&a.path_posix, &a.rule, &a.message).cmp(&(&b.path_posix, &b.rule, &b.message))
+    });
+
+    let mut rule_counts: BTreeMap<String, usize> = BTreeMap::new();
+    for issue in &issues {
+        *rule_counts.entry(issue.rule.clone()).or_insert(0) += 1;
+    }
+
+    let summary = PolicyLintSummary {
+        violations: issues.len(),
+        files_scanned: skill_files.len() + claude_command_files.len(),
+        skill_files: skill_files.len(),
+        claude_command_files: claude_command_files.len(),
+        rules: rule_counts,
+    };
+
+    Ok(PolicyLintReport {
+        root: root_str,
+        root_posix: crate::paths::path_to_posix_string(root),
+        issues,
+        summary,
+    })
+}
+
+fn find_skill_files(root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for entry in WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| !should_ignore_entry(e))
+    {
+        let entry = entry?;
+        if entry.file_type().is_file() && entry.file_name() == "SKILL.md" {
+            out.push(entry.into_path());
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn find_claude_command_files(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for rel in CLAUDE_COMMAND_DIRS {
+        let dir = root.join(rel);
+        if !dir.is_dir() {
+            continue;
+        }
+        for entry in WalkDir::new(&dir)
+            .follow_links(false)
+            .into_iter()
+            .filter_entry(|e| !should_ignore_entry(e))
+        {
+            let Ok(entry) = entry else {
+                continue;
+            };
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            if entry.path().extension().and_then(|s| s.to_str()) != Some("md") {
+                continue;
+            }
+            out.push(entry.into_path());
+        }
+    }
+    out.sort();
+    out
+}
+
+fn should_ignore_entry(entry: &walkdir::DirEntry) -> bool {
+    if !entry.file_type().is_dir() {
+        return false;
+    }
+    IGNORED_DIR_NAMES
+        .iter()
+        .any(|name| entry.file_name() == *name)
+}
+
+fn lint_skill_file(root: &Path, path: &Path, out: &mut Vec<PolicyLintIssue>) {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+    let rel_str = rel.to_string_lossy().to_string();
+    let rel_posix = crate::paths::path_to_posix_string(rel);
+
+    let text = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(err) => {
+            out.push(PolicyLintIssue {
+                rule: "io_read".to_string(),
+                path: rel_str,
+                path_posix: rel_posix,
+                message: "failed to read file".to_string(),
+                details: Some(serde_json::json!({ "error": err.to_string() })),
+            });
+            return;
+        }
+    };
+
+    let frontmatter = match extract_yaml_frontmatter(&text) {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            out.push(PolicyLintIssue {
+                rule: "skill_frontmatter".to_string(),
+                path: rel_str,
+                path_posix: rel_posix,
+                message: "missing YAML frontmatter (--- ... ---)".to_string(),
+                details: Some(serde_json::json!({ "required_fields": ["name","description"] })),
+            });
+            return;
+        }
+        Err(err) => {
+            out.push(PolicyLintIssue {
+                rule: "skill_frontmatter".to_string(),
+                path: rel_str,
+                path_posix: rel_posix,
+                message: "invalid YAML frontmatter".to_string(),
+                details: Some(serde_json::json!({ "error": err.to_string() })),
+            });
+            return;
+        }
+    };
+
+    let Some(map) = frontmatter.as_mapping() else {
+        out.push(PolicyLintIssue {
+            rule: "skill_frontmatter".to_string(),
+            path: rel_str,
+            path_posix: rel_posix,
+            message: "frontmatter must be a YAML mapping".to_string(),
+            details: Some(serde_json::json!({ "expected": "mapping" })),
+        });
+        return;
+    };
+
+    for key in ["name", "description"] {
+        match yaml_get(map, key) {
+            Some(serde_yaml::Value::String(s)) if !s.trim().is_empty() => {}
+            Some(serde_yaml::Value::String(_)) => {
+                out.push(PolicyLintIssue {
+                    rule: "skill_frontmatter".to_string(),
+                    path: rel_str.clone(),
+                    path_posix: rel_posix.clone(),
+                    message: format!("frontmatter {key} is empty"),
+                    details: Some(serde_json::json!({ "field": key })),
+                });
+            }
+            Some(_) => {
+                out.push(PolicyLintIssue {
+                    rule: "skill_frontmatter".to_string(),
+                    path: rel_str.clone(),
+                    path_posix: rel_posix.clone(),
+                    message: format!("frontmatter {key} must be a string"),
+                    details: Some(serde_json::json!({ "field": key, "expected": "string" })),
+                });
+            }
+            None => {
+                out.push(PolicyLintIssue {
+                    rule: "skill_frontmatter".to_string(),
+                    path: rel_str.clone(),
+                    path_posix: rel_posix.clone(),
+                    message: format!("frontmatter is missing {key}"),
+                    details: Some(serde_json::json!({ "missing": [key] })),
+                });
+            }
+        }
+    }
+}
+
+fn lint_claude_command_file(root: &Path, path: &Path, out: &mut Vec<PolicyLintIssue>) {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+    let rel_str = rel.to_string_lossy().to_string();
+    let rel_posix = crate::paths::path_to_posix_string(rel);
+
+    let text = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(err) => {
+            out.push(PolicyLintIssue {
+                rule: "io_read".to_string(),
+                path: rel_str,
+                path_posix: rel_posix,
+                message: "failed to read file".to_string(),
+                details: Some(serde_json::json!({ "error": err.to_string() })),
+            });
+            return;
+        }
+    };
+
+    let uses_bash = uses_bash_tool(&text);
+    if uses_bash {
+        lint_claude_command_allowed_tools(&text, &rel_str, &rel_posix, out);
+        lint_claude_command_dangerous_defaults(&text, &rel_str, &rel_posix, out);
+    }
+}
+
+fn lint_claude_command_allowed_tools(
+    markdown: &str,
+    rel_str: &str,
+    rel_posix: &str,
+    out: &mut Vec<PolicyLintIssue>,
+) {
+    let frontmatter = match extract_yaml_frontmatter(markdown) {
+        Ok(Some(v)) => v,
+        Ok(None) => {
+            out.push(PolicyLintIssue {
+                rule: "claude_command_allowed_tools".to_string(),
+                path: rel_str.to_string(),
+                path_posix: rel_posix.to_string(),
+                message: "uses bash tool but is missing YAML frontmatter (--- ... ---)".to_string(),
+                details: None,
+            });
+            return;
+        }
+        Err(err) => {
+            out.push(PolicyLintIssue {
+                rule: "claude_command_allowed_tools".to_string(),
+                path: rel_str.to_string(),
+                path_posix: rel_posix.to_string(),
+                message: "invalid YAML frontmatter".to_string(),
+                details: Some(serde_json::json!({ "error": err.to_string() })),
+            });
+            return;
+        }
+    };
+
+    let Some(map) = frontmatter.as_mapping() else {
+        out.push(PolicyLintIssue {
+            rule: "claude_command_allowed_tools".to_string(),
+            path: rel_str.to_string(),
+            path_posix: rel_posix.to_string(),
+            message: "frontmatter must be a YAML mapping".to_string(),
+            details: Some(serde_json::json!({ "expected": "mapping" })),
+        });
+        return;
+    };
+
+    let Some(allowed) = yaml_get(map, "allowed-tools") else {
+        out.push(PolicyLintIssue {
+            rule: "claude_command_allowed_tools".to_string(),
+            path: rel_str.to_string(),
+            path_posix: rel_posix.to_string(),
+            message: "uses bash tool but frontmatter is missing allowed-tools".to_string(),
+            details: Some(serde_json::json!({ "missing": ["allowed-tools"] })),
+        });
+        return;
+    };
+
+    if !allowed_tools_allows_bash(allowed) {
+        out.push(PolicyLintIssue {
+            rule: "claude_command_allowed_tools".to_string(),
+            path: rel_str.to_string(),
+            path_posix: rel_posix.to_string(),
+            message: "uses bash tool but allowed-tools does not include Bash(...)".to_string(),
+            details: None,
+        });
+    }
+}
+
+fn lint_claude_command_dangerous_defaults(
+    markdown: &str,
+    rel_str: &str,
+    rel_posix: &str,
+    out: &mut Vec<PolicyLintIssue>,
+) {
+    for (line, cmdline) in extract_bash_commands(markdown) {
+        let invocations = extract_agentpack_invocations(&cmdline);
+        for invocation in invocations {
+            let Some(command_id) = agentpack_command_id(&invocation) else {
+                continue;
+            };
+
+            let is_mutating = crate::cli::util::MUTATING_COMMAND_IDS
+                .iter()
+                .any(|id| id == &command_id.as_str());
+            if !is_mutating {
+                continue;
+            }
+
+            let has_json = invocation.iter().any(|t| *t == "--json");
+            let has_yes = invocation.iter().any(|t| *t == "--yes");
+            if has_json && has_yes {
+                continue;
+            }
+
+            let mut missing = Vec::new();
+            if !has_json {
+                missing.push("--json");
+            }
+            if !has_yes {
+                missing.push("--yes");
+            }
+
+            out.push(PolicyLintIssue {
+                rule: "dangerous_defaults".to_string(),
+                path: rel_str.to_string(),
+                path_posix: rel_posix.to_string(),
+                message: format!(
+                    "mutating agentpack command '{command_id}' must include {}",
+                    missing.join(" and ")
+                ),
+                details: Some(serde_json::json!({
+                    "line": line,
+                    "command_id": command_id,
+                    "invocation": invocation.join(" "),
+                    "missing": missing,
+                })),
+            });
+        }
+    }
+}
+
+fn uses_bash_tool(markdown: &str) -> bool {
+    markdown.contains("!bash") || markdown.contains("!`bash`")
+}
+
+fn extract_yaml_frontmatter(markdown: &str) -> anyhow::Result<Option<serde_yaml::Value>> {
+    let mut lines = markdown.lines();
+    let first = lines.next().unwrap_or("").trim_end_matches('\r');
+    if first != "---" {
+        return Ok(None);
+    }
+
+    let mut fm = Vec::new();
+    let mut found_end = false;
+    for line in lines {
+        let line = line.trim_end_matches('\r');
+        if line == "---" {
+            found_end = true;
+            break;
+        }
+        fm.push(line);
+    }
+
+    if !found_end {
+        anyhow::bail!("unterminated YAML frontmatter (missing closing ---)");
+    }
+
+    let value: serde_yaml::Value =
+        serde_yaml::from_str(&fm.join("\n")).context("parse YAML frontmatter")?;
+    Ok(Some(value))
+}
+
+fn yaml_get<'a>(map: &'a serde_yaml::Mapping, key: &str) -> Option<&'a serde_yaml::Value> {
+    map.iter().find_map(|(k, v)| match k {
+        serde_yaml::Value::String(s) if s == key => Some(v),
+        _ => None,
+    })
+}
+
+fn allowed_tools_allows_bash(allowed: &serde_yaml::Value) -> bool {
+    match allowed {
+        serde_yaml::Value::String(s) => s.contains("Bash("),
+        serde_yaml::Value::Sequence(items) => items.iter().any(|v| match v {
+            serde_yaml::Value::String(s) => s.contains("Bash("),
+            _ => false,
+        }),
+        _ => false,
+    }
+}
+
+fn extract_bash_commands(markdown: &str) -> Vec<(usize, String)> {
+    let mut out = Vec::new();
+    let mut in_block = false;
+    for (idx, raw) in markdown.lines().enumerate() {
+        let line = raw.trim_end_matches('\r');
+        let trimmed = line.trim();
+
+        if in_block {
+            if trimmed.is_empty() {
+                in_block = false;
+                continue;
+            }
+            out.push((idx + 1, trimmed.to_string()));
+            continue;
+        }
+
+        if trimmed == "!bash" || trimmed == "!`bash`" {
+            in_block = true;
+        }
+    }
+    out
+}
+
+fn extract_agentpack_invocations(line: &str) -> Vec<Vec<String>> {
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+    if tokens.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < tokens.len() {
+        if is_agentpack_token(tokens[i]) {
+            let start = i + 1;
+            let mut end = start;
+            while end < tokens.len() && !is_shell_separator(tokens[end]) {
+                end += 1;
+            }
+            let argv: Vec<String> = tokens[start..end].iter().map(|s| s.to_string()).collect();
+            if !argv.is_empty() {
+                out.push(argv);
+            }
+            i = end;
+        } else {
+            i += 1;
+        }
+    }
+
+    out
+}
+
+fn is_agentpack_token(token: &str) -> bool {
+    if token == "agentpack" {
+        return true;
+    }
+    let token = token.trim_matches(|c| c == '"' || c == '\'');
+    token.ends_with("/agentpack") || token.ends_with("\\agentpack.exe")
+}
+
+fn is_shell_separator(token: &str) -> bool {
+    matches!(token, "|" | "||" | "&&" | ";" | "&")
+}
+
+fn agentpack_command_id(argv: &[String]) -> Option<String> {
+    let mut idx = 0;
+    while idx < argv.len() {
+        let t = argv[idx].as_str();
+        if t == "--" {
+            idx += 1;
+            break;
+        }
+        if !t.starts_with('-') {
+            break;
+        }
+        if matches!(t, "--repo" | "--profile" | "--target" | "--machine") {
+            idx += 2;
+            continue;
+        }
+        if matches!(t, "--json" | "--yes" | "--dry-run") {
+            idx += 1;
+            continue;
+        }
+        idx += 1;
+    }
+
+    let cmd = argv.get(idx)?.as_str();
+    let rest: Vec<&str> = argv.iter().skip(idx + 1).map(|s| s.as_str()).collect();
+
+    let command_id = match cmd {
+        "deploy" => {
+            if rest.contains(&"--apply") {
+                "deploy --apply".to_string()
+            } else {
+                "deploy".to_string()
+            }
+        }
+        "doctor" => {
+            if rest.contains(&"--fix") {
+                "doctor --fix".to_string()
+            } else {
+                "doctor".to_string()
+            }
+        }
+        "overlay" => match rest.first().copied() {
+            Some("edit") => "overlay edit".to_string(),
+            Some("rebase") => "overlay rebase".to_string(),
+            Some(other) => format!("overlay {other}"),
+            None => "overlay".to_string(),
+        },
+        "remote" => match rest.first().copied() {
+            Some("set") => "remote set".to_string(),
+            Some(other) => format!("remote {other}"),
+            None => "remote".to_string(),
+        },
+        "evolve" => match rest.first().copied() {
+            Some("propose") => "evolve propose".to_string(),
+            Some("restore") => "evolve restore".to_string(),
+            Some(other) => format!("evolve {other}"),
+            None => "evolve".to_string(),
+        },
+        other => other.to_string(),
+    };
+
+    Some(command_id)
+}

--- a/tests/cli_policy_lint.rs
+++ b/tests/cli_policy_lint.rs
@@ -1,0 +1,108 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack(args: &[&str]) -> std::process::Output {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    agentpack_in(tmp.path(), args)
+}
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn policy_lint_json_succeeds_when_no_violations() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let repo = td.path();
+
+    std::fs::create_dir_all(repo.join(".codex/skills/test-skill")).expect("mkdir");
+    std::fs::write(
+        repo.join(".codex/skills/test-skill/SKILL.md"),
+        r#"---
+name: test-skill
+description: test skill
+---
+
+# test-skill
+"#,
+    )
+    .expect("write SKILL.md");
+
+    std::fs::create_dir_all(repo.join(".claude/commands")).expect("mkdir");
+    std::fs::write(
+        repo.join(".claude/commands/ap-test.md"),
+        r#"---
+description: "test command"
+allowed-tools:
+  - Bash("agentpack plan --json")
+---
+
+!bash
+agentpack plan --json
+"#,
+    )
+    .expect("write command");
+
+    let out = agentpack(&["--repo", repo.to_str().unwrap(), "policy", "lint", "--json"]);
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "policy.lint");
+    assert_eq!(v["data"]["summary"]["violations"], 0);
+    assert!(v["data"]["issues"].as_array().is_some());
+}
+
+#[test]
+fn policy_lint_json_fails_with_policy_violations() {
+    let td = tempfile::tempdir().expect("tempdir");
+    let repo = td.path();
+
+    std::fs::create_dir_all(repo.join(".codex/skills/bad")).expect("mkdir");
+    std::fs::write(
+        repo.join(".codex/skills/bad/SKILL.md"),
+        "# no frontmatter\n",
+    )
+    .expect("write bad SKILL.md");
+
+    std::fs::create_dir_all(repo.join(".claude/commands")).expect("mkdir");
+    std::fs::write(
+        repo.join(".claude/commands/ap-bad.md"),
+        r#"---
+description: "bad command"
+---
+
+!bash
+agentpack deploy --apply --json
+"#,
+    )
+    .expect("write bad command");
+
+    let out = agentpack(&["--repo", repo.to_str().unwrap(), "policy", "lint", "--json"]);
+    assert!(!out.status.success());
+
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_POLICY_VIOLATIONS");
+
+    let issues = v["errors"][0]["details"]["issues"]
+        .as_array()
+        .expect("issues array");
+    assert!(issues.len() >= 2);
+    assert!(issues.iter().any(|i| i["rule"] == "skill_frontmatter"));
+    assert!(
+        issues
+            .iter()
+            .any(|i| i["rule"] == "claude_command_allowed_tools")
+    );
+    assert!(issues.iter().any(|i| i["rule"] == "dangerous_defaults"));
+}

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -373,6 +373,16 @@
       "supports_json": true
     },
     {
+      "args": [],
+      "id": "policy lint",
+      "mutating": false,
+      "path": [
+        "policy",
+        "lint"
+      ],
+      "supports_json": true
+    },
+    {
       "args": [
         {
           "id": "diff",


### PR DESCRIPTION
Closes #227

Adds opt-in governance namespace `agentpack policy ...` with a CI-friendly `policy lint` command.

- New stable error code: `E_POLICY_VIOLATIONS`
- Initial lint checks: SKILL.md frontmatter, Claude command allowed-tools for bash, and no mutating agentpack calls without `--json --yes`
- Docs: SPEC + ERROR_CODES + GOVERNANCE
- Tests + updated `help --json` golden snapshot

Testing:
- `just check`
