### PR TITLE
chore(openspec): propose temp-roots conformance harness

### DIFF
--- a/openspec/changes/add-conformance-temp-roots-harness/proposal.md
+++ b/openspec/changes/add-conformance-temp-roots-harness/proposal.md
@@ -1,0 +1,28 @@
+# Change: add temp-roots conformance harness (no real home writes)
+
+## Why
+
+Target conformance tests are the safety net that lets Agentpack track target ecosystem changes without regressing core safety semantics.
+
+They must be safe to run on contributor machines and in CI:
+- no reliance on real user home or machine state
+- no accidental writes outside the test temp directory
+- parallel-safe execution
+
+## What Changes
+
+- Add/standardize a conformance test harness that:
+  - runs each conformance test entirely under temp directories
+  - sets environment isolation (`AGENTPACK_HOME`, `HOME`, deterministic `AGENTPACK_MACHINE_ID`, etc.)
+  - uses deterministic workspace setup (no network)
+- Refactor existing target conformance smoke tests to use the harness.
+
+## Non-Goals
+
+- Do not change the conformance semantics being tested (delete safety, drift classification, rollback, etc.).
+- Do not change CLI behavior or JSON schema.
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack/spec.md`
+- Affected tests: `tests/conformance_targets.rs` (and any shared harness modules)

--- a/openspec/changes/add-conformance-temp-roots-harness/specs/agentpack/spec.md
+++ b/openspec/changes/add-conformance-temp-roots-harness/specs/agentpack/spec.md
@@ -1,0 +1,14 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Conformance tests run in temporary roots without writing to real home
+
+The repository SHALL ensure target conformance tests:
+- run entirely within temporary directories,
+- do not rely on real user home or machine state, and
+- can execute safely in parallel.
+
+#### Scenario: conformance tests do not write outside temp roots
+- **WHEN** the conformance test suite is executed
+- **THEN** it does not read or write outside test-managed temporary roots

--- a/openspec/changes/add-conformance-temp-roots-harness/tasks.md
+++ b/openspec/changes/add-conformance-temp-roots-harness/tasks.md
@@ -1,0 +1,15 @@
+## 1. Contract (M1-E5-T1 / #319)
+- [x] Define the temp-roots conformance harness requirement
+- [x] Run `openspec validate add-conformance-temp-roots-harness --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add a shared conformance harness that isolates all filesystem roots to temp dirs
+- [ ] Ensure the harness sets deterministic env (no real home writes; parallel-safe)
+- [ ] Refactor existing target conformance tests to use the harness
+
+## 3. Tests
+- [ ] `cargo test --all --locked` passes locally
+
+## 4. Archive
+- [ ] After shipping: `openspec archive add-conformance-temp-roots-harness --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Refs #319

OpenSpec proposal: `add-conformance-temp-roots-harness`

- Adds a spec requirement ensuring conformance tests run entirely in temp roots, avoid real home/machine state, and remain parallel-safe.

Validation: `openspec validate add-conformance-temp-roots-harness --strict --no-interactive`
