### PR TITLE
feat(cli): structure evolve.propose skipped reasons

### DIFF
--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -201,11 +201,15 @@ Tip:
 - `created: false`
 - `reason: "dry_run"`
 - `candidates: [{module_id,target,path,path_posix}]`
-- `skipped: [{reason,target,path,path_posix,module_id?,module_ids?,suggestions?}]` (additive)
+- `skipped: [{reason,reason_code,reason_message,next_actions,target,path,path_posix,module_id?,module_ids?,suggestions?}]` (additive)
 - `summary: {drifted_proposeable, drifted_skipped, ...}`
 
 `suggestions` (additive):
 - `[{action, reason}]`
+
+`skipped[].reason_code` (enum-like; additive):
+- `missing`
+- `multi_module_output`
 
 After execution (non dry-run):
 - `created: true`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -577,6 +577,7 @@ Notes:
   - For aggregated Codex `AGENTS.md` (composed from multiple `instructions` modules): if the file contains segment markers, agentpack tries to map drift back to the corresponding module segment and propose changes.
     - If markers are missing/unparseable, it skips with a `multi_module_output` reason.
   - It only processes drift where the deployed file exists but content differs; it skips `missing` drift (recommend `deploy` to restore).
+  - In `--json` mode, each `data.skipped[]` item includes additive fields: `reason_code`, `reason_message`, and `next_actions[]`.
   - Recommended flow: run `agentpack evolve propose --dry-run --json` to inspect `candidates` / `skipped` / warnings, then decide whether to pass `--yes` to create the proposal branch.
 
 Aggregated instructions marker format (implemented; example):

--- a/openspec/changes/update-evolve-propose-skipped-reasons/specs/agentpack/spec.md
+++ b/openspec/changes/update-evolve-propose-skipped-reasons/specs/agentpack/spec.md
@@ -11,6 +11,10 @@ When invoked as `agentpack evolve propose --dry-run --json`, each `data.skipped[
 
 This change MUST be additive for `schema_version=1` (existing fields like `reason` remain).
 
+Initial `reason_code` values emitted by `evolve.propose` SHOULD include:
+- `missing`
+- `multi_module_output`
+
 #### Scenario: missing drift includes reason_code and next_actions
 - **GIVEN** an expected managed output is missing on disk
 - **WHEN** the user runs `agentpack evolve propose --dry-run --json`

--- a/openspec/changes/update-evolve-propose-skipped-reasons/tasks.md
+++ b/openspec/changes/update-evolve-propose-skipped-reasons/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Contract (M1-E3-T2 / #315)
-- [ ] Define additive skipped item fields and stable reason_code set
-- [ ] Run `openspec validate update-evolve-propose-skipped-reasons --strict --no-interactive`
+- [x] Define additive skipped item fields and stable reason_code set
+- [x] Run `openspec validate update-evolve-propose-skipped-reasons --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Add `reason_code`, `reason_message`, and `next_actions` to `evolve.propose --json` skipped items
-- [ ] Keep existing `reason`/`suggestions` fields for compatibility
+- [x] Add `reason_code`, `reason_message`, and `next_actions` to `evolve.propose --json` skipped items
+- [x] Keep existing `reason`/`suggestions` fields for compatibility
 
 ## 3. Docs
-- [ ] Update `docs/JSON_API.md` evolve.propose skipped payload documentation
-- [ ] Update `docs/SPEC.md` evolve propose notes to reference structured skipped reasons
+- [x] Update `docs/JSON_API.md` evolve.propose skipped payload documentation
+- [x] Update `docs/SPEC.md` evolve propose notes to reference structured skipped reasons
 
 ## 4. Tests
-- [ ] Update `tests/cli_evolve_propose_skipped.rs` assertions to cover new fields
-- [ ] Run `cargo test --all --locked`
+- [x] Update `tests/cli_evolve_propose_skipped.rs` assertions to cover new fields
+- [x] Run `cargo test --all --locked`
 
 ## 5. Archive
 - [ ] After shipping: `openspec archive update-evolve-propose-skipped-reasons --yes`

--- a/tests/cli_evolve_propose_skipped.rs
+++ b/tests/cli_evolve_propose_skipped.rs
@@ -117,11 +117,38 @@ modules:
     assert_eq!(skipped.len(), 2);
     assert!(skipped.iter().any(|s| s["reason"] == "missing"));
     assert!(skipped.iter().any(|s| s["reason"] == "multi_module_output"));
+    assert!(skipped.iter().any(|s| s["reason_code"] == "missing"));
+    assert!(
+        skipped
+            .iter()
+            .any(|s| s["reason_code"] == "multi_module_output")
+    );
 
     let missing = skipped
         .iter()
         .find(|s| s["reason"] == "missing")
         .expect("missing skipped item");
+    assert_eq!(missing["reason_code"], "missing");
+    assert!(
+        missing["reason_message"].as_str().unwrap_or_default() != "",
+        "missing reason_message is non-empty"
+    );
+    let missing_next_actions = missing["next_actions"]
+        .as_array()
+        .expect("missing next_actions array");
+    assert!(
+        missing_next_actions
+            .iter()
+            .any(|s| s
+                == "agentpack --target codex evolve restore --module-id prompt:one --yes --json"),
+        "missing next_actions include evolve restore"
+    );
+    assert!(
+        missing_next_actions
+            .iter()
+            .any(|s| s == "agentpack --target codex deploy --apply --yes --json"),
+        "missing next_actions include deploy --apply"
+    );
     let missing_suggestions = missing["suggestions"]
         .as_array()
         .expect("missing suggestions array");
@@ -142,6 +169,18 @@ modules:
         .iter()
         .find(|s| s["reason"] == "multi_module_output")
         .expect("multi_module_output skipped item");
+    assert_eq!(multi["reason_code"], "multi_module_output");
+    assert!(
+        multi["reason_message"].as_str().unwrap_or_default() != "",
+        "multi_module_output reason_message is non-empty"
+    );
+    assert!(
+        multi["next_actions"]
+            .as_array()
+            .expect("next_actions array")
+            .is_empty(),
+        "multi_module_output next_actions is empty"
+    );
     let multi_suggestions = multi["suggestions"]
         .as_array()
         .expect("multi_module_output suggestions array");


### PR DESCRIPTION
Motivation:
- Make `evolve.propose --json` skipped drift reporting easy to branch on (stable reason codes + explicit next actions).

Scope:
- Add additive fields to each `data.skipped[]` item: `reason_code`, `reason_message`, `next_actions[]`.
- Keep existing `reason` and `suggestions` for compatibility.
- Update docs and tests.

Non-goals:
- No breaking changes to `schema_version=1`.
- No behavior change in what is considered proposeable vs skipped.

Tests:
- `just check`

Refs: #315