### PR TITLE
chore(openspec): propose update minimal repo template

### DIFF
--- a/openspec/changes/update-minimal-repo-template/proposal.md
+++ b/openspec/changes/update-minimal-repo-template/proposal.md
@@ -1,0 +1,26 @@
+# Change: update minimal config repo template
+
+## Why
+
+Day-1 adoption benefits from a copy/pasteable example repo that includes a small but complete set of modules (instructions + prompt + skill) and a “one-screen” command sequence. This reduces time-to-first-success for both humans and agents.
+
+## What Changes
+
+- Extend `docs/examples/minimal_repo/` to include:
+  - an example Codex skill module (with `SKILL.md`)
+  - an updated `agentpack.yaml` that references the added module
+- Update docs to include a “one-screen” quickstart that:
+  - references `docs/examples/minimal_repo/`
+  - recommends installing operator `/ap-*` commands via `agentpack bootstrap`
+
+## Non-Goals
+
+- Do not change CLI behavior or flags.
+- Do not change the bootstrap operator asset content.
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack-cli/spec.md`
+- Affected docs: `docs/WORKFLOWS.md` (and/or `docs/CLI.md`)
+- Affected example files: `docs/examples/minimal_repo/...`
+- Tests: add a small CLI test to ensure the example repo remains usable for `plan`

--- a/openspec/changes/update-minimal-repo-template/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-minimal-repo-template/specs/agentpack-cli/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Repository ships a minimal config repo template
+
+The repository SHALL include a copy/pasteable minimal config repo template under `docs/examples/minimal_repo/` that contains:
+- a valid `agentpack.yaml`
+- an `instructions` module (`modules/instructions/base/AGENTS.md`)
+- a `prompt` module (`modules/prompts/...`)
+- a `skill` module with `SKILL.md` (`modules/skills/.../SKILL.md`)
+
+The docs SHOULD provide a one-screen command sequence that uses this example (and recommends installing operator `/ap-*` commands via `agentpack bootstrap`).
+
+#### Scenario: minimal example repo can run plan
+- **WHEN** the user runs `agentpack --repo docs/examples/minimal_repo plan`
+- **THEN** the command exits zero

--- a/openspec/changes/update-minimal-repo-template/tasks.md
+++ b/openspec/changes/update-minimal-repo-template/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract (#321)
+- [x] Define template + docs expectations in spec delta
+- [x] Run `openspec validate update-minimal-repo-template --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add a minimal Codex skill module under `docs/examples/minimal_repo/modules/skills/.../SKILL.md`
+- [ ] Update `docs/examples/minimal_repo/agentpack.yaml` to reference the new module
+- [ ] Update `docs/examples/minimal_repo/README.md` with a one-screen quickstart (including `bootstrap`)
+- [ ] Update `docs/WORKFLOWS.md` (and/or `docs/CLI.md`) to link the example template + quickstart
+
+## 3. Tests
+- [ ] Add a CLI test that runs `agentpack --repo docs/examples/minimal_repo plan` successfully
+
+## 4. Archive
+- [ ] After shipping: `openspec archive update-minimal-repo-template --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Refs #321

OpenSpec proposal: `update-minimal-repo-template`

- Adds spec requirements for a minimal copy/pasteable config repo template under `docs/examples/minimal_repo/` (includes instructions/prompt/skill modules)
- Notes the docs quickstart expectation

Validation: `openspec validate update-minimal-repo-template --strict --no-interactive`