### PR TITLE
chore(openspec): propose add-import-command

### DIFF
--- a/openspec/changes/add-import-command/proposal.md
+++ b/openspec/changes/add-import-command/proposal.md
@@ -1,0 +1,20 @@
+# Change: add `agentpack import` command
+
+## Why
+Agentpack v0.6 already provides a safe, deterministic engine for deploying assets from a config repo, but first-time adoption is still high-friction: most users already have existing assets living outside the config repo (e.g. `AGENTS.md`, `~/.codex/prompts`, `~/.codex/skills`, `.claude/commands`). A first-class `import` command makes adoption a one-session workflow: scan -> plan -> write modules -> deploy.
+
+## What Changes
+- Add a new CLI command `agentpack import` (default: dry-run) that scans existing assets and produces an import plan.
+- `agentpack import --apply` writes imported assets into the config repo as `local_path` modules and updates `agentpack.yaml` (no target writes).
+- Support a `--home-root <path>` override so tests/CI can avoid scanning the real `~`.
+- Define a stable `--json` payload for `command="import"` (additive within `schema_version=1`).
+
+## Impact
+- Affected specs:
+  - `agentpack-cli` (new command + JSON payload)
+- Affected code (planned):
+  - `src/cli/args.rs` (CLI wiring)
+  - `src/cli/commands/import.rs` (handler)
+  - helpers for scanning + deterministic plan output
+- Backwards compatibility:
+  - additive-only (new command, no changes to existing command semantics)

--- a/openspec/changes/add-import-command/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-import-command/specs/agentpack-cli/spec.md
@@ -1,0 +1,35 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: import command produces an import plan
+The system SHALL provide a new CLI command `agentpack import` that scans existing assets and produces an import plan.
+
+The command SHALL be read-only by default (no writes).
+
+#### Scenario: import --json is parseable and includes a plan
+- **WHEN** the user runs `agentpack import --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `command` equals `"import"`
+- **AND** `data.plan` exists
+
+### Requirement: import apply writes only to the config repo
+When invoked with `--apply`, `agentpack import` SHALL write imported assets into the config repo as `local_path` modules and SHALL update `agentpack.yaml` accordingly.
+
+The command SHALL NOT write to target roots (e.g. `~/.codex`, `~/.claude`) as part of the import operation.
+
+In `--json` mode, `agentpack import --apply` MUST require an explicit `--yes` confirmation; if `--yes` is missing, the system MUST return `E_CONFIRM_REQUIRED` and MUST NOT perform writes.
+
+#### Scenario: import --apply --json without --yes is refused
+- **WHEN** the user runs `agentpack import --apply --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`
+
+### Requirement: import supports a home root override for deterministic tests
+The system SHALL support `agentpack import --home-root <path>` to override the home directory used for scanning user-scope assets.
+
+#### Scenario: import reads from home-root instead of the real home
+- **GIVEN** a temporary home directory containing Codex assets under `.codex/`
+- **WHEN** the user runs `agentpack import --home-root <tmp> --json`
+- **THEN** `data.plan` includes items sourced from `<tmp>/.codex/...`

--- a/openspec/changes/add-import-command/tasks.md
+++ b/openspec/changes/add-import-command/tasks.md
@@ -1,0 +1,22 @@
+## 1. Contract (M1-E1-T1 / #306)
+- [ ] Define CLI flags + behavior (dry-run default, `--apply`, `--home-root`)
+- [ ] Define `--json` payload for `command="import"` and update `docs/JSON_API.md` + `docs/SPEC.md`
+- [x] Run `openspec validate add-import-command --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add CLI wiring + `import` handler
+- [ ] Implement repo + home scanners (read-only)
+- [ ] Materialize imported assets into config repo modules (atomic writes)
+- [ ] Update `agentpack.yaml` with new modules (idempotent; deterministic ordering)
+
+## 3. Tests
+- [ ] Integration fixtures (temp repo + temp home): dry-run plan stability
+- [ ] Integration fixtures: `--apply` writes modules + updates manifest
+
+## 4. Docs
+- [ ] `docs/CLI.md`: add `import` section
+- [ ] `docs/WORKFLOWS.md`: add “migrate existing environment” workflow
+
+## 5. Archive
+- [ ] After shipping: `openspec archive add-import-command --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Summary
- Add OpenSpec change proposal for introducing `agentpack import` (scan -> plan -> optional apply).

Scope
- Spec deltas for `agentpack-cli` only (new command + JSON contract requirements).

Testing
- `openspec validate add-import-command --strict --no-interactive`

Refs #306
