### PR TITLE
feat(cli): doctor --fix --json requires --yes

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -535,7 +535,7 @@ Notes:
 - git hygiene (v0.3+):
   - if a target root is inside a git repo and `.agentpack.manifest.json` is not ignored: emit a warning (avoid accidental commits)
   - `--fix`: idempotently appends `.agentpack.manifest.json` to that repo’s `.gitignore`
-    - in `--json` mode, if it writes, it requires `--yes` (otherwise `E_CONFIRM_REQUIRED`)
+    - in `--json` mode, `doctor --fix` requires `--yes` (otherwise `E_CONFIRM_REQUIRED`)
 - in `--json` mode, `data.next_actions` MAY be included (additive) to suggest common follow-up commands
 
 ### 4.11 `remote` / `sync`

--- a/openspec/changes/update-doctor-fix-confirm-semantics/tasks.md
+++ b/openspec/changes/update-doctor-fix-confirm-semantics/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Contract (M1-E3-T3 / #316)
-- [ ] Define `doctor --fix --json` guardrail requirement
-- [ ] Run `openspec validate update-doctor-fix-confirm-semantics --strict --no-interactive`
+- [x] Define `doctor --fix --json` guardrail requirement
+- [x] Run `openspec validate update-doctor-fix-confirm-semantics --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Route `doctor --fix` through the central `--json` mutation guardrail (`E_CONFIRM_REQUIRED` without `--yes`)
+- [x] Route `doctor --fix` through the central `--json` mutation guardrail (`E_CONFIRM_REQUIRED` without `--yes`)
 
 ## 3. Tests
-- [ ] Add `doctor --fix` coverage to `tests/cli_guardrails.rs`
-- [ ] Run `cargo test --all --locked`
+- [x] Add `doctor --fix` coverage to `tests/cli_guardrails.rs`
+- [x] Run `cargo test --all --locked`
 
 ## 4. Docs
-- [ ] Update `docs/SPEC.md` if behavior changes
+- [x] Update `docs/SPEC.md` if behavior changes
 
 ## 5. Archive
 - [ ] After shipping: `openspec archive update-doctor-fix-confirm-semantics --yes`

--- a/tests/cli_guardrails.rs
+++ b/tests/cli_guardrails.rs
@@ -19,6 +19,7 @@ fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
 fn json_mode_requires_yes_for_mutating_commands() {
     let cases: &[(&str, &[&str])] = &[
         ("init", &["init", "--json"]),
+        ("doctor --fix", &["doctor", "--fix", "--json"]),
         ("import --apply", &["import", "--apply", "--json"]),
         (
             "add",


### PR DESCRIPTION
Motivation:
- Align `doctor --fix` with the standard `--json` mutation guardrails and ensure it is covered by guardrails tests.

Scope:
- Route `doctor --fix` through the central `require_yes_for_json_mutation` helper.
- Add `doctor --fix` to `tests/cli_guardrails.rs`.
- Clarify the behavior in `docs/SPEC.md`.

Non-goals:
- No change to what doctor checks or fixes.

Tests:
- `just check`

Refs: #316