### PR TITLE
chore(openspec): propose update-evolve-propose-marked-instructions-outputs

### DIFF
--- a/openspec/changes/update-evolve-propose-marked-instructions-outputs/proposal.md
+++ b/openspec/changes/update-evolve-propose-marked-instructions-outputs/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+`agentpack evolve propose` can map drift in combined `AGENTS.md` back to individual `instructions:*` modules when the file contains per-module section markers.
+
+The VS Code target also produces a combined instructions output at `.github/copilot-instructions.md` and already uses the same marker format when multiple instructions modules are present. However, the current `evolve propose` implementation only attempts marker-based attribution for files named `AGENTS.md`, causing VS Code combined instructions drift to be reported as `multi_module_output` and preventing the “drift → evolve propose → overlay” loop.
+
+## What changes
+
+- Extend marker-based drift attribution in `evolve propose` to work for any combined instructions output that contains valid per-module section markers in both desired and deployed content (not only `AGENTS.md`).
+- Add integration tests covering VS Code `.github/copilot-instructions.md`.
+- Update documentation to describe combined instructions outputs for both Codex and VS Code.
+
+## Impact
+
+- Behavior: VS Code combined instructions drift becomes proposeable when markers are present; previously skipped items become `candidates`.
+- Contract: JSON envelope shape is unchanged; this is effectively additive (more candidates, fewer skipped).
+- Risk: low; if markers are missing/unparseable, behavior remains conservative and items continue to be skipped as `multi_module_output`.

--- a/openspec/changes/update-evolve-propose-marked-instructions-outputs/specs/agentpack/spec.md
+++ b/openspec/changes/update-evolve-propose-marked-instructions-outputs/specs/agentpack/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Combined instructions outputs include per-module markers
+When multiple `instructions` modules contribute to a combined deployed instructions output (for example Codex `AGENTS.md` or VS Code `.github/copilot-instructions.md`), the system SHALL include stable, per-module section markers so drift in the combined file can be mapped back to a specific module.
+
+#### Scenario: Combined AGENTS.md contains markers
+- **GIVEN** two `instructions` modules are enabled for the `codex` target
+- **WHEN** the system renders desired state for Codex agent instructions
+- **THEN** the combined `AGENTS.md` content contains a section marker per module id
+
+#### Scenario: Combined VS Code copilot-instructions.md contains markers
+- **GIVEN** two `instructions` modules are enabled for the `vscode` target
+- **WHEN** the system renders desired state for VS Code Copilot instructions
+- **THEN** the combined `.github/copilot-instructions.md` content contains a section marker per module id
+
+### Requirement: evolve propose can map marked instructions drift back to a module
+When a deployed combined instructions output contains valid per-module section markers, `agentpack evolve propose` SHALL treat drifted sections as proposeable and generate overlay updates for the corresponding `instructions` module(s).
+
+#### Scenario: drifted marked section becomes a propose candidate (Codex AGENTS.md)
+- **GIVEN** a deployed combined `AGENTS.md` containing section markers for `instructions:one` and `instructions:two`
+- **AND** only the `instructions:one` section content is edited on disk
+- **WHEN** the user runs `agentpack evolve propose --dry-run --json`
+- **THEN** `data.candidates[]` contains an item with `module_id="instructions:one"`
+- **AND** the drift is not reported as `multi_module_output` skipped for that output
+
+#### Scenario: drifted marked section becomes a propose candidate (VS Code copilot-instructions.md)
+- **GIVEN** a deployed combined `.github/copilot-instructions.md` containing section markers for `instructions:one` and `instructions:two`
+- **AND** only the `instructions:one` section content is edited on disk
+- **WHEN** the user runs `agentpack evolve propose --dry-run --json`
+- **THEN** `data.candidates[]` contains an item with `module_id="instructions:one"`
+- **AND** the drift is not reported as `multi_module_output` skipped for that output

--- a/openspec/changes/update-evolve-propose-marked-instructions-outputs/tasks.md
+++ b/openspec/changes/update-evolve-propose-marked-instructions-outputs/tasks.md
@@ -1,0 +1,12 @@
+## 1. Implementation
+
+- [ ] 1.1 Extend `evolve propose` marker attribution beyond `AGENTS.md`
+- [ ] 1.2 Add VS Code combined instructions test coverage
+- [ ] 1.3 Update docs (`docs/SPEC.md`, `docs/EVOLVE.md`) to include VS Code
+
+## 2. Validation
+
+- [ ] 2.1 Run `openspec validate update-evolve-propose-marked-instructions-outputs --strict`
+- [ ] 2.2 Run `cargo fmt --all -- --check`
+- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] 2.4 Run `cargo test --all --locked`


### PR DESCRIPTION
Refs #367\n\n## Why\nVS Code target emits a combined instructions file (.github/copilot-instructions.md) with per-module markers, but evolve propose currently only applies marker-based attribution to files named AGENTS.md. This blocks drift -> proposal -> overlay for VS Code instructions.\n\n## What\n- Adds OpenSpec change: update-evolve-propose-marked-instructions-outputs\n- Modifies requirements to cover combined instructions outputs for Codex AGENTS.md and VS Code .github/copilot-instructions.md\n\n## Validation\n- openspec validate update-evolve-propose-marked-instructions-outputs --strict --no-interactive