### PR TITLE
chore(openspec): propose add-policy-require-lockfile

### DIFF
--- a/openspec/changes/add-policy-require-lockfile/proposal.md
+++ b/openspec/changes/add-policy-require-lockfile/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+For supply-chain control, teams often want to ensure that any git-sourced modules are pinned to immutable commits for reproducibility and auditability. Agentpack’s `repo/agentpack.lock.json` already pins git sources to commits, but there is currently no governance check that the lockfile exists and is in sync when git sources are present.
+
+Adding an opt-in policy lint check keeps the default personal-user experience unchanged while enabling CI enforcement for org-managed repos.
+
+## What changes
+
+- Extend `repo/agentpack.org.yaml` `supply_chain_policy` with an optional boolean `require_lockfile`.
+- When `require_lockfile=true` and `repo/agentpack.yaml` contains enabled git-sourced modules:
+  - `agentpack policy lint` MUST require `repo/agentpack.lock.json` to exist and be valid.
+  - The lockfile MUST contain entries for the enabled git modules, and the locked remote URL MUST match the configured remote URL.
+- Violations are reported as policy lint issues and fail with `E_POLICY_VIOLATIONS` (no new error codes).
+
+## Impact
+
+- Opt-in only; no behavior change unless `supply_chain_policy.require_lockfile` is enabled.
+- CI-friendly; does not require network access.

--- a/openspec/changes/add-policy-require-lockfile/specs/agentpack/spec.md
+++ b/openspec/changes/add-policy-require-lockfile/specs/agentpack/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Governance can require lockfile pinning for git modules
+The governance config (`repo/agentpack.org.yaml`) SHALL support an optional boolean:
+
+- `supply_chain_policy.require_lockfile: boolean`
+
+When `require_lockfile=true` and the repo manifest (`repo/agentpack.yaml`) contains at least one enabled git-sourced module, `agentpack policy lint` MUST enforce that:
+- `repo/agentpack.lock.json` exists and is valid, and
+- the lockfile contains entries for the enabled git modules, and
+- each locked git module’s `resolved_source.git.url` matches the configured module git URL.
+
+Violations MUST be reported as policy lint issues and fail with `E_POLICY_VIOLATIONS`.
+
+#### Scenario: policy lint fails when lockfile is missing for git modules
+- **GIVEN** `repo/agentpack.org.yaml` configures `supply_chain_policy.require_lockfile=true`
+- **AND** `repo/agentpack.yaml` contains at least one enabled git-sourced module
+- **AND** `repo/agentpack.lock.json` is missing
+- **WHEN** the user runs `agentpack policy lint --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_POLICY_VIOLATIONS`

--- a/openspec/changes/add-policy-require-lockfile/tasks.md
+++ b/openspec/changes/add-policy-require-lockfile/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [ ] 1.1 Add `supply_chain_policy.require_lockfile` to org config schema (additive)
+- [ ] 1.2 Enforce lockfile presence/sync in `agentpack policy lint` for enabled git modules
+- [ ] 1.3 Add tests for missing/invalid/out-of-sync lockfile cases
+- [ ] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`)
+
+## 2. Validation
+
+- [ ] 2.1 Run `openspec validate add-policy-require-lockfile --strict`
+- [ ] 2.2 Run `cargo fmt --all -- --check`
+- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] 2.4 Run `cargo test --all --locked`


### PR DESCRIPTION
Refs #379

## Why
Add an opt-in governance check to ensure git-sourced modules are pinned via repo/agentpack.lock.json for reproducibility and auditability.

## What
- OpenSpec change: add-policy-require-lockfile
- Adds supply_chain_policy.require_lockfile and requires policy lint enforcement when enabled

## Validation
- openspec validate add-policy-require-lockfile --strict --no-interactive
