### PR TITLE
feat(cli): expand evolve.propose marked instructions outputs

### DIFF
--- a/docs/EVOLVE.md
+++ b/docs/EVOLVE.md
@@ -64,8 +64,8 @@ The default strategy is conservative: only propose drift that can be safely mapp
 - The output file has `module_ids.len() == 1`
 - The file exists and content differs (`modified`)
 
-2) **Aggregated output (Codex `AGENTS.md`)**
-- When multiple instructions modules are combined into one `AGENTS.md`, agentpack wraps each module section with markers:
+2) **Aggregated output (combined instructions files)**
+- When multiple instructions modules are combined into a single instructions output (e.g. Codex `AGENTS.md`, VS Code `.github/copilot-instructions.md`), agentpack wraps each module section with markers:
 
 ```md
 <!-- agentpack:module=instructions:one -->

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -574,7 +574,7 @@ Notes:
   - If git identity is missing and commit fails, agentpack prints guidance and keeps the branch and changes.
 - Current behavior is conservative: only generate proposals for drift that can be safely attributed to a single module.
   - By default it only processes outputs with `module_ids.len() == 1`.
-  - For aggregated Codex `AGENTS.md` (composed from multiple `instructions` modules): if the file contains segment markers, agentpack tries to map drift back to the corresponding module segment and propose changes.
+  - For combined instructions outputs (composed from multiple `instructions` modules), if the file contains segment markers, agentpack tries to map drift back to the corresponding module segment and propose changes (e.g. Codex `AGENTS.md`, VS Code `.github/copilot-instructions.md`).
     - If markers are missing/unparseable, it skips with a `multi_module_output` reason.
   - It only processes drift where the deployed file exists but content differs; it skips `missing` drift (recommend `deploy` to restore).
   - In `--json` mode, each `data.skipped[]` item includes additive fields: `reason_code`, `reason_message`, and `next_actions[]`.

--- a/docs/zh-CN/EVOLVE.md
+++ b/docs/zh-CN/EVOLVE.md
@@ -64,8 +64,8 @@ Evolve 的定位不是“自动修改你的系统”，而是把变化变成 **�
 - 某个输出文件的 `module_ids.len() == 1`
 - 文件存在且内容不同（modified）
 
-2) **聚合输出（Codex 的 AGENTS.md）**：
-- 当多个 instructions 模块合成一个 `AGENTS.md` 时，agentpack 会在每个模块段落外包 marker：
+2) **聚合输出（合并后的 instructions 文件）**：
+- 当多个 instructions 模块被合并到同一个 instructions 输出文件里（例如 Codex 的 `AGENTS.md`、VS Code 的 `.github/copilot-instructions.md`），agentpack 会在每个模块段落外包 marker：
 
 ```md
 <!-- agentpack:module=instructions:one -->

--- a/openspec/changes/update-evolve-propose-marked-instructions-outputs/tasks.md
+++ b/openspec/changes/update-evolve-propose-marked-instructions-outputs/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Implementation
 
-- [ ] 1.1 Extend `evolve propose` marker attribution beyond `AGENTS.md`
-- [ ] 1.2 Add VS Code combined instructions test coverage
-- [ ] 1.3 Update docs (`docs/SPEC.md`, `docs/EVOLVE.md`) to include VS Code
+- [x] 1.1 Extend `evolve propose` marker attribution beyond `AGENTS.md`
+- [x] 1.2 Add VS Code combined instructions test coverage
+- [x] 1.3 Update docs (`docs/SPEC.md`, `docs/EVOLVE.md`) to include VS Code
 
 ## 2. Validation
 
-- [ ] 2.1 Run `openspec validate update-evolve-propose-marked-instructions-outputs --strict`
-- [ ] 2.2 Run `cargo fmt --all -- --check`
-- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] 2.4 Run `cargo test --all --locked`
+- [x] 2.1 Run `openspec validate update-evolve-propose-marked-instructions-outputs --strict`
+- [x] 2.2 Run `cargo fmt --all -- --check`
+- [x] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 2.4 Run `cargo test --all --locked`

--- a/src/cli/commands/evolve.rs
+++ b/src/cli/commands/evolve.rs
@@ -237,39 +237,30 @@ fn evolve_propose(
                     });
                 }
                 Some(actual) => {
-                    let looks_like_agents_md = tp
-                        .path
-                        .file_name()
-                        .and_then(|s| s.to_str())
-                        .map(|s| s == "AGENTS.md")
-                        .unwrap_or(false);
-
-                    if looks_like_agents_md {
-                        if let Some(section_candidates) = try_propose_marked_instructions_sections(
-                            &desired_file.bytes,
-                            actual,
-                            &desired_file.module_ids,
-                        )? {
-                            for (module_id, bytes) in section_candidates {
-                                if let Some(prev) = instructions_sections.get(&module_id) {
-                                    if prev != &bytes {
-                                        warnings.push(format!(
-                                            "evolve.propose: skipped {} {} section for {}: conflicting edits across aggregated outputs",
-                                            tp.target,
-                                            tp.path.display(),
-                                            module_id
-                                        ));
-                                        continue;
-                                    }
+                    if let Some(section_candidates) = try_propose_marked_instructions_sections(
+                        &desired_file.bytes,
+                        actual,
+                        &desired_file.module_ids,
+                    )? {
+                        for (module_id, bytes) in section_candidates {
+                            if let Some(prev) = instructions_sections.get(&module_id) {
+                                if prev != &bytes {
+                                    warnings.push(format!(
+                                        "evolve.propose: skipped {} {} section for {}: conflicting edits across aggregated outputs",
+                                        tp.target,
+                                        tp.path.display(),
+                                        module_id
+                                    ));
                                     continue;
                                 }
-
-                                instructions_sections.insert(module_id.clone(), bytes.clone());
-                                summary.drifted_proposeable += 1;
-                                candidates.push((module_id, tp.clone(), bytes));
+                                continue;
                             }
-                            continue;
+
+                            instructions_sections.insert(module_id.clone(), bytes.clone());
+                            summary.drifted_proposeable += 1;
+                            candidates.push((module_id, tp.clone(), bytes));
                         }
+                        continue;
                     }
 
                     summary.drifted_skipped += 1;

--- a/tests/cli_evolve_propose_marked_instructions.rs
+++ b/tests/cli_evolve_propose_marked_instructions.rs
@@ -10,6 +10,16 @@ fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
         .expect("run agentpack")
 }
 
+fn agentpack_in_cwd(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
 fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
     let stdout = String::from_utf8_lossy(&output.stdout);
     serde_json::from_str(&stdout).expect("stdout is valid json")
@@ -94,6 +104,109 @@ modules:
         &[
             "--target",
             "codex",
+            "evolve",
+            "propose",
+            "--dry-run",
+            "--json",
+        ],
+    );
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "evolve.propose");
+    assert_eq!(v["data"]["reason"], "dry_run");
+
+    let candidates = v["data"]["candidates"]
+        .as_array()
+        .expect("candidates array");
+    assert!(
+        candidates
+            .iter()
+            .any(|c| c["module_id"] == "instructions:one")
+    );
+
+    let skipped = v["data"]["skipped"].as_array().expect("skipped array");
+    assert!(!skipped.iter().any(|s| s["reason"] == "multi_module_output"));
+}
+
+#[test]
+fn evolve_propose_can_map_marked_instructions_sections_to_modules_for_vscode() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let workspace = tmp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+
+    assert!(
+        agentpack_in_cwd(tmp.path(), &workspace, &["init"])
+            .status
+            .success()
+    );
+
+    let repo_dir = tmp.path().join("repo");
+    let i1 = repo_dir.join("modules/instructions/one");
+    let i2 = repo_dir.join("modules/instructions/two");
+    std::fs::create_dir_all(&i1).expect("create instructions module 1");
+    std::fs::create_dir_all(&i2).expect("create instructions module 2");
+    std::fs::write(i1.join("AGENTS.md"), "# one\n").expect("write AGENTS 1");
+    std::fs::write(i2.join("AGENTS.md"), "# two\n").expect("write AGENTS 2");
+
+    let manifest = r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["instructions:one","instructions:two"]
+    exclude_modules: []
+
+targets:
+  vscode:
+    mode: files
+    scope: project
+    options:
+      write_instructions: true
+      write_prompts: false
+
+modules:
+  - id: "instructions:one"
+    type: instructions
+    enabled: true
+    tags: []
+    targets: ["vscode"]
+    source:
+      local_path:
+        path: "modules/instructions/one"
+  - id: "instructions:two"
+    type: instructions
+    enabled: true
+    tags: []
+    targets: ["vscode"]
+    source:
+      local_path:
+        path: "modules/instructions/two"
+"#;
+    std::fs::write(repo_dir.join("agentpack.yaml"), manifest).expect("write manifest");
+
+    let deploy = agentpack_in_cwd(
+        tmp.path(),
+        &workspace,
+        &["--target", "vscode", "deploy", "--apply", "--json", "--yes"],
+    );
+    assert!(deploy.status.success());
+
+    let agents_path = workspace.join(".github/copilot-instructions.md");
+    let mut agents = std::fs::read_to_string(&agents_path).expect("read copilot-instructions.md");
+    assert!(agents.contains("<!-- agentpack:module=instructions:one -->"));
+    assert!(agents.contains("<!-- agentpack:module=instructions:two -->"));
+    assert!(agents.contains("<!-- /agentpack -->"));
+
+    agents = agents.replace("# one", "# one edited");
+    std::fs::write(&agents_path, agents).expect("write drifted copilot-instructions.md");
+
+    let out = agentpack_in_cwd(
+        tmp.path(),
+        &workspace,
+        &[
+            "--target",
+            "vscode",
             "evolve",
             "propose",
             "--dry-run",


### PR DESCRIPTION
Refs #367
Spec: update-evolve-propose-marked-instructions-outputs

## What
- evolve propose: use per-module section markers to attribute drift for combined instructions outputs beyond AGENTS.md (enables VS Code .github/copilot-instructions.md).
- Add integration test coverage for the VS Code combined instructions case.
- Update docs: docs/SPEC.md, docs/EVOLVE.md, docs/zh-CN/EVOLVE.md.

## Validation
- openspec validate update-evolve-propose-marked-instructions-outputs --strict --no-interactive
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
