### PR TITLE
test(conformance): temp-roots harness

### DIFF
--- a/openspec/changes/add-conformance-temp-roots-harness/tasks.md
+++ b/openspec/changes/add-conformance-temp-roots-harness/tasks.md
@@ -3,12 +3,12 @@
 - [x] Run `openspec validate add-conformance-temp-roots-harness --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Add a shared conformance harness that isolates all filesystem roots to temp dirs
-- [ ] Ensure the harness sets deterministic env (no real home writes; parallel-safe)
-- [ ] Refactor existing target conformance tests to use the harness
+- [x] Add a shared conformance harness that isolates all filesystem roots to temp dirs
+- [x] Ensure the harness sets deterministic env (no real home writes; parallel-safe)
+- [x] Refactor existing target conformance tests to use the harness
 
 ## 3. Tests
-- [ ] `cargo test --all --locked` passes locally
+- [x] `cargo test --all --locked` passes locally
 
 ## 4. Archive
 - [ ] After shipping: `openspec archive add-conformance-temp-roots-harness --yes`

--- a/tests/conformance_harness/mod.rs
+++ b/tests/conformance_harness/mod.rs
@@ -1,0 +1,74 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+pub(crate) struct ConformanceHarness {
+    _tmp: tempfile::TempDir,
+    home: PathBuf,
+    workspace: PathBuf,
+}
+
+impl ConformanceHarness {
+    pub(crate) fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(&home).expect("create home");
+
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("create workspace");
+
+        assert!(git_in(&workspace, &["init"]).status.success());
+        // Provide a stable origin for deterministic project_id derivation.
+        let _ = git_in(
+            &workspace,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/example.git",
+            ],
+        );
+
+        Self {
+            _tmp: tmp,
+            home,
+            workspace,
+        }
+    }
+
+    pub(crate) fn home(&self) -> &Path {
+        &self.home
+    }
+
+    pub(crate) fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    pub(crate) fn agentpack(&self, args: &[&str]) -> Output {
+        agentpack_in(&self.home, &self.workspace, args)
+    }
+}
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .env("AGENTPACK_MACHINE_ID", "test-machine")
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("XDG_CONFIG_HOME", home)
+        .env("XDG_CACHE_HOME", home)
+        .env("XDG_DATA_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn git_in(dir: &Path, args: &[&str]) -> Output {
+    Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run git")
+}


### PR DESCRIPTION
Refs #319

Motivation
- Conformance tests should be safe to run locally and in CI: no writes to real home, no reliance on machine state, and parallel-safe.

Scope
- Add a shared test harness at `tests/conformance_harness/mod.rs` that isolates filesystem roots to temp dirs and sets deterministic env (`AGENTPACK_HOME`, `HOME`, `AGENTPACK_MACHINE_ID`, etc.).
- Refactor `tests/conformance_targets.rs` to use the harness for all target smoke tests.
- Update `openspec/changes/add-conformance-temp-roots-harness/tasks.md` to reflect completed implementation.

Non-goals
- No changes to conformance semantics.
- No CLI behavior or JSON schema changes.

Tests
- `just check`
