### PR TITLE
test(conformance): windows path/permission edge cases

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -145,6 +145,28 @@ Retryable: depends on upgrading agentpack or fixing config.
 Recommended action: set `version` to a supported value (currently `1`) or upgrade agentpack.
 Details: includes `{path, version, supported}`.
 
+### E_IO_PERMISSION_DENIED
+Meaning: a filesystem write failed due to permissions (including read-only destination files) or an access-denied condition.
+Retryable: maybe.
+Recommended action:
+- Ensure the destination path (and its parent directories) are writable.
+- On Windows, ensure the destination is not locked by another process (e.g., an editor) and retry.
+Details: includes `{path, path_posix, raw_os_error?, hint}`.
+
+### E_IO_INVALID_PATH
+Meaning: a filesystem write failed because the destination path is invalid for the current platform (e.g., invalid characters on Windows).
+Retryable: no (until path is fixed).
+Recommended action: fix the configured destination path (remove invalid characters / use a valid root) and retry.
+Details: includes `{path, path_posix, raw_os_error?, hint}`.
+
+### E_IO_PATH_TOO_LONG
+Meaning: a filesystem write failed because the destination path exceeds platform limits.
+Retryable: no (until path is shortened or platform configuration is changed).
+Recommended action:
+- Use a shorter workspace/home path, or
+- On Windows, enable long path support if applicable.
+Details: includes `{path, path_posix, raw_os_error?, hint}`.
+
 ## Non-stable / fallback error codes
 
 ### E_UNEXPECTED

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -44,6 +44,9 @@ When `--json` is enabled, common actionable failures must return stable error co
 - `E_POLICY_CONFIG_MISSING`: missing `repo/agentpack.org.yaml` when running governance policy commands.
 - `E_POLICY_CONFIG_INVALID`: `repo/agentpack.org.yaml` is invalid.
 - `E_POLICY_CONFIG_UNSUPPORTED_VERSION`: `repo/agentpack.org.yaml` `version` is unsupported.
+- `E_IO_PERMISSION_DENIED`: a filesystem write failed due to permissions (including read-only destinations).
+- `E_IO_INVALID_PATH`: a filesystem write failed because the destination path is invalid for the platform.
+- `E_IO_PATH_TOO_LONG`: a filesystem write failed because the destination path exceeds platform limits.
 
 See: `ERROR_CODES.md`.
 

--- a/openspec/changes/add-windows-path-permission-edge-cases/tasks.md
+++ b/openspec/changes/add-windows-path-permission-edge-cases/tasks.md
@@ -3,12 +3,12 @@
 - [x] Run `openspec validate add-windows-path-permission-edge-cases --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Add stable JSON error codes for common filesystem write failures (permission denied / invalid path / path too long)
-- [ ] Update `docs/ERROR_CODES.md` for the new codes (and keep doc sync test passing)
-- [ ] Add Windows-focused conformance tests for invalid chars, long paths, read-only, and permission denied
+- [x] Add stable JSON error codes for common filesystem write failures (permission denied / invalid path / path too long)
+- [x] Update `docs/ERROR_CODES.md` for the new codes (and keep doc sync test passing)
+- [x] Add Windows-focused conformance tests for invalid chars, long paths, read-only, and permission denied
 
 ## 3. Tests
-- [ ] `just check` passes locally
+- [x] `just check` passes locally
 
 ## 4. Archive
 - [ ] After shipping: `openspec archive add-windows-path-permission-edge-cases --yes`

--- a/tests/conformance_windows_edge_cases.rs
+++ b/tests/conformance_windows_edge_cases.rs
@@ -1,0 +1,187 @@
+#![cfg(windows)]
+
+use std::path::{Path, PathBuf};
+
+mod conformance_harness;
+
+use conformance_harness::ConformanceHarness;
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn write_module(repo_dir: &Path, rel_dir: &str, filename: &str, content: &str) -> PathBuf {
+    let dir = repo_dir.join(rel_dir);
+    std::fs::create_dir_all(&dir).expect("create module dir");
+    let path = dir.join(filename);
+    std::fs::write(&path, content).expect("write module file");
+    path
+}
+
+fn write_manifest_codex(repo_dir: &Path, codex_home: &Path) {
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{codex_home}'
+      write_agents_global: true
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: instructions:base
+    type: instructions
+    source:
+      local_path:
+        path: modules/instructions/base
+    enabled: true
+    tags: ["base"]
+    targets: ["codex"]
+  - id: prompt:hello
+    type: prompt
+    source:
+      local_path:
+        path: modules/prompts/hello
+    enabled: true
+    tags: ["base"]
+    targets: ["codex"]
+"#,
+        codex_home = codex_home.display()
+    );
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest).expect("write manifest");
+}
+
+#[test]
+fn deploy_json_returns_stable_code_for_invalid_path() {
+    let harness = ConformanceHarness::new();
+    let home = harness.home();
+    let workspace = harness.workspace();
+
+    let init = harness.agentpack(&["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    let codex_home = workspace.join("codex<home");
+    write_manifest_codex(&repo_dir, &codex_home);
+
+    write_module(
+        &repo_dir,
+        "modules/instructions/base",
+        "AGENTS.md",
+        "# Base instructions\n",
+    );
+    write_module(
+        &repo_dir,
+        "modules/prompts/hello",
+        "hello.md",
+        "Hello prompt v1\n",
+    );
+
+    let deploy = harness.agentpack(&["--target", "codex", "deploy", "--apply", "--yes", "--json"]);
+    assert!(!deploy.status.success());
+    let v = parse_stdout_json(&deploy);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_IO_INVALID_PATH");
+}
+
+#[test]
+fn deploy_json_returns_stable_code_for_path_too_long() {
+    let harness = ConformanceHarness::new();
+    let home = harness.home();
+    let workspace = harness.workspace();
+
+    let init = harness.agentpack(&["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+
+    let mut codex_home = workspace.to_path_buf();
+    // Build a path that exceeds Windows limits while keeping each component reasonable.
+    for i in 0..250 {
+        codex_home = codex_home.join(format!("d{i:03}{}", "a".repeat(200)));
+    }
+
+    write_manifest_codex(&repo_dir, &codex_home);
+
+    write_module(
+        &repo_dir,
+        "modules/instructions/base",
+        "AGENTS.md",
+        "# Base instructions\n",
+    );
+    write_module(
+        &repo_dir,
+        "modules/prompts/hello",
+        "hello.md",
+        "Hello prompt v1\n",
+    );
+
+    let deploy = harness.agentpack(&["--target", "codex", "deploy", "--apply", "--yes", "--json"]);
+    assert!(!deploy.status.success());
+    let v = parse_stdout_json(&deploy);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_IO_PATH_TOO_LONG");
+}
+
+#[test]
+fn deploy_json_returns_stable_code_for_read_only_destination() {
+    let harness = ConformanceHarness::new();
+    let home = harness.home();
+    let workspace = harness.workspace();
+
+    let init = harness.agentpack(&["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    let codex_home = workspace.join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    write_manifest_codex(&repo_dir, &codex_home);
+
+    let prompt_module = write_module(
+        &repo_dir,
+        "modules/prompts/hello",
+        "hello.md",
+        "Hello prompt v1\n",
+    );
+    write_module(
+        &repo_dir,
+        "modules/instructions/base",
+        "AGENTS.md",
+        "# Base instructions\n",
+    );
+
+    let deploy1 = harness.agentpack(&["--target", "codex", "deploy", "--apply", "--yes", "--json"]);
+    assert!(deploy1.status.success());
+
+    let deployed_prompt = codex_home.join("prompts").join("hello.md");
+    assert!(
+        deployed_prompt.exists(),
+        "expected {}",
+        deployed_prompt.display()
+    );
+    let mut perms = std::fs::metadata(&deployed_prompt)
+        .expect("stat deployed prompt")
+        .permissions();
+    perms.set_readonly(true);
+    std::fs::set_permissions(&deployed_prompt, perms).expect("set read-only");
+
+    std::fs::write(&prompt_module, "Hello prompt v2\n").expect("update module");
+    let deploy2 = harness.agentpack(&["--target", "codex", "deploy", "--apply", "--yes", "--json"]);
+    assert!(!deploy2.status.success());
+
+    let v = parse_stdout_json(&deploy2);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_IO_PERMISSION_DENIED");
+}


### PR DESCRIPTION
Refs #320

Motivation
- Windows path and permission failures (invalid characters, path length limits, read-only destinations) should not surface as unclassified `E_UNEXPECTED` in `--json` mode.

Scope
- Add stable JSON error codes for common filesystem write failures:
  - `E_IO_PERMISSION_DENIED`
  - `E_IO_INVALID_PATH`
  - `E_IO_PATH_TOO_LONG`
- Classify `write_atomic` failures into these codes (with actionable `details`).
- Update `docs/ERROR_CODES.md` and `docs/SPEC.md` to document the new stable codes.
- Add Windows-only conformance tests (`tests/conformance_windows_edge_cases.rs`) validating the codes for:
  - invalid path characters
  - path too long
  - read-only destination updates
- Update `openspec/changes/add-windows-path-permission-edge-cases/tasks.md` to reflect completion.

Non-goals
- No target mapping changes.

Tests
- `just check`
