### PR TITLE
chore(openspec): propose update import conflict reporting

### DIFF
--- a/openspec/changes/update-import-conflict-reporting/proposal.md
+++ b/openspec/changes/update-import-conflict-reporting/proposal.md
@@ -1,0 +1,24 @@
+# Change: update import conflict reporting
+
+## Why
+
+`agentpack import` is the day-1 adoption path. When an import would conflict (e.g., destination paths already exist inside the config repo, or multiple scanned candidates map to the same module id), the user/agent needs a clear, scriptable report during dry-run, before attempting `--apply`.
+
+Today, destination path conflicts are detected only during `--apply`, which makes the workflow less predictable and harder to automate.
+
+## What Changes
+
+- In dry-run mode, `agentpack import --json` SHALL surface conflicts in a machine-readable way (at minimum: destination path exists in config repo; module id collisions inside the scan).
+- In apply mode, conflicts SHALL continue to fail safely with a stable error code (currently `E_IMPORT_CONFLICT`), and the error details SHOULD include actionable suggestions.
+
+## Non-Goals
+
+- Do not add an `--adopt`/overwrite mode for import in this change.
+- Do not change the `--json` envelope shape (additive fields only).
+
+## Impact
+
+- Affected spec: `openspec/specs/agentpack-cli/spec.md` (new requirement)
+- Affected code: `src/cli/commands/import.rs`
+- Affected docs: `docs/CLI.md` / `docs/JSON_API.md` (additive fields), possibly `docs/SPEC.md` notes
+- Tests: extend `tests/cli_import.rs` to assert dry-run conflict reporting deterministically

--- a/openspec/changes/update-import-conflict-reporting/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-import-conflict-reporting/specs/agentpack-cli/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: import dry-run reports conflicts before apply
+
+When `agentpack import` is run in dry-run mode, the system SHALL report conflicts that would prevent a safe apply.
+
+At minimum, the system SHALL detect and report:
+- destination path conflicts (a planned destination path already exists inside the config repo)
+- module id collisions within the scan (multiple candidates map to the same `module_id`)
+
+The conflict report MUST be deterministic and machine-readable in `--json` mode (additive fields are allowed).
+
+#### Scenario: import --json reports destination conflicts during dry-run
+- **GIVEN** a config repo where an import destination path already exists (e.g. `repo/modules/prompts/imported/prompt1.md`)
+- **WHEN** the user runs `agentpack import --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `command` equals `"import"`
+- **AND** `data.plan` includes the conflicting item
+- **AND** the output includes a machine-readable indication that the destination already exists
+
+#### Scenario: import --apply fails safely on destination conflicts
+- **GIVEN** a config repo where an import destination path already exists
+- **WHEN** the user runs `agentpack import --apply --yes --json`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_IMPORT_CONFLICT`

--- a/openspec/changes/update-import-conflict-reporting/tasks.md
+++ b/openspec/changes/update-import-conflict-reporting/tasks.md
@@ -1,0 +1,21 @@
+## 1. Contract (M1-E1-T3 / #308)
+- [ ] Define dry-run conflict reporting requirements (destination path conflicts + module id collisions)
+- [ ] Confirm stable error code for apply conflicts (`E_IMPORT_CONFLICT`), and document details fields
+- [ ] Run `openspec validate update-import-conflict-reporting --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Detect destination path conflicts during plan building (no writes)
+- [ ] Add additive JSON fields to report conflicts in dry-run output
+- [ ] Keep apply behavior safe-by-default (fail on conflicts; stable error code + details)
+- [ ] Update human output to summarize conflicts + suggested next actions
+
+## 3. Tests
+- [ ] Add/extend integration tests for dry-run conflict reporting and error codes
+
+## 4. Docs
+- [ ] Update `docs/JSON_API.md` with additive fields for import conflict reporting
+- [ ] Update `docs/CLI.md` with conflict notes / examples
+
+## 5. Archive
+- [ ] After shipping: `openspec archive update-import-conflict-reporting --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Summary
- OpenSpec proposal for M1-E1-T3 (#308): make `agentpack import` report conflicts during dry-run (destination exists + module_id collisions), and keep apply failing safely with stable `E_IMPORT_CONFLICT`.

Validation
- openspec validate update-import-conflict-reporting --strict --no-interactive

Refs
- Roadmap: docs/Agentpack_Roadmap_Spec_Epics_Backlog_CodexReady_v0.6.md
- Issue: #308
