### PR TITLE
feat(cli): improve evolve.propose default branch naming

### DIFF
--- a/docs/EVOLVE.md
+++ b/docs/EVOLVE.md
@@ -53,7 +53,7 @@ Recommended flow:
 Behavior and constraints:
 - This is a mutating command: in `--json` mode you must pass `--yes`.
 - Requires the config repo to be a git repo, and the working tree must be clean (otherwise it refuses).
-- Creates a branch (default `evolve/propose-<timestamp>`), writes drifted files into the appropriate overlay paths, then runs `git add -A` and attempts to commit.
+- Creates a branch (default `evolve/propose-<scope>-<module>-<timestamp>`), writes drifted files into the appropriate overlay paths, then runs `git add -A` and attempts to commit.
   - If commit fails (e.g., missing git identity), changes are not lost: the branch and working tree changes remain.
 
 ### What drift is proposable?

--- a/docs/zh-CN/EVOLVE.md
+++ b/docs/zh-CN/EVOLVE.md
@@ -53,7 +53,7 @@ Evolve 的定位不是“自动修改你的系统”，而是把变化变成 **�
 行为与限制：
 - 这是写入类命令：`--json` 下必须 `--yes`。
 - 会要求 config repo 是 git 仓库，并且工作区必须干净（否则拒绝）。
-- 会创建分支（默认 `evolve/propose-<timestamp>`），把 drifted 文件写入对应 overlay 路径，然后 `git add -A` 并尝试 commit。
+- 会创建分支（默认 `evolve/propose-<scope>-<module>-<timestamp>`），把 drifted 文件写入对应 overlay 路径，然后 `git add -A` 并尝试 commit。
   - commit 失败（例如缺 git identity）时不会丢改动：分支与变更会保留。
 
 ### 哪些 drift 会被 propose？

--- a/openspec/changes/update-evolve-propose-branch-naming/tasks.md
+++ b/openspec/changes/update-evolve-propose-branch-naming/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Implementation
 
-- [ ] 1.1 Update `evolve propose` default branch naming to include scope/module/timestamp
-- [ ] 1.2 Update CLI help + docs to reflect new default branch name
+- [x] 1.1 Update `evolve propose` default branch naming to include scope/module/timestamp
+- [x] 1.2 Update CLI help + docs to reflect new default branch name
 
 ## 2. Validation
 
-- [ ] 2.1 Run `openspec validate update-evolve-propose-branch-naming --strict`
-- [ ] 2.2 Run `cargo fmt --all -- --check`
-- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] 2.4 Run `cargo test --all --locked`
+- [x] 2.1 Run `openspec validate update-evolve-propose-branch-naming --strict`
+- [x] 2.2 Run `cargo fmt --all -- --check`
+- [x] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 2.4 Run `cargo test --all --locked`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -382,7 +382,7 @@ pub enum EvolveCommands {
         #[arg(long, value_enum, default_value = "global")]
         scope: EvolveScope,
 
-        /// Branch name to create (default: evolve/propose-<timestamp>)
+        /// Branch name to create (default: evolve/propose-<scope>-<module>-<timestamp>)
         #[arg(long)]
         branch: Option<String>,
     },


### PR DESCRIPTION
Refs #371
Spec: update-evolve-propose-branch-naming

## What
- Update evolve.propose default branch name to include scope (global|machine|project) and module attribution (module id when filtered/single-module, otherwise multi), plus a timestamp component.
- Keep --branch override behavior unchanged.
- Update CLI help + docs/EVOLVE (EN + zh-CN).

## Validation
- openspec validate update-evolve-propose-branch-naming --strict --no-interactive
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
