### PR TITLE
chore(openspec): propose add-policy-allowlist-remotes

### DIFF
--- a/openspec/changes/add-policy-allowlist-remotes/proposal.md
+++ b/openspec/changes/add-policy-allowlist-remotes/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+Organizations often need to restrict where agentpack-managed modules can be sourced from (supply-chain control). Today, `agentpack policy lint` can validate operator asset hygiene and basic distribution policy, but it does not enforce any allowlist for git remotes referenced by `repo/agentpack.yaml`.
+
+This makes it easy to accidentally introduce modules sourced from unexpected remotes.
+
+## What changes
+
+- Extend `repo/agentpack.org.yaml` with an optional `supply_chain_policy` section.
+- When `supply_chain_policy.allowed_git_remotes` is configured, `agentpack policy lint` validates that every git-sourced module in `repo/agentpack.yaml` uses a remote that matches the allowlist.
+- Violations are reported as standard policy lint issues and fail with `E_POLICY_VIOLATIONS` (no new error codes).
+
+## Impact
+
+- Opt-in only: no behavior change unless `supply_chain_policy.allowed_git_remotes` is configured.
+- CI-friendly: no network access required; checks are based on config contents.

--- a/openspec/changes/add-policy-allowlist-remotes/specs/agentpack/spec.md
+++ b/openspec/changes/add-policy-allowlist-remotes/specs/agentpack/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Governance supply_chain_policy can allowlist git remotes
+The governance config (`repo/agentpack.org.yaml`) SHALL support an optional supply chain policy section:
+
+- `supply_chain_policy.allowed_git_remotes: string[]`
+
+When `allowed_git_remotes` is configured and non-empty, `agentpack policy lint` MUST validate that every git-sourced module in `repo/agentpack.yaml` uses a git remote that matches at least one allowlist entry.
+
+The allowlist match MUST be case-insensitive and SHOULD treat common git URL forms as equivalent (e.g. `https://github.com/org/repo.git` and `git@github.com:org/repo.git`).
+
+Violations MUST be reported as standard `policy lint` issues and fail with `E_POLICY_VIOLATIONS`.
+
+#### Scenario: policy lint fails when a module uses a non-allowlisted remote
+- **GIVEN** `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes`
+- **AND** `repo/agentpack.yaml` contains a git-sourced module whose remote does not match the allowlist
+- **WHEN** the user runs `agentpack policy lint --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_POLICY_VIOLATIONS`
+- **AND** `errors[0].details.issues[]` includes an issue for the non-allowlisted module

--- a/openspec/changes/add-policy-allowlist-remotes/tasks.md
+++ b/openspec/changes/add-policy-allowlist-remotes/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [ ] 1.1 Add `supply_chain_policy.allowed_git_remotes` to org config schema (additive)
+- [ ] 1.2 Enforce allowlist in `agentpack policy lint` for git-sourced modules
+- [ ] 1.3 Add tests for allowlist pass/fail cases
+- [ ] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`)
+
+## 2. Validation
+
+- [ ] 2.1 Run `openspec validate add-policy-allowlist-remotes --strict`
+- [ ] 2.2 Run `cargo fmt --all -- --check`
+- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] 2.4 Run `cargo test --all --locked`


### PR DESCRIPTION
Refs #375

## Why
Add an opt-in governance supply-chain control to restrict git remotes used by modules in repo/agentpack.yaml.

## What
- OpenSpec change: add-policy-allowlist-remotes
- Adds supply_chain_policy.allowed_git_remotes and requires policy lint to enforce it (E_POLICY_VIOLATIONS on violations)

## Validation
- openspec validate add-policy-allowlist-remotes --strict --no-interactive
