### PR TITLE
chore(openspec): propose update-doctor-fix-confirm-semantics

### DIFF
--- a/openspec/changes/update-doctor-fix-confirm-semantics/proposal.md
+++ b/openspec/changes/update-doctor-fix-confirm-semantics/proposal.md
@@ -1,0 +1,22 @@
+# Change: doctor --fix confirmation semantics in --json mode
+
+## Why
+
+`agentpack doctor --fix` is a write-capable operation (it can update `.gitignore`). In `--json` mode, write-capable operations must require explicit `--yes` and return a stable `E_CONFIRM_REQUIRED` error otherwise.
+
+We want to ensure `doctor --fix` follows the same guardrail pattern as other mutating commands and is covered by guardrails tests.
+
+## What Changes
+
+- Ensure `doctor --fix --json` requires `--yes` consistently via the central mutating guardrail helper.
+- Add guardrails test coverage for `doctor --fix` in `--json` mode.
+
+## Non-Goals
+
+- No changes to the underlying doctor checks or what gets fixed.
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack/spec.md`
+- Affected code: `src/cli/commands/doctor.rs`
+- Affected tests: `tests/cli_guardrails.rs`

--- a/openspec/changes/update-doctor-fix-confirm-semantics/specs/agentpack/spec.md
+++ b/openspec/changes/update-doctor-fix-confirm-semantics/specs/agentpack/spec.md
@@ -1,0 +1,13 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: doctor --fix requires --yes in --json mode
+
+When invoked with `--json`, `agentpack doctor --fix` MUST require explicit `--yes`. If `--yes` is missing, it MUST return `E_CONFIRM_REQUIRED` and MUST NOT perform any writes.
+
+#### Scenario: doctor --fix --json without --yes is refused
+- **WHEN** the user runs `agentpack doctor --fix --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`

--- a/openspec/changes/update-doctor-fix-confirm-semantics/tasks.md
+++ b/openspec/changes/update-doctor-fix-confirm-semantics/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract (M1-E3-T3 / #316)
+- [ ] Define `doctor --fix --json` guardrail requirement
+- [ ] Run `openspec validate update-doctor-fix-confirm-semantics --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Route `doctor --fix` through the central `--json` mutation guardrail (`E_CONFIRM_REQUIRED` without `--yes`)
+
+## 3. Tests
+- [ ] Add `doctor --fix` coverage to `tests/cli_guardrails.rs`
+- [ ] Run `cargo test --all --locked`
+
+## 4. Docs
+- [ ] Update `docs/SPEC.md` if behavior changes
+
+## 5. Archive
+- [ ] After shipping: `openspec archive update-doctor-fix-confirm-semantics --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Motivation:
- Ensure `doctor --fix` follows the standard `--json` mutation guardrails (`E_CONFIRM_REQUIRED` without `--yes`).

Scope:
- Add OpenSpec proposal covering `doctor --fix --json` confirmation semantics and guardrails tests.

Non-goals:
- No implementation changes in this PR.

Tests:
- `openspec validate update-doctor-fix-confirm-semantics --strict --no-interactive`

Refs: #316