### PR TITLE
chore(openspec): propose expand CLI JSON golden snapshots

### DIFF
--- a/openspec/changes/expand-cli-json-golden-snapshots/proposal.md
+++ b/openspec/changes/expand-cli-json-golden-snapshots/proposal.md
@@ -1,0 +1,27 @@
+# Change: expand CLI JSON golden snapshots for core commands
+
+## Why
+
+`--json` output is a stable automation contract. We already have partial golden coverage, but gaps mean regressions can slip in (field renames, ordering drift, path normalization issues, missing `--yes` guardrails) without CI catching them.
+
+We need broader, deterministic JSON golden snapshots for the core command suite so any contract changes are explicit and reviewed.
+
+## What Changes
+
+- Expand CLI JSON golden snapshot coverage for core commands (success paths), including at minimum:
+  - `init`, `update`
+  - `plan`, `diff`, `preview`
+  - `overlay path`
+  - `evolve` (at least one representative path)
+- Ensure snapshots are cross-platform stable (path normalization, deterministic ordering, stable placeholders for ephemeral ids).
+
+## Non-Goals
+
+- Do not change CLI behavior or JSON schema in this change.
+- Do not introduce new error codes.
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack-cli/spec.md`
+- Affected tests: `tests/cli_json_golden*.rs`, `tests/golden/*.json`
+- Affected docs: none (unless a mismatch or drift is discovered)

--- a/openspec/changes/expand-cli-json-golden-snapshots/specs/agentpack-cli/spec.md
+++ b/openspec/changes/expand-cli-json-golden-snapshots/specs/agentpack-cli/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Core CLI commands are covered by JSON golden snapshots
+
+The repository SHALL include JSON golden snapshots that cover the success-path `data` payloads for the core CLI commands, so contract changes to `--json` output are detected by CI and reviewed explicitly.
+
+At minimum, the snapshots MUST include coverage for:
+- `init`, `update`
+- `plan`, `diff`, `preview`
+- `deploy`, `status`, `doctor`, `rollback`
+- `overlay path`
+- `evolve` (at least one representative scenario)
+
+#### Scenario: CI fails when core command JSON changes
+- **GIVEN** a change modifies a core command’s `--json` `data` payload
+- **WHEN** CI runs the JSON golden snapshot tests
+- **THEN** the tests fail with a diff that requires an explicit golden update

--- a/openspec/changes/expand-cli-json-golden-snapshots/tasks.md
+++ b/openspec/changes/expand-cli-json-golden-snapshots/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract (M1-E4-T1 / #317)
+- [x] Define the JSON golden snapshot coverage requirement
+- [x] Run `openspec validate expand-cli-json-golden-snapshots --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add missing JSON golden snapshots for `init` and `update` success paths
+- [ ] Add missing JSON golden snapshots for `plan`, `diff`, and `preview` (non-diff) success paths
+- [ ] Add missing JSON golden snapshots for `overlay path` and `evolve` (representative deterministic scenarios)
+
+## 3. Tests
+- [ ] Ensure snapshots are deterministic across platforms (path normalization + stable placeholders)
+- [ ] Ensure `cargo test --all --locked` runs the golden suite in CI
+
+## 4. Archive
+- [ ] After shipping: `openspec archive expand-cli-json-golden-snapshots --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Refs #317

OpenSpec proposal: `expand-cli-json-golden-snapshots`

- Defines a contract requirement to cover core command `--json` `data` payloads with deterministic golden snapshots.
- No CLI behavior changes.

Validation: `openspec validate expand-cli-json-golden-snapshots --strict --no-interactive`
