### PR TITLE
chore(openspec): propose update-evolve-propose-branch-naming

### DIFF
--- a/openspec/changes/update-evolve-propose-branch-naming/proposal.md
+++ b/openspec/changes/update-evolve-propose-branch-naming/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+`agentpack evolve propose` creates a local git branch in the config repo. The current default branch name (`evolve/propose-<timestamp_nanos>`) is hard to interpret and does not encode the proposal scope or the affected module(s), which makes it harder to review and manage multiple proposals.
+
+The roadmap calls for a more controllable and informative default branch name that includes `scope`, `module_id` (when known), and a timestamp, while still allowing explicit overrides via `--branch`.
+
+## What changes
+
+- Change the default `evolve propose` branch naming scheme to include:
+  - scope (`global|machine|project`)
+  - module attribution (`<module_id>` when filtered or a single-module proposal, otherwise `multi`)
+  - timestamp (human-readable)
+- Keep `--branch` behavior unchanged (explicit name wins).
+- Update docs/CLI help text to reflect the new default.
+
+## Impact
+
+- User-visible behavior: default branch name changes (only when `--branch` is not provided).
+- No JSON schema changes; output fields remain unchanged.

--- a/openspec/changes/update-evolve-propose-branch-naming/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-evolve-propose-branch-naming/specs/agentpack-cli/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: evolve propose default branch names include scope and module attribution
+When `agentpack evolve propose` creates a proposal branch without an explicit `--branch`, the system SHALL use a deterministic, informative branch name that includes:
+- the proposal scope (`global|machine|project`), and
+- module attribution (either a specific `module_id` when it can be determined, or `multi`), and
+- a timestamp component for uniqueness.
+
+The branch name MUST be git-safe (no spaces; no characters invalid for ref names).
+
+#### Scenario: module-filtered proposal includes module_id and scope in branch name
+- **GIVEN** drift exists for module `instructions:one`
+- **WHEN** the user runs `agentpack evolve propose --module-id instructions:one --scope global`
+- **THEN** the created branch name includes `global` and `instructions:one` (or a sanitized equivalent)

--- a/openspec/changes/update-evolve-propose-branch-naming/tasks.md
+++ b/openspec/changes/update-evolve-propose-branch-naming/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+- [ ] 1.1 Update `evolve propose` default branch naming to include scope/module/timestamp
+- [ ] 1.2 Update CLI help + docs to reflect new default branch name
+
+## 2. Validation
+
+- [ ] 2.1 Run `openspec validate update-evolve-propose-branch-naming --strict`
+- [ ] 2.2 Run `cargo fmt --all -- --check`
+- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] 2.4 Run `cargo test --all --locked`


### PR DESCRIPTION
Refs #371

## Why
Default evolve.propose branch names are not informative (missing scope/module), which makes multiple proposals harder to manage.

## What
- Adds OpenSpec change: update-evolve-propose-branch-naming
- Specifies a deterministic default branch naming scheme including scope + module attribution + timestamp (git-safe)

## Validation
- openspec validate update-evolve-propose-branch-naming --strict --no-interactive
