### PR TITLE
feat(policy): add org distribution policy lint

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -92,6 +92,28 @@ agentpack --repo . policy lock
 
 When `policy_pack` is configured, `policy lint` expects the lockfile to exist and match the configured source. This keeps `policy lint` CI-friendly (no network access required).
 
+## Org distribution policy (minimal v1)
+
+Organizations can optionally define a minimal “distribution policy” in `repo/agentpack.org.yaml` to enforce what a repo **must** configure.
+
+Example `repo/agentpack.org.yaml`:
+
+```yaml
+version: 1
+
+distribution_policy:
+  required_targets: ["codex", "claude_code"]
+  required_modules: ["instructions:base"]
+```
+
+Enforcement:
+- `agentpack policy lint` validates the policy against `repo/agentpack.yaml`:
+  - `required_targets[]` MUST exist under `targets:`
+  - `required_modules[]` MUST exist under `modules:` and be `enabled: true`
+- Violations fail with `E_POLICY_VIOLATIONS` (CI gate).
+
+Non-goal: this policy does not change `agentpack plan/diff/deploy/...` behavior.
+
 ## Future roadmap (high-level)
 
 The governance layer may evolve in stages:
@@ -105,5 +127,5 @@ The governance layer may evolve in stages:
    - A lock strategy ensures auditability and reproducibility.
 
 3) **Org distribution policy spec**:
-   - Define minimum fields + stable error code strategy for policy violations.
-   - Must remain scoped to `agentpack policy ...`; core deploy remains unchanged.
+   - Implemented (minimal v1) via `distribution_policy` in `repo/agentpack.org.yaml`.
+   - Scoped to `agentpack policy ...`; core deploy remains unchanged.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -195,6 +195,9 @@ Minimal schema (v1):
 - `version: 1`
 - Optional `policy_pack`:
   - `source: string` (source spec; see below)
+- Optional `distribution_policy`:
+  - `required_targets: string[]` (must exist under `repo/agentpack.yaml -> targets:`)
+  - `required_modules: string[]` (must exist in `repo/agentpack.yaml -> modules:` and be `enabled: true`)
 
 Source spec syntax (same as `agentpack add`):
 - `local:<repo-relative-path>`
@@ -207,6 +210,10 @@ version: 1
 
 policy_pack:
   source: "git:https://github.com/your-org/agentpack-policy-pack.git#ref=v1.0.0&subdir=pack"
+
+distribution_policy:
+  required_targets: ["codex", "claude_code"]
+  required_modules: ["instructions:base"]
 ```
 
 ### 2.4 `repo/agentpack.org.lock.json` (governance policy lockfile; opt-in)
@@ -631,6 +638,7 @@ Behavior:
   - Claude command allowed-tools: command markdown that uses the bash tool MUST declare `allowed-tools` that includes `Bash(...)`.
   - Dangerous defaults: command markdown that uses the bash tool MUST invoke mutating agentpack commands with `--json` and `--yes`.
   - Policy pack pinning (when configured): if `repo/agentpack.org.yaml` configures `policy_pack`, then `repo/agentpack.org.lock.json` MUST exist and MUST match the configured source (no network access).
+  - Org distribution policy (when configured): if `repo/agentpack.org.yaml` configures `distribution_policy`, then `policy lint` MUST validate the required targets/modules in `repo/agentpack.yaml`.
 
 Exit codes:
 - Succeeds (exit 0) when no violations are found.

--- a/openspec/changes/add-org-distribution-policy/tasks.md
+++ b/openspec/changes/add-org-distribution-policy/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Spec (contract)
-- [ ] Define `distribution_policy` schema in `repo/agentpack.org.yaml`.
-- [ ] Define `agentpack policy lint` enforcement rules + machine-readable violation details.
-- [ ] Confirm stable error-code behavior (reuse `E_POLICY_VIOLATIONS`).
-- [ ] Run `openspec validate add-org-distribution-policy --strict --no-interactive`.
+- [x] Define `distribution_policy` schema in `repo/agentpack.org.yaml`.
+- [x] Define `agentpack policy lint` enforcement rules + machine-readable violation details.
+- [x] Confirm stable error-code behavior (reuse `E_POLICY_VIOLATIONS`).
+- [x] Run `openspec validate add-org-distribution-policy --strict --no-interactive`.
 
 ## 2. Implementation
-- [ ] Extend `OrgConfig` parsing with `distribution_policy`.
-- [ ] Implement `policy lint` checks against `repo/agentpack.yaml` (required targets/modules).
-- [ ] Add/update tests for distribution policy violations and success cases.
+- [x] Extend `OrgConfig` parsing with `distribution_policy`.
+- [x] Implement `policy lint` checks against `repo/agentpack.yaml` (required targets/modules).
+- [x] Add/update tests for distribution policy violations and success cases.
 
 ## 3. Docs
-- [ ] Update `docs/SPEC.md` (org config schema + policy lint rules).
-- [ ] Update `docs/GOVERNANCE.md` (distribution policy overview + CI usage).
+- [x] Update `docs/SPEC.md` (org config schema + policy lint rules).
+- [x] Update `docs/GOVERNANCE.md` (distribution policy overview + CI usage).
 
 ## 4. Archive
 - [ ] After shipping: `openspec archive add-org-distribution-policy --yes`.

--- a/src/policy_pack.rs
+++ b/src/policy_pack.rs
@@ -22,11 +22,21 @@ pub(crate) struct OrgConfig {
     pub version: u32,
     #[serde(default)]
     pub policy_pack: Option<PolicyPackConfig>,
+    #[serde(default)]
+    pub distribution_policy: Option<DistributionPolicyConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct PolicyPackConfig {
     pub source: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct DistributionPolicyConfig {
+    #[serde(default)]
+    pub required_targets: Vec<String>,
+    #[serde(default)]
+    pub required_modules: Vec<String>,
 }
 
 impl OrgConfig {


### PR DESCRIPTION
Implements OpenSpec change `add-org-distribution-policy`.

- Extends `agentpack.org.yaml` with `distribution_policy` (required_targets / required_modules).
- Enforces policy in `agentpack policy lint` against `agentpack.yaml`.
- Updates docs (SPEC + GOVERNANCE) and adds tests.

Evidence: cargo test --all --locked

Closes #229.