### PR TITLE
test(cli): expand core command JSON goldens

### DIFF
--- a/openspec/changes/expand-cli-json-golden-snapshots/tasks.md
+++ b/openspec/changes/expand-cli-json-golden-snapshots/tasks.md
@@ -3,13 +3,13 @@
 - [x] Run `openspec validate expand-cli-json-golden-snapshots --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Add missing JSON golden snapshots for `init` and `update` success paths
-- [ ] Add missing JSON golden snapshots for `plan`, `diff`, and `preview` (non-diff) success paths
-- [ ] Add missing JSON golden snapshots for `overlay path` and `evolve` (representative deterministic scenarios)
+- [x] Add missing JSON golden snapshots for `init` and `update` success paths
+- [x] Add missing JSON golden snapshots for `plan`, `diff`, and `preview` (non-diff) success paths
+- [x] Add missing JSON golden snapshots for `overlay path` and `evolve` (representative deterministic scenarios)
 
 ## 3. Tests
-- [ ] Ensure snapshots are deterministic across platforms (path normalization + stable placeholders)
-- [ ] Ensure `cargo test --all --locked` runs the golden suite in CI
+- [x] Ensure snapshots are deterministic across platforms (path normalization + stable placeholders)
+- [x] Ensure `cargo test --all --locked` runs the golden suite in CI
 
 ## 4. Archive
 - [ ] After shipping: `openspec archive expand-cli-json-golden-snapshots --yes`

--- a/tests/golden/diff_json_data.json
+++ b/tests/golden/diff_json_data.json
@@ -1,0 +1,31 @@
+{
+  "changes": [
+    {
+      "after_sha256": "9fd1eb377a88e389c63985877f37682a0cac07245b032a67e527b37eda67f640",
+      "before_sha256": null,
+      "op": "create",
+      "path": "<TMP>/codex_home/AGENTS.md",
+      "path_posix": "<TMP>/codex_home/AGENTS.md",
+      "reason": "file missing",
+      "target": "codex"
+    },
+    {
+      "after_sha256": "a82da1d0efeff016b890eca15b53e2cd71cf375187d5e2a3da2278f3bad4d498",
+      "before_sha256": null,
+      "op": "create",
+      "path": "<TMP>/codex_home/prompts/hello.md",
+      "path_posix": "<TMP>/codex_home/prompts/hello.md",
+      "reason": "file missing",
+      "target": "codex"
+    }
+  ],
+  "profile": "default",
+  "summary": {
+    "create": 2,
+    "delete": 0,
+    "update": 0
+  },
+  "targets": [
+    "codex"
+  ]
+}

--- a/tests/golden/evolve_propose_dry_run_json_data.json
+++ b/tests/golden/evolve_propose_dry_run_json_data.json
@@ -1,0 +1,20 @@
+{
+  "candidates": [
+    {
+      "module_id": "prompt:hello",
+      "path": "<TMP>/codex_home/prompts/hello.md",
+      "path_posix": "<TMP>/codex_home/prompts/hello.md",
+      "target": "codex"
+    }
+  ],
+  "created": false,
+  "reason": "dry_run",
+  "skipped": [],
+  "summary": {
+    "drifted_proposeable": 1,
+    "drifted_skipped": 0,
+    "skipped_missing": 0,
+    "skipped_multi_module": 0,
+    "skipped_read_error": 0
+  }
+}

--- a/tests/golden/evolve_restore_json_data.json
+++ b/tests/golden/evolve_restore_json_data.json
@@ -1,0 +1,19 @@
+{
+  "reason": "restored",
+  "restored": [
+    {
+      "module_ids": [
+        "prompt:hello"
+      ],
+      "path": "<TMP>/codex_home/prompts/hello.md",
+      "path_posix": "<TMP>/codex_home/prompts/hello.md",
+      "target": "codex"
+    }
+  ],
+  "summary": {
+    "missing": 1,
+    "restored": 1,
+    "skipped_existing": 1,
+    "skipped_read_error": 0
+  }
+}

--- a/tests/golden/init_json_data.json
+++ b/tests/golden/init_json_data.json
@@ -1,0 +1,4 @@
+{
+  "repo": "<TMP>/repo",
+  "repo_posix": "<TMP>/repo"
+}

--- a/tests/golden/overlay_path_json_data.json
+++ b/tests/golden/overlay_path_json_data.json
@@ -1,0 +1,6 @@
+{
+  "module_id": "instructions:base",
+  "overlay_dir": "<TMP>/repo/overlays/instructions_base--d39861fff1",
+  "overlay_dir_posix": "<TMP>/repo/overlays/instructions_base--d39861fff1",
+  "scope": "global"
+}

--- a/tests/golden/plan_json_data.json
+++ b/tests/golden/plan_json_data.json
@@ -1,0 +1,31 @@
+{
+  "changes": [
+    {
+      "after_sha256": "9fd1eb377a88e389c63985877f37682a0cac07245b032a67e527b37eda67f640",
+      "before_sha256": null,
+      "op": "create",
+      "path": "<TMP>/codex_home/AGENTS.md",
+      "path_posix": "<TMP>/codex_home/AGENTS.md",
+      "reason": "file missing",
+      "target": "codex"
+    },
+    {
+      "after_sha256": "a82da1d0efeff016b890eca15b53e2cd71cf375187d5e2a3da2278f3bad4d498",
+      "before_sha256": null,
+      "op": "create",
+      "path": "<TMP>/codex_home/prompts/hello.md",
+      "path_posix": "<TMP>/codex_home/prompts/hello.md",
+      "reason": "file missing",
+      "target": "codex"
+    }
+  ],
+  "profile": "default",
+  "summary": {
+    "create": 2,
+    "delete": 0,
+    "update": 0
+  },
+  "targets": [
+    "codex"
+  ]
+}

--- a/tests/golden/preview_json_data.json
+++ b/tests/golden/preview_json_data.json
@@ -1,0 +1,33 @@
+{
+  "plan": {
+    "changes": [
+      {
+        "after_sha256": "9fd1eb377a88e389c63985877f37682a0cac07245b032a67e527b37eda67f640",
+        "before_sha256": null,
+        "op": "create",
+        "path": "<TMP>/codex_home/AGENTS.md",
+        "path_posix": "<TMP>/codex_home/AGENTS.md",
+        "reason": "file missing",
+        "target": "codex"
+      },
+      {
+        "after_sha256": "a82da1d0efeff016b890eca15b53e2cd71cf375187d5e2a3da2278f3bad4d498",
+        "before_sha256": null,
+        "op": "create",
+        "path": "<TMP>/codex_home/prompts/hello.md",
+        "path_posix": "<TMP>/codex_home/prompts/hello.md",
+        "reason": "file missing",
+        "target": "codex"
+      }
+    ],
+    "summary": {
+      "create": 2,
+      "delete": 0,
+      "update": 0
+    }
+  },
+  "profile": "default",
+  "targets": [
+    "codex"
+  ]
+}

--- a/tests/golden/update_json_data.json
+++ b/tests/golden/update_json_data.json
@@ -1,0 +1,27 @@
+{
+  "git_modules_fetched": 0,
+  "lockfile": "<TMP>/repo/agentpack.lock.json",
+  "lockfile_posix": "<TMP>/repo/agentpack.lock.json",
+  "steps": [
+    {
+      "detail": {
+        "lockfile": "<TMP>/repo/agentpack.lock.json",
+        "lockfile_posix": "<TMP>/repo/agentpack.lock.json",
+        "modules": 2
+      },
+      "name": "lock",
+      "ok": true
+    },
+    {
+      "detail": {
+        "git_modules_fetched": 0,
+        "store": "<TMP>/cache",
+        "store_posix": "<TMP>/cache"
+      },
+      "name": "fetch",
+      "ok": true
+    }
+  ],
+  "store": "<TMP>/cache",
+  "store_posix": "<TMP>/cache"
+}


### PR DESCRIPTION
Refs #317

Motivation
- Lock the `--json` automation contract with broader golden snapshots so regressions become explicit diffs.

Scope
- Extend `tests/cli_json_golden_core_commands.rs` to cover additional core command `--json` success-path `data` payloads.
- Add new golden snapshots under `tests/golden/`:
  - `init_json_data.json`, `update_json_data.json`
  - `plan_json_data.json`, `diff_json_data.json`, `preview_json_data.json`
  - `overlay_path_json_data.json`
  - `evolve_propose_dry_run_json_data.json`, `evolve_restore_json_data.json`
- Update `openspec/changes/expand-cli-json-golden-snapshots/tasks.md` to reflect completed implementation items.

Non-goals
- No CLI behavior changes.
- No JSON schema changes.

Acceptance
- CI fails on any core command JSON `data` change unless the corresponding golden is updated intentionally.

Tests
- `just check`
