### PR TITLE
chore(openspec): propose update-status-actionable-output

### DIFF
--- a/openspec/changes/update-status-actionable-output/proposal.md
+++ b/openspec/changes/update-status-actionable-output/proposal.md
@@ -1,0 +1,26 @@
+# Change: update status actionable output (grouped summary + structured next_actions)
+
+## Why
+
+`agentpack status` is the first command an agent (or user) should run when something is off. Today, `status --json` includes a flat drift summary and optional `next_actions` as command strings, but agents still have to infer meaning from strings and cannot easily group drift by target root.
+
+We want to make `status` more action-oriented for automation while keeping `schema_version=1` compatibility (additive-only JSON changes).
+
+## What Changes
+
+- Add an additive grouped drift summary in `status --json` (by `(target, root)`).
+- Add an additive structured `next_actions` representation in `status --json` that includes a stable `action` code plus a suggested `command`.
+- Improve human output to display per-root summaries and recommended follow-up commands.
+- Update docs and JSON goldens to lock the new fields.
+
+## Non-Goals
+
+- No breaking changes to the `schema_version=1` JSON contract (do not remove/rename existing fields).
+- Do not change drift detection semantics.
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack-cli/spec.md`
+- Affected code: `src/cli/commands/status.rs`, `src/cli/commands/schema.rs`
+- Affected docs: `docs/JSON_API.md`, `docs/SPEC.md`
+- Affected tests: `tests/golden/status_json_data.json`, `tests/golden/schema_json_data.json`

--- a/openspec/changes/update-status-actionable-output/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-status-actionable-output/specs/agentpack-cli/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: status emits grouped drift summary (additive)
+
+When invoked as `agentpack status --json`, the system SHALL include an additive `data.summary_by_root` field to make drift counts easy to consume without re-grouping client-side.
+
+`data.summary_by_root` SHALL be a list of items with:
+- `target: string`
+- `root: string`
+- `root_posix: string`
+- `summary: {modified, missing, extra}`
+
+The list SHOULD be deterministic (stable ordering).
+
+#### Scenario: status groups drift by root
+- **GIVEN** drift exists under at least two different roots
+- **WHEN** the user runs `agentpack status --json`
+- **THEN** `data.summary_by_root` contains at least two entries
+- **AND** each entry’s `summary` counts match the corresponding `data.drift[]` items
+
+### Requirement: status emits structured next actions (additive)
+
+When invoked as `agentpack status --json`, the system SHALL include an additive `data.next_actions_detailed` field that provides structured next actions for automation.
+
+`data.next_actions_detailed` SHALL be a list of objects with:
+- `action: string` (stable, enum-like)
+- `command: string` (a safe follow-up command)
+
+`data.next_actions_detailed[].command` values SHOULD correspond to the commands in `data.next_actions[]` when both are present.
+
+#### Scenario: status suggests structured bootstrap action
+- **GIVEN** operator assets are missing or outdated
+- **WHEN** the user runs `agentpack status --json`
+- **THEN** `data.next_actions_detailed[]` contains an item with `action = "bootstrap"`
+- **AND** that item’s `command` contains `agentpack bootstrap`
+
+## MODIFIED Requirements
+
+### Requirement: schema command documents JSON output contract
+
+The `agentpack schema --json` payload SHALL document `status` additive fields including:
+- `next_actions?`
+- `next_actions_detailed?`
+- `summary_by_root?`
+
+#### Scenario: schema lists status additive status fields
+- **WHEN** the user runs `agentpack schema --json`
+- **THEN** the schema output documents `status` data fields including `next_actions_detailed?`
+- **AND** the schema output documents `status` data fields including `summary_by_root?`

--- a/openspec/changes/update-status-actionable-output/tasks.md
+++ b/openspec/changes/update-status-actionable-output/tasks.md
@@ -1,0 +1,21 @@
+## 1. Contract (M1-E3-T1 / #314)
+- [ ] Define additive `status --json` fields for grouped summary and structured next actions
+- [ ] Run `openspec validate update-status-actionable-output --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add grouped drift summary output to `agentpack status --json`
+- [ ] Add structured `next_actions` output (action code + command) to `agentpack status --json`
+- [ ] Improve human `status` output to group by root with per-root summaries
+- [ ] Update `agentpack schema --json` to document new `status` data fields
+
+## 3. Docs
+- [ ] Update `docs/JSON_API.md` status payload documentation
+- [ ] Update `docs/SPEC.md` status JSON notes (additive fields)
+
+## 4. Tests
+- [ ] Update JSON golden snapshots for `status` and `schema`
+- [ ] Run `cargo test --all --locked`
+
+## 5. Archive
+- [ ] After shipping: `openspec archive update-status-actionable-output --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Motivation:
- Make `agentpack status` more action-oriented for automation while keeping `schema_version=1` additive-only changes.

Scope:
- Add OpenSpec change proposal for grouped status summary + structured next actions.

Non-goals:
- No implementation changes in this PR.

Acceptance:
- OpenSpec deltas define additive fields and schema documentation updates.

Tests:
- `openspec validate update-status-actionable-output --strict --no-interactive`

Refs: #314