### PR TITLE
chore(openspec): propose Windows path/permission edge cases

### DIFF
--- a/openspec/changes/add-windows-path-permission-edge-cases/proposal.md
+++ b/openspec/changes/add-windows-path-permission-edge-cases/proposal.md
@@ -1,0 +1,29 @@
+# Change: add Windows path/permission conformance edge cases
+
+## Why
+
+Agentpack’s safety guarantees depend on predictable filesystem behavior across platforms. Windows has distinct path and permission constraints (invalid characters, path length limits, read-only semantics) that can produce confusing failures if left as unclassified `E_UNEXPECTED` errors.
+
+We need conformance coverage for these boundaries and stable JSON error codes so automation can handle failures safely and humans get actionable guidance.
+
+## What Changes
+
+- Add conformance tests (Windows-focused) covering:
+  - invalid path characters
+  - overly long paths
+  - read-only destination files
+  - permission denied writes
+- Classify common filesystem write failures into stable `--json` error codes with actionable details (instead of `E_UNEXPECTED`).
+- Update the error code registry (`docs/ERROR_CODES.md`) accordingly.
+
+## Non-Goals
+
+- Do not change the desired-state semantics or target mappings.
+- Do not introduce new targets.
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack-cli/spec.md`, `openspec/specs/agentpack/spec.md`
+- Affected docs: `docs/ERROR_CODES.md` (new stable codes)
+- Affected code: filesystem/apply error classification for `deploy`/`rollback`/other writers
+- Affected tests: new conformance cases (Windows-gated where appropriate)

--- a/openspec/changes/add-windows-path-permission-edge-cases/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-windows-path-permission-edge-cases/specs/agentpack-cli/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: JSON-mode filesystem write failures use stable error codes
+
+When invoked with `--json`, write-capable commands (e.g., `deploy`, `rollback`, `bootstrap`, `evolve restore`) SHALL classify common filesystem write failures into stable error codes (documented in `docs/ERROR_CODES.md`) instead of falling back to `E_UNEXPECTED`.
+
+At minimum, the system MUST provide stable codes for:
+- permission denied / read-only write failures
+- invalid path / invalid characters
+- path too long
+
+#### Scenario: deploy returns stable error code on permission denied
+- **GIVEN** the destination path is not writable
+- **WHEN** the user runs `agentpack deploy --apply --json`
+- **THEN** the command exits non-zero
+- **AND** `errors[0].code` is a stable documented code for permission denied
+
+#### Scenario: deploy returns stable error code on invalid path
+- **GIVEN** the destination path is invalid for the platform
+- **WHEN** the user runs `agentpack deploy --apply --json`
+- **THEN** the command exits non-zero
+- **AND** `errors[0].code` is a stable documented code for invalid path
+
+#### Scenario: deploy returns stable error code on path too long
+- **GIVEN** the destination path exceeds platform limits
+- **WHEN** the user runs `agentpack deploy --apply --json`
+- **THEN** the command exits non-zero
+- **AND** `errors[0].code` is a stable documented code for path too long

--- a/openspec/changes/add-windows-path-permission-edge-cases/specs/agentpack/spec.md
+++ b/openspec/changes/add-windows-path-permission-edge-cases/specs/agentpack/spec.md
@@ -1,0 +1,16 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Conformance tests cover Windows path and permission edge cases
+
+The repository SHALL include conformance tests that exercise Windows path and permission boundary cases, including:
+- invalid path characters
+- path too long
+- read-only destination files
+- permission denied writes
+
+#### Scenario: conformance suite validates Windows edge cases
+- **GIVEN** the test suite is running on Windows
+- **WHEN** conformance tests execute
+- **THEN** failures return stable JSON error codes with actionable messages

--- a/openspec/changes/add-windows-path-permission-edge-cases/tasks.md
+++ b/openspec/changes/add-windows-path-permission-edge-cases/tasks.md
@@ -1,0 +1,15 @@
+## 1. Contract (M1-E5-T2 / #320)
+- [x] Define requirements for Windows path/permission conformance + stable error codes
+- [x] Run `openspec validate add-windows-path-permission-edge-cases --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add stable JSON error codes for common filesystem write failures (permission denied / invalid path / path too long)
+- [ ] Update `docs/ERROR_CODES.md` for the new codes (and keep doc sync test passing)
+- [ ] Add Windows-focused conformance tests for invalid chars, long paths, read-only, and permission denied
+
+## 3. Tests
+- [ ] `just check` passes locally
+
+## 4. Archive
+- [ ] After shipping: `openspec archive add-windows-path-permission-edge-cases --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Refs #320

OpenSpec proposal: `add-windows-path-permission-edge-cases`

- Adds requirements for Windows path/permission conformance coverage.
- Adds requirements for stable `--json` error codes for common filesystem write failures (permission denied / invalid path / path too long).

Validation: `openspec validate add-windows-path-permission-edge-cases --strict --no-interactive`
