### PR TITLE
chore(openspec): propose init --guided

### DIFF
--- a/openspec/changes/add-init-guided/proposal.md
+++ b/openspec/changes/add-init-guided/proposal.md
@@ -1,0 +1,25 @@
+# Change: add init --guided
+
+## Why
+
+Day-1 adoption needs a “zero-knowledge” path to create a valid `agentpack.yaml` without reading docs. A minimal interactive wizard reduces friction while keeping the existing `init` behavior intact.
+
+## What Changes
+
+- Add `agentpack init --guided`:
+  - Only runs in a real TTY (stdin and stdout must be terminals).
+  - Asks a small set of questions (targets, scope, optional bootstrap) and writes a manifest that can run through `update → preview --diff → deploy --apply --yes`.
+- In non-TTY contexts, `--guided` fails with a clear message; in `--json` mode it returns a stable error code so automation can branch safely.
+
+## Non-Goals
+
+- Do not redesign the manifest schema.
+- Do not add new targets.
+- Do not change default behavior of `agentpack init` without `--guided`.
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack-cli/spec.md`
+- Affected code: `src/cli/args.rs`, `src/cli/commands/init.rs`
+- Affected docs: `docs/CLI.md`, `docs/WORKFLOWS.md`, `docs/ERROR_CODES.md` (new error code)
+- Tests: add integration tests for non-TTY failure + generated manifest validity

--- a/openspec/changes/add-init-guided/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-init-guided/specs/agentpack-cli/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: init --guided creates a minimal working manifest
+
+The system SHALL provide `agentpack init --guided` as an interactive wizard to generate a minimal `repo/agentpack.yaml` that can be used immediately by common workflows.
+
+The wizard SHOULD ask, at minimum:
+- which targets to configure (`codex`, `claude_code`, `cursor`, `vscode`)
+- the target scope (`project` or `both`)
+- whether to bootstrap operator assets after init
+
+#### Scenario: guided init writes a manifest in a TTY
+- **GIVEN** a clean `$AGENTPACK_HOME`
+- **AND** stdin and stdout are terminals
+- **WHEN** the user runs `agentpack init --guided`
+- **THEN** the command exits zero
+- **AND** `repo/agentpack.yaml` exists and is parseable
+
+### Requirement: guided init refuses to run without a TTY
+
+When `agentpack init --guided` is invoked without a TTY (stdin or stdout is not a terminal), the system MUST fail early and MUST NOT write any files.
+
+In `--json` mode, the system MUST return a stable error code so automation can branch safely.
+
+#### Scenario: guided init fails in non-TTY JSON mode
+- **GIVEN** stdin or stdout is not a terminal
+- **WHEN** the user runs `agentpack init --guided --json`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_TTY_REQUIRED`

--- a/openspec/changes/add-init-guided/tasks.md
+++ b/openspec/changes/add-init-guided/tasks.md
@@ -1,0 +1,22 @@
+## 1. Contract (M1-E2-T1 / #309)
+- [ ] Define `init --guided` behavior + prompts + output requirements
+- [ ] Define stable error code for non-TTY guided init in `--json` mode
+- [ ] Run `openspec validate add-init-guided --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add CLI flag `init --guided`
+- [ ] Implement minimal TTY wizard (targets, scope, bootstrap)
+- [ ] Generate a valid `agentpack.yaml` (deterministic ordering) based on answers
+- [ ] Ensure non-TTY fails early (no writes)
+
+## 3. Tests
+- [ ] `init --guided --json` fails with stable error code when not a TTY
+- [ ] Generated manifest can be loaded and used by `update/preview/deploy` in a temp env
+
+## 4. Docs
+- [ ] Document `init --guided` in `docs/CLI.md` and `docs/WORKFLOWS.md`
+- [ ] Add the stable error code to `docs/ERROR_CODES.md`
+
+## 5. Archive
+- [ ] After shipping: `openspec archive add-init-guided --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Summary
- OpenSpec proposal for M1-E2-T1 (#309): add `agentpack init --guided` TTY wizard (targets/scope/bootstrap) and define non-TTY failure with stable `E_TTY_REQUIRED` in `--json` mode.

Validation
- openspec validate add-init-guided --strict --no-interactive

Refs
- Roadmap: docs/Agentpack_Roadmap_Spec_Epics_Backlog_CodexReady_v0.6.md
- Issue: #309
