### PR TITLE
test(docs): enforce ERROR_CODES.md matches code

### DIFF
--- a/openspec/changes/add-error-codes-doc-check/tasks.md
+++ b/openspec/changes/add-error-codes-doc-check/tasks.md
@@ -3,10 +3,10 @@
 - [x] Run `openspec validate add-error-codes-doc-check --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Add a CI check to ensure `docs/ERROR_CODES.md` matches emitted `errors[0].code` values
+- [x] Add a CI check to ensure `docs/ERROR_CODES.md` matches emitted `errors[0].code` values
 
 ## 3. Tests
-- [ ] Ensure the check runs in `cargo test --all --locked` and has a clear failure message
+- [x] Ensure the check runs in `cargo test --all --locked` and has a clear failure message
 
 ## 4. Archive
 - [ ] After shipping: `openspec archive add-error-codes-doc-check --yes`

--- a/tests/cli_error_codes_doc_sync.rs
+++ b/tests/cli_error_codes_doc_sync.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeSet;
+
+fn codes_from_error_codes_md() -> anyhow::Result<BTreeSet<String>> {
+    let text = std::fs::read_to_string("docs/ERROR_CODES.md")?;
+    let mut out = BTreeSet::new();
+    for line in text.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("### ") else {
+            continue;
+        };
+        let code = rest.split_whitespace().next().unwrap_or_default();
+        if code.starts_with("E_") {
+            out.insert(code.to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn codes_from_user_error_new_calls() -> anyhow::Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+
+    for entry in walkdir::WalkDir::new("src") {
+        let entry = entry?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|s| s.to_str()) != Some("rs") {
+            continue;
+        }
+
+        let text = std::fs::read_to_string(entry.path())?;
+        extract_codes_for_callsite(&text, "UserError::new(", &mut out);
+
+        if entry.path().ends_with("user_error.rs") {
+            extract_codes_for_callsite(&text, "Self::new(", &mut out);
+        }
+    }
+
+    // `--json` fallback code for non-UserError failures.
+    out.insert("E_UNEXPECTED".to_string());
+
+    Ok(out)
+}
+
+fn extract_codes_for_callsite(text: &str, needle: &str, out: &mut BTreeSet<String>) {
+    let mut idx = 0;
+    while let Some(pos) = text[idx..].find(needle) {
+        idx += pos + needle.len();
+
+        let rest = &text[idx..];
+        let mut offset = 0;
+        for ch in rest.chars() {
+            if ch.is_whitespace() {
+                offset += ch.len_utf8();
+                continue;
+            }
+            if ch != '"' {
+                break;
+            }
+            offset += ch.len_utf8();
+            let after_quote = &rest[offset..];
+            let Some(end) = after_quote.find('"') else {
+                break;
+            };
+            let code = &after_quote[..end];
+            if code.starts_with("E_") {
+                out.insert(code.to_string());
+            }
+            break;
+        }
+        idx += offset;
+    }
+}
+
+#[test]
+fn error_codes_md_matches_emitted_json_codes() -> anyhow::Result<()> {
+    let docs = codes_from_error_codes_md()?;
+    let code = codes_from_user_error_new_calls()?;
+
+    let missing: Vec<String> = code.difference(&docs).cloned().collect();
+    let extra: Vec<String> = docs.difference(&code).cloned().collect();
+
+    if missing.is_empty() && extra.is_empty() {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "docs/ERROR_CODES.md is out of sync with emitted error codes.\n\nMissing in docs/ERROR_CODES.md:\n  {}\n\nExtra in docs/ERROR_CODES.md:\n  {}\n\nRemediation:\n- Add missing codes under the appropriate section (Stable vs Non-stable).\n- Remove extra codes if they are no longer emitted.\n",
+        if missing.is_empty() {
+            "(none)".to_string()
+        } else {
+            missing.join("\n  ")
+        },
+        if extra.is_empty() {
+            "(none)".to_string()
+        } else {
+            extra.join("\n  ")
+        }
+    );
+}


### PR DESCRIPTION
Closes #318

Implements OpenSpec change `add-error-codes-doc-check`.

- Adds `tests/cli_error_codes_doc_sync.rs` to compare `docs/ERROR_CODES.md` against emitted JSON codes (UserError::new + `E_UNEXPECTED`)
- Updates OpenSpec tasks checklist

Testing: `just check`