### PR TITLE
spec(mcp): stabilize MCP tool set v1.0

### DIFF
--- a/openspec/changes/update-mcp-toolset-stability/proposal.md
+++ b/openspec/changes/update-mcp-toolset-stability/proposal.md
@@ -1,0 +1,22 @@
+# Change: stabilize MCP tool set and schemas
+
+## Why
+
+Agentpack’s MCP server is intended to be a thin, structured execution surface that reuses the CLI as the single semantic source of truth. To be reliable across hosts (Codex/IDE clients), the MCP tool catalog needs a stable, documented set of tools and input schemas.
+
+## What Changes
+
+- Stabilize the MCP tool list to include the core read-only and mutating operations used in the operator loop:
+  - `doctor`, `status`, `preview`, `diff`, `plan`, `deploy`, `deploy_apply`, `rollback`, `evolve_propose`, `evolve_restore`, `explain`
+- Document each tool input schema in `openspec/specs/agentpack-mcp/spec.md` (outputs reuse the CLI `--json` envelope).
+- Update MCP server implementation and tests to match the stabilized tool set.
+
+## Non-Goals
+
+- Do not introduce two-stage confirmation (`confirm_token`) in this change (tracked separately).
+
+## Impact
+
+- Affected specs: `openspec/specs/agentpack-mcp/spec.md`
+- Affected code: `src/mcp.rs`
+- Affected tests: `tests/mcp_server_stdio*.rs`

--- a/openspec/changes/update-mcp-toolset-stability/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/update-mcp-toolset-stability/specs/agentpack-mcp/spec.md
@@ -1,0 +1,198 @@
+# agentpack-mcp (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Expose Agentpack operations as MCP tools
+
+The server SHALL expose these tools at minimum:
+`plan`, `diff`, `preview`, `status`, `doctor`, `deploy`, `deploy_apply`, `rollback`, `evolve_propose`, `evolve_restore`, `explain`.
+
+Each tool’s `inputSchema` SHALL be valid JSON Schema.
+
+Tool input schemas (v1.0):
+
+#### Tool: plan
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "profile": { "type": "string", "default": "default" },
+    "target": { "type": "string", "default": "all", "enum": ["all", "codex", "claude_code", "cursor", "vscode"] },
+    "machine": { "type": "string", "description": "Machine id for machine overlays. Omit to auto-detect." },
+    "dry_run": { "type": "boolean", "default": false }
+  }
+}
+```
+
+#### Tool: diff
+Same as `plan`.
+
+#### Tool: preview
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "profile": { "type": "string", "default": "default" },
+    "target": { "type": "string", "default": "all", "enum": ["all", "codex", "claude_code", "cursor", "vscode"] },
+    "machine": { "type": "string", "description": "Machine id for machine overlays. Omit to auto-detect." },
+    "diff": { "type": "boolean", "default": false, "description": "Include diffs (like `agentpack preview --diff`)." },
+    "dry_run": { "type": "boolean", "default": false }
+  }
+}
+```
+
+#### Tool: status
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "profile": { "type": "string", "default": "default" },
+    "target": { "type": "string", "default": "all", "enum": ["all", "codex", "claude_code", "cursor", "vscode"] },
+    "machine": { "type": "string", "description": "Machine id for machine overlays. Omit to auto-detect." },
+    "only": { "type": "array", "items": { "type": "string", "enum": ["missing", "modified", "extra"] } },
+    "dry_run": { "type": "boolean", "default": false }
+  }
+}
+```
+
+#### Tool: doctor
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "target": { "type": "string", "default": "all", "enum": ["all", "codex", "claude_code", "cursor", "vscode"] }
+  }
+}
+```
+
+#### Tool: deploy
+Same as `plan`.
+
+#### Tool: deploy_apply
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["yes"],
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "profile": { "type": "string", "default": "default" },
+    "target": { "type": "string", "default": "all", "enum": ["all", "codex", "claude_code", "cursor", "vscode"] },
+    "machine": { "type": "string", "description": "Machine id for machine overlays. Omit to auto-detect." },
+    "adopt": { "type": "boolean", "default": false, "description": "Allow overwriting existing unmanaged files (adopt updates)." },
+    "dry_run": { "type": "boolean", "default": false, "description": "Force dry-run behavior (do not apply even if this tool is the apply variant)." },
+    "yes": { "const": true, "description": "Required explicit approval for mutating operations." }
+  }
+}
+```
+
+#### Tool: rollback
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["to", "yes"],
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "to": { "type": "string", "description": "Snapshot id to rollback to." },
+    "yes": { "const": true, "description": "Required explicit approval for mutating operations." }
+  }
+}
+```
+
+#### Tool: evolve_propose
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "profile": { "type": "string", "default": "default" },
+    "target": { "type": "string", "default": "all", "enum": ["all", "codex", "claude_code", "cursor", "vscode"] },
+    "machine": { "type": "string", "description": "Machine id for machine overlays. Omit to auto-detect." },
+    "module_id": { "type": "string", "description": "Only propose changes for a single module id." },
+    "scope": { "type": "string", "default": "global", "enum": ["global", "machine", "project"], "description": "Overlay scope to write into." },
+    "branch": { "type": "string", "description": "Branch name to create (default: evolve/propose-<timestamp>)." },
+    "dry_run": { "type": "boolean", "default": false },
+    "yes": { "type": "boolean", "default": false, "description": "Required explicit approval when not dry_run." }
+  }
+}
+```
+
+#### Tool: evolve_restore
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "profile": { "type": "string", "default": "default" },
+    "target": { "type": "string", "default": "all", "enum": ["all", "codex", "claude_code", "cursor", "vscode"] },
+    "machine": { "type": "string", "description": "Machine id for machine overlays. Omit to auto-detect." },
+    "module_id": { "type": "string", "description": "Only restore missing outputs attributable to a module id." },
+    "dry_run": { "type": "boolean", "default": false },
+    "yes": { "type": "boolean", "default": false, "description": "Required explicit approval when not dry_run." }
+  }
+}
+```
+
+#### Tool: explain
+```json
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["kind"],
+  "properties": {
+    "repo": { "type": "string", "description": "Path to the agentpack config repo (default: $AGENTPACK_HOME/repo)." },
+    "profile": { "type": "string", "default": "default" },
+    "target": { "type": "string", "default": "all", "enum": ["all", "codex", "claude_code", "cursor", "vscode"] },
+    "machine": { "type": "string", "description": "Machine id for machine overlays. Omit to auto-detect." },
+    "kind": { "type": "string", "enum": ["plan", "diff", "status"], "description": "Maps to `agentpack explain <kind> --json`." }
+  }
+}
+```
+
+#### Scenario: tools/list includes the stabilized tool set
+- **WHEN** a client calls `tools/list`
+- **THEN** the returned tool list includes each of the required tools by name
+
+### Requirement: Tool results reuse the Agentpack JSON envelope
+For each tool, the tool result SHALL reuse Agentpack’s stable `--json` envelope as the single canonical payload:
+- In MCP `content`, the server MUST include a `text` block containing the serialized JSON envelope.
+- In MCP `structuredContent`, the server SHOULD return the envelope as a JSON object (recommended for clients that support structured data).
+
+The envelope `command` field SHALL match the underlying Agentpack CLI command:
+- `plan` -> `command = "plan"`
+- `diff` -> `command = "diff"`
+- `preview` -> `command = "preview"`
+- `deploy` -> `command = "deploy"`
+- `status` -> `command = "status"`
+- `doctor` -> `command = "doctor"`
+- `deploy_apply` -> `command = "deploy"`
+- `rollback` -> `command = "rollback"`
+- `evolve_propose` -> `command = "evolve.propose"`
+- `evolve_restore` -> `command = "evolve.restore"`
+- `explain` -> `command` reflects the chosen kind (e.g., `explain.plan` and `explain.status`)
+
+On errors, the server SHALL set MCP `isError=true` and SHALL include an envelope with `ok=false` and stable Agentpack error codes when applicable.
+
+#### Scenario: plan tool returns an Agentpack envelope
+- **WHEN** a client calls tool `plan` with default inputs
+- **THEN** the tool result `structuredContent` includes `schema_version`, `ok`, `command`, `version`
+
+### Requirement: Mutating tools require explicit approval
+Mutating tools (`deploy_apply`, `rollback`, `evolve_propose`, `evolve_restore`) SHALL require explicit approval via an input parameter `yes=true` when the call may write.
+If approval is missing, the server MUST return `E_CONFIRM_REQUIRED` and MUST NOT perform writes.
+
+#### Scenario: deploy_apply without yes is refused
+- **WHEN** a client calls tool `deploy_apply` without `yes=true`
+- **THEN** the tool result has `isError=true`
+- **AND** the Agentpack envelope includes `errors[0].code = E_CONFIRM_REQUIRED`

--- a/openspec/changes/update-mcp-toolset-stability/tasks.md
+++ b/openspec/changes/update-mcp-toolset-stability/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract (M4-E1-T1 / #355)
+- [ ] Define the stabilized MCP tool list and input schemas
+- [ ] Run `openspec validate update-mcp-toolset-stability --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Update MCP server tool list to include the stabilized set
+- [ ] Add implementations for `preview`, `deploy`, `evolve_propose`, `evolve_restore`, and `explain`
+- [ ] Keep tool results as Agentpack JSON envelopes (structuredContent + text)
+
+## 3. Tests
+- [ ] Update MCP stdio tests to assert the stabilized tool list
+- [ ] Run `cargo test --all --locked`
+
+## 4. Archive
+- [ ] After shipping: `openspec archive update-mcp-toolset-stability --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Refs #355

## Motivation
MCP clients need a stable tool catalog and input schemas so they can reliably drive Agentpack across hosts.

## Scope
- OpenSpec change: `openspec/changes/update-mcp-toolset-stability/`
- Stabilizes MCP tool names and documents v1.0 input schemas.
- Updates envelope/approval requirements to cover the stabilized tool set.

## Non-goals
- No implementation changes in this PR.
- No two-stage confirmation (`confirm_token`).

## Acceptance criteria
- `openspec validate update-mcp-toolset-stability --strict --no-interactive` passes.

## Regression
- `openspec validate update-mcp-toolset-stability --strict --no-interactive`
