### PR TITLE
docs(examples): expand minimal_repo template

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -12,6 +12,9 @@ If you already have existing assets (e.g., `~/.codex/prompts`, `~/.codex/skills`
 - Recommended (guided, TTY only): `agentpack init --guided --git`
 - Non-interactive: `agentpack init --git`
 
+Tip:
+- If you’re starting from scratch (no existing assets), see `docs/examples/minimal_repo/` for a copy/pasteable config repo template and a one-screen quickstart.
+
 2. Generate an import plan (dry-run):
 - `agentpack import`
 - Automation-friendly: `agentpack import --json`

--- a/docs/examples/minimal_repo/README.md
+++ b/docs/examples/minimal_repo/README.md
@@ -3,7 +3,7 @@
 This directory is a copy/pasteable example of an Agentpack config repo layout:
 
 - `agentpack.yaml` (manifest)
-- `modules/` (local modules: instructions, prompt, and a Claude Code slash command)
+- `modules/` (local modules: instructions, prompt, skill, and a Claude Code slash command)
 
 It is similar to what `agentpack init` creates, but with `modules:` entries pre-filled so you can see a working end-to-end example.
 
@@ -16,7 +16,9 @@ It is similar to what `agentpack init` creates, but with `modules:` entries pre-
 
 1. Copy this directory to your Agentpack repo path (default: `~/.agentpack/repo`), or point to it via `agentpack --repo <path>`.
 2. Edit `targets.codex.options.codex_home` if needed.
-3. Run:
+3. (Recommended) Install operator assets into the config repo:
+   - `agentpack bootstrap --scope project`
+4. Run:
    - `agentpack update`
    - `agentpack preview --diff`
    - `agentpack deploy --apply`

--- a/docs/examples/minimal_repo/agentpack.yaml
+++ b/docs/examples/minimal_repo/agentpack.yaml
@@ -39,6 +39,13 @@ modules:
     source:
       local_path:
         path: "modules/prompts/draftpr.md"
+  - id: "skill:example-skill"
+    type: skill
+    tags: ["base"]
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/skills/example-skill"
   - id: "command:ap-plan"
     type: command
     tags: ["base"]

--- a/docs/examples/minimal_repo/modules/skills/example-skill/SKILL.md
+++ b/docs/examples/minimal_repo/modules/skills/example-skill/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: example-skill
+description: Example Codex skill from Agentpack minimal repo template.
+---
+
+# example-skill
+
+This is a tiny example skill used by `docs/examples/minimal_repo/`.
+
+- Replace it with your real skills.
+- Keep the `name`/`description` frontmatter (required by Agentpack validation).

--- a/openspec/changes/update-minimal-repo-template/tasks.md
+++ b/openspec/changes/update-minimal-repo-template/tasks.md
@@ -3,13 +3,13 @@
 - [x] Run `openspec validate update-minimal-repo-template --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Add a minimal Codex skill module under `docs/examples/minimal_repo/modules/skills/.../SKILL.md`
-- [ ] Update `docs/examples/minimal_repo/agentpack.yaml` to reference the new module
-- [ ] Update `docs/examples/minimal_repo/README.md` with a one-screen quickstart (including `bootstrap`)
-- [ ] Update `docs/WORKFLOWS.md` (and/or `docs/CLI.md`) to link the example template + quickstart
+- [x] Add a minimal Codex skill module under `docs/examples/minimal_repo/modules/skills/.../SKILL.md`
+- [x] Update `docs/examples/minimal_repo/agentpack.yaml` to reference the new module
+- [x] Update `docs/examples/minimal_repo/README.md` with a one-screen quickstart (including `bootstrap`)
+- [x] Update `docs/WORKFLOWS.md` (and/or `docs/CLI.md`) to link the example template + quickstart
 
 ## 3. Tests
-- [ ] Add a CLI test that runs `agentpack --repo docs/examples/minimal_repo plan` successfully
+- [x] Add a CLI test that runs `agentpack --repo docs/examples/minimal_repo plan` successfully
 
 ## 4. Archive
 - [ ] After shipping: `openspec archive update-minimal-repo-template --yes`

--- a/tests/cli_examples_minimal_repo.rs
+++ b/tests/cli_examples_minimal_repo.rs
@@ -1,0 +1,53 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn git_init(dir: &Path) {
+    assert!(
+        Command::new("git")
+            .current_dir(dir)
+            .args(["init"])
+            .output()
+            .expect("git init")
+            .status
+            .success()
+    );
+}
+
+fn example_repo_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("docs/examples/minimal_repo")
+}
+
+#[test]
+#[cfg(feature = "target-codex")]
+fn minimal_repo_example_plan_succeeds_for_codex() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+
+    let workspace = home.join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    git_init(&workspace);
+
+    let repo = example_repo_dir();
+    assert!(repo.join("agentpack.yaml").exists());
+
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    let out = Command::new(bin)
+        .current_dir(&workspace)
+        .args([
+            "--repo",
+            repo.to_string_lossy().as_ref(),
+            "--target",
+            "codex",
+            "plan",
+        ])
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack");
+
+    assert!(
+        out.status.success(),
+        "agentpack plan failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
Closes #321

Implements OpenSpec change `update-minimal-repo-template`.

- Adds an example Codex skill module under `docs/examples/minimal_repo/modules/skills/example-skill/`
- Updates the example manifest + README (includes `bootstrap` quickstart)
- Links the example from `docs/WORKFLOWS.md`
- Adds a CLI test to keep the example runnable (`plan`)

Testing: `just check`