### PR TITLE
feat(cli): report import conflicts in dry-run

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -37,6 +37,7 @@ Tips:
 Notes:
 - In `--json` mode, `import --apply` requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
 - If an import destination already exists inside the config repo, the command refuses to overwrite and returns `E_IMPORT_CONFLICT`.
+- In dry-run (`--json`), conflicts are reported via `data.conflicts[]`, and conflicting plan items may include `dest_exists=true`.
 
 ## add / remove
 

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -30,7 +30,7 @@ Details: includes `{flag, adopt_updates, sample_paths}`.
 Meaning: `import --apply` would overwrite an existing path in the config repo (module file/dir destination already exists), and Agentpack refused to overwrite.
 Retryable: yes.
 Recommended action: delete or move the conflicting destination paths, then re-run `agentpack import --apply`.
-Details: includes `{sample_paths, hint}`.
+Details: includes `{count, sample_paths, sample_paths_posix, hint}`.
 
 ### E_CONFIG_MISSING
 Meaning: missing `repo/agentpack.yaml`.

--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -151,6 +151,7 @@ Tip:
 - `project: {project_id, project_root, project_root_posix, origin_url?}` (additive)
 - `plan: ImportPlanItem[]`
 - `summary: {candidates, create, skipped_existing_module, skipped_invalid}` (additive)
+- `conflicts: ImportConflict[]` (additive; may be empty)
 - `next_actions: string[]` (additive)
 
 `ImportPlanItem`:
@@ -158,7 +159,16 @@ Tip:
 - `module_id, module_type, scope(user|project)`
 - `source_path, source_path_posix`
 - `dest_path, dest_path_posix`
+- Optional: `dest_exists` (additive; true when destination already exists in the config repo)
 - Optional: `skip_reason` (additive)
+
+`ImportConflict` (additive):
+- `kind: "dest_path_exists"|"duplicate_module_id_in_scan"`
+- `count: number`
+- Optional: `module_id` (present for `duplicate_module_id_in_scan`)
+- Optional: `sample_paths: string[]`
+- Optional: `sample_paths_posix: string[]`
+- `hint: string`
 
 ### overlay.path
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -406,6 +406,7 @@ Optional:
 Notes:
 - In `--json` mode, `import --apply` is treated as mutating and requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
 - If an import destination already exists inside the config repo, the command refuses to overwrite and returns `E_IMPORT_CONFLICT`.
+- In `--json` dry-run, the command MAY report conflicts via additive fields (see `docs/JSON_API.md`).
 - If project-scope assets are imported, agentpack MAY create a project-scoped profile (e.g. `project-<project_id>`) to avoid applying project assets under the default profile.
 
 ### 4.2 `add` / `remove`

--- a/openspec/changes/update-import-conflict-reporting/tasks.md
+++ b/openspec/changes/update-import-conflict-reporting/tasks.md
@@ -1,20 +1,21 @@
 ## 1. Contract (M1-E1-T3 / #308)
-- [ ] Define dry-run conflict reporting requirements (destination path conflicts + module id collisions)
-- [ ] Confirm stable error code for apply conflicts (`E_IMPORT_CONFLICT`), and document details fields
-- [ ] Run `openspec validate update-import-conflict-reporting --strict --no-interactive`
+- [x] Define dry-run conflict reporting requirements (destination path conflicts + module id collisions)
+- [x] Confirm stable error code for apply conflicts (`E_IMPORT_CONFLICT`), and document details fields
+- [x] Run `openspec validate update-import-conflict-reporting --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Detect destination path conflicts during plan building (no writes)
-- [ ] Add additive JSON fields to report conflicts in dry-run output
-- [ ] Keep apply behavior safe-by-default (fail on conflicts; stable error code + details)
-- [ ] Update human output to summarize conflicts + suggested next actions
+- [x] Detect destination path conflicts during plan building (no writes)
+- [x] Add additive JSON fields to report conflicts in dry-run output
+- [x] Keep apply behavior safe-by-default (fail on conflicts; stable error code + details)
+- [x] Update human output to summarize conflicts + suggested next actions
 
 ## 3. Tests
-- [ ] Add/extend integration tests for dry-run conflict reporting and error codes
+- [x] Add/extend integration tests for dry-run conflict reporting and error codes
 
 ## 4. Docs
-- [ ] Update `docs/JSON_API.md` with additive fields for import conflict reporting
-- [ ] Update `docs/CLI.md` with conflict notes / examples
+- [x] Update `docs/JSON_API.md` with additive fields for import conflict reporting
+- [x] Update `docs/CLI.md` with conflict notes / examples
+- [x] Update `docs/ERROR_CODES.md` with conflict details fields
 
 ## 5. Archive
 - [ ] After shipping: `openspec archive update-import-conflict-reporting --yes`


### PR DESCRIPTION
Summary
- Make `agentpack import` report conflicts during dry-run for predictability/automation:
  - destination already exists in config repo (`dest_path_exists`)
  - module id collisions within scan (`duplicate_module_id_in_scan`)
- Keep apply safe-by-default: still fails with stable `E_IMPORT_CONFLICT` and now returns richer details.

Contract (additive)
- `import --json` adds:
  - `data.conflicts[]`
  - `data.plan[].dest_exists` (when true)
- `E_IMPORT_CONFLICT` details add `count` and `sample_paths_posix`.

Docs
- Update `docs/JSON_API.md`, `docs/CLI.md`, `docs/ERROR_CODES.md`, `docs/SPEC.md`.

Testing
- cargo test --test cli_import

OpenSpec
- Implements openspec/changes/update-import-conflict-reporting

Refs
- Issue: #308
- Proposal PR: #325
