### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ This project follows SemVer with the following clarifications (especially for au
 
 ### Security
 
+## [0.6.0] - 2026-01-15
+
+### Added
+- Governance policy tooling: `agentpack policy lint` (CI-friendly), plus `agentpack policy lock` to pin policy packs into `repo/agentpack.org.lock.json`.
+- Org distribution policy (opt-in): `policy lint` can enforce required targets/modules when `repo/agentpack.org.yaml` configures `distribution_policy`.
+- MCP server integration: `agentpack mcp serve` exposes structured read-only tools (`plan`, `diff`, `status`, `doctor`) plus approval-gated mutations (`deploy_apply`, `rollback`).
+- Optional lightweight TUI: `agentpack tui` (feature-gated) for browsing `plan/diff/status` and triggering safe apply with explicit confirmation.
+
+### Changed
+- Target adapters are now feature-gated at compile time; `agentpack help --json` reports the compiled target set.
+
 ## [0.5.0] - 2026-01-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentpack"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentpack"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.87.0"
 authors = ["liqiongyu <li@libiao.co>"]

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ cargo install agentpack --locked
 If crates.io install is not available yet, install from source:
 
 ```bash
-cargo install --git https://github.com/liqiongyu/agentpack --tag v0.5.0 --locked
+cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked
 ```
 
 ### Prebuilt binaries
 
 GitHub Releases: https://github.com/liqiongyu/agentpack/releases
 
-## Quickstart (v0.5)
+## Quickstart (v0.6)
 
 ```bash
 agentpack init

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,14 +27,14 @@ cargo install agentpack --locked
 如果暂时无法从 crates.io 安装，可以从源码安装：
 
 ```bash
-cargo install --git https://github.com/liqiongyu/agentpack --tag v0.5.0 --locked
+cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked
 ```
 
 ### 预编译二进制
 
 GitHub Releases: https://github.com/liqiongyu/agentpack/releases
 
-## 快速开始（v0.5）
+## 快速开始（v0.6）
 
 ```bash
 agentpack init

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md
 
-> Current as of **v0.5.0** (2026-01-13). Historical content is tracked in git history.
+> Current as of **v0.6.0** (2026-01-15). Historical content is tracked in git history.
 
 ## 1. One-line summary
 

--- a/docs/Agentpack_Spec_Epics_Backlog_CodexReady.md
+++ b/docs/Agentpack_Spec_Epics_Backlog_CodexReady.md
@@ -4,7 +4,7 @@
 > 重点是 **一致性无冲突** + **细粒度** + **每个 Backlog 条目都能对应一个小 PR**。
 
 - **文档日期**：2026-01-14
-- **基线版本**：Agentpack v0.5.0（以本仓库当前代码 + `docs/SPEC.md` 为准）
+- **基线版本**：Agentpack v0.6.0（以本仓库当前代码 + `docs/SPEC.md` 为准）
 - **适用读者**：维护者 / 贡献者 / 通过 Codex（或其它 coding agent）协作开发的人
 
 ---
@@ -151,7 +151,7 @@ D) 个人重度用户体验优先；组织治理是长期目标但必须隔离
 
 ### Epic M0-DOC：消除文档/实现漂移，提升新用户上手（P1）
 
-#### M0-DOC-1（P1）修正文档中的 target 列表（与 v0.5.0 实现一致）
+#### M0-DOC-1（P1）修正文档中的 target 列表（与 v0.6.0 实现一致）
 动机：目前仓库里不同文档对 `--target` 支持集合的描述存在漂移，容易误导自动化脚本/新用户。
 
 范围（in）：
@@ -188,7 +188,7 @@ D) 个人重度用户体验优先；组织治理是长期目标但必须隔离
 
 验收标准：
 - README 里有 Quickstart 链接
-- Quickstart 中所有命令在 v0.5.0 上可跑通（不要写未来命令）
+- Quickstart 中所有命令在 v0.6.0 上可跑通（不要写未来命令）
 
 ---
 
@@ -209,7 +209,7 @@ D) 个人重度用户体验优先；组织治理是长期目标但必须隔离
 
 ### Epic M0-UX：把“日常循环”做得更顺滑（P1）
 
-> 说明：v0.5.0 已经有 `status.summary` / `status.next_actions` 等能力。本 Epic 的目标是“更好用、更少噪音、更可编排”，而不是重复造轮子。
+> 说明：v0.6.0 已经有 `status.summary` / `status.next_actions` 等能力。本 Epic 的目标是“更好用、更少噪音、更可编排”，而不是重复造轮子。
 
 #### M0-UX-1（P1）Status 输出的“建议动作”去重/排序稳定化（human + json）
 动机：status 的 next_actions 是高价值入口；需要稳定排序与更少的误导建议。
@@ -536,7 +536,7 @@ B) 独立二进制
 
 # Spec (implementation contract)
 
-> Current as of **v0.5.0** (2026-01-13). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
+> Current as of **v0.6.0** (2026-01-15). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
 
 ## 0. Conventions
 
@@ -552,7 +552,7 @@ Default data directory: `~/.agentpack` (override via `AGENTPACK_HOME`), with:
 
 Optional durability mode: set `AGENTPACK_FSYNC=1` to request `fsync` on atomic writes (slower, but more crash-consistent).
 
-Supported as of v0.5.0:
+Supported as of v0.6.0:
 - targets: `codex`, `claude_code`, `cursor`, `vscode`
 - module types: `instructions`, `skill`, `prompt`, `command`
 - source types: `local_path`, `git` (`url` + `ref` + `subdir`)
@@ -835,7 +835,7 @@ Additional (v0.3+):
 - Overlay skeleton writes `<overlay_dir>/.agentpack/baseline.json` for overlay drift warnings (not deployed).
 - `.agentpack/` is a reserved metadata directory: it is never deployed to target roots and must not appear in module outputs.
 
-## 4. CLI commands (v0.5.0)
+## 4. CLI commands (v0.6.0)
 
 Global flags:
 - `--repo <path>`: config repo location

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # BACKLOG.md
 
-> Current as of **v0.5.0** (2026-01-13). Historical content is tracked in git history.
+> Current as of **v0.6.0** (2026-01-15). Historical content is tracked in git history.
 
 ## Status
 

--- a/docs/CODEX_EXEC_PLAN.md
+++ b/docs/CODEX_EXEC_PLAN.md
@@ -2,7 +2,7 @@
 
 Agentpack “AI-first” execution roadmap (task-shaped, designed to be executable by Codex CLI / automation)
 
-> Current as of **v0.5.0** (2026-01-13). This file consolidates the discussion around:
+> Current as of **v0.6.0** (2026-01-15). This file consolidates the discussion around:
 > - how agents (Codex / Claude Code) should use Agentpack
 > - how Agentpack should evolve next (UX, integrations, overlays, targets, testing)
 > - concrete engineering tasks (P0/P1/P2), each intended to fit in a single PR

--- a/docs/CODEX_WORKPLAN.md
+++ b/docs/CODEX_WORKPLAN.md
@@ -2,7 +2,7 @@
 
 Agentpack engineering + OSS workplan (designed to be executable by Codex CLI / automation)
 
-> Current as of **v0.5.0** (2026-01-13). v0.5.0 delivered a round of correctness hardening (fs_key prefix length cap, end-to-end atomic writes, adopt protection, sparse overlays + rebase, CLI split, overlay metadata + doctor checks, etc.). This workplan focuses on the next steps to make the project “truly great” as open source.
+> Current as of **v0.6.0** (2026-01-15). v0.5.0 delivered a round of correctness hardening (fs_key prefix length cap, end-to-end atomic writes, adopt protection, sparse overlays + rebase, CLI split, overlay metadata + doctor checks, etc.). This workplan focuses on the next steps to make the project “truly great” as open source.
 
 Recommended usage:
 - One task per PR (or per commit group). PR description should include: intent, acceptance criteria, and regression test commands.

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,6 +1,6 @@
 # ERROR_CODES.md (stable error code registry)
 
-> Current as of **v0.5.0** (2026-01-13). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
+> Current as of **v0.6.0** (2026-01-15). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
 
 This file defines stable, externally-consumable error codes for `--json` mode (`errors[0].code`).
 

--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -1,6 +1,6 @@
 # JSON API (the `--json` output contract)
 
-> Current as of **v0.5.0** (2026-01-13). `SPEC.md` is the semantic source of truth; this file focuses on the stable `--json` contract.
+> Current as of **v0.6.0** (2026-01-15). `SPEC.md` is the semantic source of truth; this file focuses on the stable `--json` contract.
 
 ## 1) Stability guarantees (principles)
 
@@ -31,7 +31,7 @@ Failure example:
   "schema_version": 1,
   "ok": false,
   "command": "deploy",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "data": {},
   "warnings": [],
   "errors": [

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,6 +1,6 @@
 # PRD.md
 
-> Current as of **v0.5.0** (2026-01-13). Historical content is tracked in git history.
+> Current as of **v0.6.0** (2026-01-15). Historical content is tracked in git history.
 
 ## 1. Background
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,4 +1,4 @@
-# Quickstart (v0.5.0)
+# Quickstart (v0.6.0)
 
 > Language: English | [Chinese (Simplified)](zh-CN/QUICKSTART.md)
 
@@ -36,7 +36,7 @@ Common “heavy user” setups (pick one to start):
   - From crates.io:
     - `cargo install agentpack --locked`
   - If you see `could not find \`agentpack\` in registry \`crates-io\``, install from source:
-    - `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.5.0 --locked`
+    - `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked`
 - Non-Rust users:
   - Download a prebuilt binary from GitHub Releases (see the repository README).
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # Spec (implementation contract)
 
-> Current as of **v0.5.0** (2026-01-13). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
+> Current as of **v0.6.0** (2026-01-15). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
 
 ## 0. Conventions
 
@@ -16,7 +16,7 @@ Default data directory: `~/.agentpack` (override via `AGENTPACK_HOME`), with:
 
 Optional durability mode: set `AGENTPACK_FSYNC=1` to request `fsync` on atomic writes (slower, but more crash-consistent).
 
-Supported as of v0.5.0:
+Supported as of v0.6.0:
 - targets: `codex`, `claude_code`, `cursor`, `vscode`
 - module types: `instructions`, `skill`, `prompt`, `command`
 - source types: `local_path`, `git` (`url` + `ref` + `subdir`)
@@ -368,7 +368,7 @@ Additional (v0.3+):
 - Patch overlay rebase conflicts may be written under `<overlay_dir>/.agentpack/conflicts/` (not deployed).
 - `.agentpack/` is a reserved metadata directory: it is never deployed to target roots and must not appear in module outputs.
 
-## 4. CLI commands (v0.5.0)
+## 4. CLI commands (v0.6.0)
 
 Global flags:
 - `--repo <path>`: config repo location

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -1,4 +1,4 @@
-# 快速开始（v0.5.0）
+# 快速开始（v0.6.0）
 
 > Language: 简体中文 | [English](../QUICKSTART.md)
 
@@ -36,7 +36,7 @@
   - 从 crates.io 安装：
     - `cargo install agentpack --locked`
   - 如果你遇到 `could not find \`agentpack\` in registry \`crates-io\``，可以从源码安装：
-    - `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.5.0 --locked`
+    - `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked`
 - 非 Rust 用户：
   - 从 GitHub Releases 下载对应平台二进制（见仓库 README）。
 


### PR DESCRIPTION
## Summary
- Bump version to `0.6.0`.
- Add `0.6.0` entry to `CHANGELOG.md`.
- Update docs/README version markers to `v0.6.0`.

## Release
After merge:
- `git tag -a v0.6.0 -m "v0.6.0" && git push origin v0.6.0`

Closes #303
