### PR TITLE
chore(openspec): propose update import mapping rules

### DIFF
--- a/openspec/changes/update-import-mapping-rules/proposal.md
+++ b/openspec/changes/update-import-mapping-rules/proposal.md
@@ -1,0 +1,25 @@
+# Change: update import mapping rules
+
+## Why
+
+`agentpack import` is intended to be the “day-1 adoption” path. For that to work, import output must be predictable and explainable across tools and scopes.
+
+The current `import` implementation is an MVP: it imports assets safely, but its mapping rules (module ids, tags, and scope separation) are not yet fully specified or documented, and there are avoidable collision cases (e.g. same skill name in user + project).
+
+## What Changes
+
+- Define deterministic mapping rules for `import` (module ids, tags, targets, and destination paths).
+- Ensure user-scope and project-scope candidates do not silently collide in module ids (prefer collision-free ids by construction).
+- Document the mapping with 3 common examples (repo-only, user-only, mixed) so users and agents can predict results.
+
+## Non-Goals
+
+- Do not add overwrite/adopt behavior for existing config repo paths (handled separately).
+- Do not generate overlays as part of import (future work).
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack-cli/spec.md`
+- Affected code: `src/cli/commands/import.rs`
+- Affected docs: `docs/WORKFLOWS.md` (examples), possibly `docs/SPEC.md` / `docs/JSON_API.md`
+- Tests: extend `tests/cli_import.rs` to assert mapping determinism

--- a/openspec/changes/update-import-mapping-rules/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-import-mapping-rules/specs/agentpack-cli/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: import mapping rules are deterministic and collision-free
+
+When scanning existing assets, `agentpack import` SHALL map each candidate to a module deterministically, including:
+- `module_id` (type-scoped id)
+- `module_type`
+- `scope` (`user` or `project`)
+- `targets`
+- `tags`
+- destination paths inside the config repo
+
+The command SHOULD include tool tags in `tags` (e.g. `codex`, `claude_code`, `cursor`, `vscode`) based on the candidate source.
+
+The command SHALL ensure that `module_id` values produced in a single import plan are unique. If multiple candidates would otherwise map to the same `module_id`, at least one MUST be reported as skipped (e.g., with `op="skip_invalid"` and a `skip_reason`).
+
+#### Scenario: user-scope prompt mapping is deterministic
+- **GIVEN** a temporary home root containing `.codex/prompts/prompt1.md`
+- **WHEN** the user runs `agentpack import --home-root <tmp> --json`
+- **THEN** `data.plan` contains an item with `module_id="prompt:prompt1"`
+- **AND** that item includes `tags` containing `imported`, `user`, and `codex`
+- **AND** that item includes `targets` containing `codex`
+
+#### Scenario: user/project collisions do not produce duplicate module ids
+- **GIVEN** a project containing a Codex skill under `.codex/skills/foo/SKILL.md`
+- **AND** the provided home root also contains `.codex/skills/foo/SKILL.md`
+- **WHEN** the user runs `agentpack import --home-root <tmp> --json`
+- **THEN** `data.plan` does not contain two items with the same `module_id`

--- a/openspec/changes/update-import-mapping-rules/tasks.md
+++ b/openspec/changes/update-import-mapping-rules/tasks.md
@@ -1,0 +1,19 @@
+## 1. Contract (M1-E1-T2 / #307)
+- [ ] Define deterministic mapping rules in OpenSpec delta
+- [ ] Update `docs/SPEC.md` / `docs/JSON_API.md` if contract fields/semantics change
+- [ ] Run `openspec validate update-import-mapping-rules --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Update `import` module id mapping to avoid user/project collisions
+- [ ] Add tool tags (`codex`, `claude_code`, `cursor`, `vscode`) and scope tags (`user`, `project`) consistently
+- [ ] Keep plan ordering deterministic
+
+## 3. Tests
+- [ ] Extend `tests/cli_import.rs` to assert mapping rules (ids/tags/targets) deterministically
+
+## 4. Docs
+- [ ] Add 3 examples (repo-only / user-only / mixed) to `docs/WORKFLOWS.md`
+
+## 5. Archive
+- [ ] After shipping: `openspec archive update-import-mapping-rules --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Summary
- OpenSpec proposal for M1-E1-T2 (#307): define deterministic import mapping rules (module ids/tags/targets), and require collision-free module ids within a single import plan.

Validation
- openspec validate update-import-mapping-rules --strict --no-interactive

Refs
- Roadmap: `docs/Agentpack_Roadmap_Spec_Epics_Backlog_CodexReady_v0.6.md`
- Issue: #307
