### PR TITLE
chore(openspec): propose update-evolve-propose-skipped-reasons

### DIFF
--- a/openspec/changes/update-evolve-propose-skipped-reasons/proposal.md
+++ b/openspec/changes/update-evolve-propose-skipped-reasons/proposal.md
@@ -1,0 +1,28 @@
+# Change: evolve.propose skipped reasons become structured (reason_code + next_actions)
+
+## Why
+
+`agentpack evolve propose --json` currently reports skipped drift items with a string `reason` plus optional free-form `suggestions`. Automation has to interpret strings, and there is no stable per-item `next_actions` list that an agent can execute safely.
+
+We want to make skipped drift reporting more action-oriented and machine-friendly by introducing stable, enum-like reason codes, human-readable messages, and explicit follow-up commands.
+
+## What Changes
+
+- Add additive fields to each `data.skipped[]` item in `evolve.propose --json`:
+  - `reason_code` (stable enum-like string)
+  - `reason_message` (human readable)
+  - `next_actions[]` (suggested command strings; may be empty)
+- Keep existing fields (`reason`, `suggestions`, etc.) for `schema_version=1` compatibility.
+- Update docs and tests to lock the new fields.
+
+## Non-Goals
+
+- No breaking changes to `schema_version=1` (no field removals/renames).
+- Do not change which drift is considered proposeable vs skipped (only reporting).
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack/spec.md`
+- Affected code: `src/cli/commands/evolve.rs`
+- Affected docs: `docs/JSON_API.md`, `docs/SPEC.md`
+- Affected tests: `tests/cli_evolve_propose_skipped.rs`

--- a/openspec/changes/update-evolve-propose-skipped-reasons/specs/agentpack/spec.md
+++ b/openspec/changes/update-evolve-propose-skipped-reasons/specs/agentpack/spec.md
@@ -1,0 +1,34 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: evolve propose skipped items include structured reason fields (additive)
+
+When invoked as `agentpack evolve propose --dry-run --json`, each `data.skipped[]` item MUST include:
+- `reason_code` (stable, enum-like string)
+- `reason_message` (human-readable explanation)
+- `next_actions[]` (suggested follow-up commands; may be empty)
+
+This change MUST be additive for `schema_version=1` (existing fields like `reason` remain).
+
+#### Scenario: missing drift includes reason_code and next_actions
+- **GIVEN** an expected managed output is missing on disk
+- **WHEN** the user runs `agentpack evolve propose --dry-run --json`
+- **THEN** `data.skipped[]` contains an item with `reason=missing`
+- **AND** that item contains `reason_code=missing`
+- **AND** that item contains a non-empty `reason_message`
+- **AND** `next_actions[]` includes at least one safe follow-up command
+
+## MODIFIED Requirements
+
+### Requirement: evolve propose reports skipped drift
+
+When drift exists but cannot be safely mapped back to a single module (e.g., multi-module aggregated outputs) or when the deployed file is missing, `agentpack evolve propose` MUST report the drift as skipped instead of claiming there is no drift.
+
+#### Scenario: missing drift is reported as skipped
+- **GIVEN** an expected managed output is missing on disk
+- **WHEN** the user runs `agentpack evolve propose --dry-run --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.reason` equals `no_proposeable_drift`
+- **AND** `data.skipped[]` contains an item with `reason=missing`
+- **AND** that item contains `reason_code=missing`

--- a/openspec/changes/update-evolve-propose-skipped-reasons/tasks.md
+++ b/openspec/changes/update-evolve-propose-skipped-reasons/tasks.md
@@ -1,0 +1,19 @@
+## 1. Contract (M1-E3-T2 / #315)
+- [ ] Define additive skipped item fields and stable reason_code set
+- [ ] Run `openspec validate update-evolve-propose-skipped-reasons --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add `reason_code`, `reason_message`, and `next_actions` to `evolve.propose --json` skipped items
+- [ ] Keep existing `reason`/`suggestions` fields for compatibility
+
+## 3. Docs
+- [ ] Update `docs/JSON_API.md` evolve.propose skipped payload documentation
+- [ ] Update `docs/SPEC.md` evolve propose notes to reference structured skipped reasons
+
+## 4. Tests
+- [ ] Update `tests/cli_evolve_propose_skipped.rs` assertions to cover new fields
+- [ ] Run `cargo test --all --locked`
+
+## 5. Archive
+- [ ] After shipping: `openspec archive update-evolve-propose-skipped-reasons --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Motivation:
- Make `evolve.propose --json` skipped drift reporting machine-friendly via stable reason codes and explicit next actions.

Scope:
- Add OpenSpec proposal for additive skipped-item fields: `reason_code`, `reason_message`, `next_actions[]`.

Non-goals:
- No implementation changes in this PR.

Acceptance:
- Deltas define additive fields and keep existing `reason` for compatibility.

Tests:
- `openspec validate update-evolve-propose-skipped-reasons --strict --no-interactive`

Refs: #315