### PR TITLE
chore(openspec): propose ERROR_CODES.md doc check

### DIFF
--- a/openspec/changes/add-error-codes-doc-check/proposal.md
+++ b/openspec/changes/add-error-codes-doc-check/proposal.md
@@ -1,0 +1,25 @@
+# Change: add ERROR_CODES.md consistency check
+
+## Why
+
+`docs/ERROR_CODES.md` is a stable registry for `--json` automation (`errors[0].code`). Drift between the registry and the actual codes emitted by the CLI breaks tooling and agents.
+
+We need a CI guardrail that fails when the docs registry is missing/has extra codes compared to the codes emitted by Agentpack in `--json` mode.
+
+## What Changes
+
+- Add a deterministic CI check (Rust test) that compares:
+  - codes documented in `docs/ERROR_CODES.md`
+  - codes emitted by the CLI in `--json` mode (i.e., `UserError` codes + the `E_UNEXPECTED` fallback)
+- Provide a clear failure message with remediation (update the docs registry).
+
+## Non-Goals
+
+- Do not change any existing error code behaviors.
+- Do not change the JSON envelope schema.
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack-cli/spec.md`
+- Affected tests: new test under `tests/`
+- Affected docs: none (unless drift is found)

--- a/openspec/changes/add-error-codes-doc-check/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-error-codes-doc-check/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: ERROR_CODES.md stays consistent with emitted JSON error codes
+
+The repository SHALL include an automated check that ensures `docs/ERROR_CODES.md` contains exactly the set of error codes that can be emitted as `errors[0].code` by the CLI in `--json` mode.
+
+#### Scenario: docs registry matches emitted codes
+- **WHEN** CI runs the consistency check
+- **THEN** it passes when the sets match
+- **AND** it fails with an actionable message when codes are missing or extra

--- a/openspec/changes/add-error-codes-doc-check/tasks.md
+++ b/openspec/changes/add-error-codes-doc-check/tasks.md
@@ -1,0 +1,13 @@
+## 1. Contract (M1-E4-T2 / #318)
+- [x] Define the ERROR_CODES registry consistency requirement
+- [x] Run `openspec validate add-error-codes-doc-check --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add a CI check to ensure `docs/ERROR_CODES.md` matches emitted `errors[0].code` values
+
+## 3. Tests
+- [ ] Ensure the check runs in `cargo test --all --locked` and has a clear failure message
+
+## 4. Archive
+- [ ] After shipping: `openspec archive add-error-codes-doc-check --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Refs #318

OpenSpec proposal: `add-error-codes-doc-check`

- Adds a spec requirement for a CI guardrail ensuring `docs/ERROR_CODES.md` matches the set of JSON error codes emitted by the CLI.

Validation: `openspec validate add-error-codes-doc-check --strict --no-interactive`