### PR TITLE
chore(openspec): propose policy pack lock

### DIFF
--- a/openspec/changes/add-policy-pack-lock/proposal.md
+++ b/openspec/changes/add-policy-pack-lock/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+Organizations want to distribute and audit governance rules independently of core Agentpack configuration. A “policy pack” reference that can be pinned (lockfile) makes CI enforcement reproducible and reviewable.
+
+Governance MUST remain explicit opt-in and MUST NOT affect personal-user defaults or core deploy semantics.
+
+## What changes
+
+- Add a governance config file: `repo/agentpack.org.yaml`
+  - Allows referencing an optional `policy_pack` source (local path or git).
+- Add a governance lockfile: `repo/agentpack.org.lock.json`
+  - Pins the referenced policy pack to an immutable version (e.g. git commit) plus a content hash for auditability.
+- Add `agentpack policy lock`
+  - Resolves the policy pack reference and writes/updates the lockfile.
+- Integrate with `agentpack policy lint`
+  - When a policy pack is configured, lint SHOULD use the pinned lockfile and SHOULD avoid network access.
+
+## Scope (v1)
+
+- Source types supported for policy packs:
+  - `local:` (repo-relative path)
+  - `git:` (url + ref + optional subdir), pinned to a commit in the lockfile
+- Deterministic lockfile generation:
+  - stable ordering
+  - deterministic hashing of policy pack content
+- Governance-only isolation:
+  - only `agentpack policy ...` reads `agentpack.org.yaml` / `agentpack.org.lock.json`
+  - core commands (`plan/diff/deploy/...`) remain unchanged
+
+## Non-goals
+
+- No new “policy DSL” beyond wiring a referenced pack and pinning it.
+- No automatic enforcement in core deploy/apply flows (governance remains isolated).
+- No requirement for network access in `policy lint` (it should be CI-friendly; missing lock may be surfaced as an issue).
+
+## Impact
+
+- New opt-in files in the config repo: `agentpack.org.yaml` and `agentpack.org.lock.json`.
+- New mutating command `agentpack policy lock` (must obey `--json` + `--yes` guardrails).
+- Additional stable error codes for governance config/lock failures may be introduced.

--- a/openspec/changes/add-policy-pack-lock/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-policy-pack-lock/specs/agentpack-cli/spec.md
@@ -1,0 +1,36 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: Provide a policy pack lock command
+The system SHALL provide a governance lock command:
+
+`agentpack policy lock`
+
+The command MUST read `repo/agentpack.org.yaml` and MUST write/update `repo/agentpack.org.lock.json`.
+
+In `--json` mode, the command MUST require `--yes` for safety (otherwise return `E_CONFIRM_REQUIRED`).
+
+#### Scenario: policy lock writes a deterministic lockfile
+- **GIVEN** `repo/agentpack.org.yaml` references a policy pack source
+- **WHEN** the user runs `agentpack policy lock` twice
+- **THEN** `repo/agentpack.org.lock.json` content is identical across runs
+
+#### Scenario: policy lock --json without --yes is refused
+- **GIVEN** `repo/agentpack.org.yaml` references a policy pack source
+- **WHEN** the user runs `agentpack policy lock --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`
+
+### Requirement: policy lint can validate policy pack pinning
+When a policy pack is configured, `agentpack policy lint` SHALL avoid network access and SHALL validate that the policy pack is pinned via the governance lockfile.
+
+#### Scenario: lint fails when a policy pack is configured but no lock exists
+- **WHEN** the user runs `agentpack policy lint --json`
+- **AND** `repo/agentpack.org.yaml` configures a policy pack
+- **AND** `repo/agentpack.org.lock.json` is missing
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_POLICY_VIOLATIONS`
+- **AND** the output includes machine-readable details about the missing lock

--- a/openspec/changes/add-policy-pack-lock/specs/agentpack/spec.md
+++ b/openspec/changes/add-policy-pack-lock/specs/agentpack/spec.md
@@ -1,0 +1,21 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Support an opt-in governance config and lockfile
+The system SHALL support an opt-in governance configuration file at:
+
+`repo/agentpack.org.yaml`
+
+The system SHALL support an opt-in governance lockfile at:
+
+`repo/agentpack.org.lock.json`
+
+Core commands (`plan`, `diff`, `deploy`, etc.) MUST NOT read the governance config or lockfile.
+
+The governance config MAY reference a policy pack source and the system SHALL be able to pin that source via the governance lockfile for auditability.
+
+#### Scenario: core commands ignore governance config
+- **GIVEN** `repo/agentpack.org.yaml` exists
+- **WHEN** the user runs `agentpack plan`
+- **THEN** core behavior is unchanged (no governance config is read)

--- a/openspec/changes/add-policy-pack-lock/tasks.md
+++ b/openspec/changes/add-policy-pack-lock/tasks.md
@@ -1,0 +1,23 @@
+## 1. Spec (contract)
+- [ ] Define `repo/agentpack.org.yaml` (policy pack reference)
+- [ ] Define `repo/agentpack.org.lock.json` (pinning + hashing)
+- [ ] Define `agentpack policy lock` behavior (human + `--json`)
+- [ ] Define how `policy lint` uses the pinned lockfile (no network)
+- [ ] Define stable error codes for policy config/lock failures (if needed)
+- [ ] Run `openspec validate add-policy-pack-lock --strict --no-interactive`
+
+## 2. Implementation (CLI)
+- [ ] Parse and validate `agentpack.org.yaml` (policy subcommands only)
+- [ ] Implement `policy lock` (resolve source + write lockfile)
+- [ ] Update `policy lint` to validate/pin policy pack usage
+- [ ] Register mutating command id and guardrails (`MUTATING_COMMAND_IDS`, help snapshot, tests)
+- [ ] Add tests (lock determinism, json error codes, lint integration)
+
+## 3. Docs
+- [ ] Update `docs/SPEC.md` (governance config + lock + policy lock)
+- [ ] Update `docs/ERROR_CODES.md` (new stable codes, if added)
+- [ ] Update `docs/GOVERNANCE.md` (policy pack usage + CI guidance)
+
+## 4. Archive
+- [ ] After shipping: `openspec archive add-policy-pack-lock --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Refs #228

OpenSpec proposal for M3-GOV-2 (policy pack reference + lock):
- Adds governance config + lockfile requirements (`repo/agentpack.org.yaml` / `repo/agentpack.org.lock.json`)
- Adds CLI requirements for `agentpack policy lock` and lock-aware `policy lint`

Validation:
- `openspec validate add-policy-pack-lock --strict --no-interactive`
