### PR TITLE
feat(policy): enforce allowlist remotes

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -114,6 +114,23 @@ Enforcement:
 
 Non-goal: this policy does not change `agentpack plan/diff/deploy/...` behavior.
 
+## Supply chain policy (remote allowlist)
+
+Organizations can optionally enforce a git remote allowlist for modules declared in `repo/agentpack.yaml`.
+
+Example `repo/agentpack.org.yaml`:
+
+```yaml
+version: 1
+
+supply_chain_policy:
+  allowed_git_remotes: ["github.com/your-org/"]
+```
+
+Enforcement:
+- `agentpack policy lint` validates that every git-sourced module in `repo/agentpack.yaml` uses a remote that matches at least one allowlist entry.
+- Matching is case-insensitive and normalizes common git URL forms (e.g. `https://github.com/your-org/repo.git` and `git@github.com:your-org/repo.git`).
+
 ## Future roadmap (high-level)
 
 The governance layer may evolve in stages:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -201,6 +201,8 @@ Minimal schema (v1):
 - Optional `distribution_policy`:
   - `required_targets: string[]` (must exist under `repo/agentpack.yaml -> targets:`)
   - `required_modules: string[]` (must exist in `repo/agentpack.yaml -> modules:` and be `enabled: true`)
+- Optional `supply_chain_policy`:
+  - `allowed_git_remotes: string[]` (when non-empty, `policy lint` enforces an allowlist for module git sources)
 
 Source spec syntax (same as `agentpack add`):
 - `local:<repo-relative-path>`
@@ -217,6 +219,9 @@ policy_pack:
 distribution_policy:
   required_targets: ["codex", "claude_code"]
   required_modules: ["instructions:base"]
+
+supply_chain_policy:
+  allowed_git_remotes: ["github.com/your-org/"]
 ```
 
 ### 2.4 `repo/agentpack.org.lock.json` (governance policy lockfile; opt-in)
@@ -673,6 +678,7 @@ Behavior:
   - Dangerous defaults: command markdown that uses the bash tool MUST invoke mutating agentpack commands with `--json` and `--yes`.
   - Policy pack pinning (when configured): if `repo/agentpack.org.yaml` configures `policy_pack`, then `repo/agentpack.org.lock.json` MUST exist and MUST match the configured source (no network access).
   - Org distribution policy (when configured): if `repo/agentpack.org.yaml` configures `distribution_policy`, then `policy lint` MUST validate the required targets/modules in `repo/agentpack.yaml`.
+  - Supply chain allowlist (when configured): if `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes`, then `policy lint` MUST validate that git module sources in `repo/agentpack.yaml` match at least one allowlist entry.
 
 Exit codes:
 - Succeeds (exit 0) when no violations are found.

--- a/openspec/changes/add-policy-allowlist-remotes/tasks.md
+++ b/openspec/changes/add-policy-allowlist-remotes/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Implementation
 
-- [ ] 1.1 Add `supply_chain_policy.allowed_git_remotes` to org config schema (additive)
-- [ ] 1.2 Enforce allowlist in `agentpack policy lint` for git-sourced modules
-- [ ] 1.3 Add tests for allowlist pass/fail cases
-- [ ] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`)
+- [x] 1.1 Add `supply_chain_policy.allowed_git_remotes` to org config schema (additive)
+- [x] 1.2 Enforce allowlist in `agentpack policy lint` for git-sourced modules
+- [x] 1.3 Add tests for allowlist pass/fail cases
+- [x] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`)
 
 ## 2. Validation
 
-- [ ] 2.1 Run `openspec validate add-policy-allowlist-remotes --strict`
-- [ ] 2.2 Run `cargo fmt --all -- --check`
-- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] 2.4 Run `cargo test --all --locked`
+- [x] 2.1 Run `openspec validate add-policy-allowlist-remotes --strict`
+- [x] 2.2 Run `cargo fmt --all -- --check`
+- [x] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 2.4 Run `cargo test --all --locked`

--- a/src/policy_pack.rs
+++ b/src/policy_pack.rs
@@ -24,6 +24,8 @@ pub(crate) struct OrgConfig {
     pub policy_pack: Option<PolicyPackConfig>,
     #[serde(default)]
     pub distribution_policy: Option<DistributionPolicyConfig>,
+    #[serde(default)]
+    pub supply_chain_policy: Option<SupplyChainPolicyConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -37,6 +39,12 @@ pub(crate) struct DistributionPolicyConfig {
     pub required_targets: Vec<String>,
     #[serde(default)]
     pub required_modules: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SupplyChainPolicyConfig {
+    #[serde(default)]
+    pub allowed_git_remotes: Vec<String>,
 }
 
 impl OrgConfig {


### PR DESCRIPTION
Refs #375
Spec: add-policy-allowlist-remotes

## What
- Add optional org config section: supply_chain_policy.allowed_git_remotes.
- policy lint enforces the allowlist for git-sourced modules in agentpack.yaml (case-insensitive; normalizes https vs git@ forms).
- Docs update: docs/SPEC.md, docs/GOVERNANCE.md.
- Tests: policy lint pass/fail cases.

## Validation
- openspec validate add-policy-allowlist-remotes --strict --no-interactive
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
