### PR TITLE
feat(policy): require lockfile for git modules

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -125,11 +125,13 @@ version: 1
 
 supply_chain_policy:
   allowed_git_remotes: ["github.com/your-org/"]
+  require_lockfile: true
 ```
 
 Enforcement:
 - `agentpack policy lint` validates that every git-sourced module in `repo/agentpack.yaml` uses a remote that matches at least one allowlist entry.
 - Matching is case-insensitive and normalizes common git URL forms (e.g. `https://github.com/your-org/repo.git` and `git@github.com:your-org/repo.git`).
+- When `require_lockfile=true` and enabled git modules exist, `agentpack policy lint` requires `repo/agentpack.lock.json` to exist and include entries for those modules.
 
 ## Future roadmap (high-level)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -203,6 +203,7 @@ Minimal schema (v1):
   - `required_modules: string[]` (must exist in `repo/agentpack.yaml -> modules:` and be `enabled: true`)
 - Optional `supply_chain_policy`:
   - `allowed_git_remotes: string[]` (when non-empty, `policy lint` enforces an allowlist for module git sources)
+  - `require_lockfile: boolean` (when true, and enabled git modules exist, `policy lint` requires `repo/agentpack.lock.json` to exist and cover them)
 
 Source spec syntax (same as `agentpack add`):
 - `local:<repo-relative-path>`
@@ -222,6 +223,7 @@ distribution_policy:
 
 supply_chain_policy:
   allowed_git_remotes: ["github.com/your-org/"]
+  require_lockfile: true
 ```
 
 ### 2.4 `repo/agentpack.org.lock.json` (governance policy lockfile; opt-in)
@@ -679,6 +681,7 @@ Behavior:
   - Policy pack pinning (when configured): if `repo/agentpack.org.yaml` configures `policy_pack`, then `repo/agentpack.org.lock.json` MUST exist and MUST match the configured source (no network access).
   - Org distribution policy (when configured): if `repo/agentpack.org.yaml` configures `distribution_policy`, then `policy lint` MUST validate the required targets/modules in `repo/agentpack.yaml`.
   - Supply chain allowlist (when configured): if `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes`, then `policy lint` MUST validate that git module sources in `repo/agentpack.yaml` match at least one allowlist entry.
+  - Supply chain lockfile pinning (when configured): if `repo/agentpack.org.yaml` configures `supply_chain_policy.require_lockfile=true`, then `policy lint` MUST require `repo/agentpack.lock.json` to exist and contain entries for enabled git modules.
 
 Exit codes:
 - Succeeds (exit 0) when no violations are found.

--- a/openspec/changes/add-policy-require-lockfile/tasks.md
+++ b/openspec/changes/add-policy-require-lockfile/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Implementation
 
-- [ ] 1.1 Add `supply_chain_policy.require_lockfile` to org config schema (additive)
-- [ ] 1.2 Enforce lockfile presence/sync in `agentpack policy lint` for enabled git modules
-- [ ] 1.3 Add tests for missing/invalid/out-of-sync lockfile cases
-- [ ] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`)
+- [x] 1.1 Add `supply_chain_policy.require_lockfile` to org config schema (additive)
+- [x] 1.2 Enforce lockfile presence/sync in `agentpack policy lint` for enabled git modules
+- [x] 1.3 Add tests for missing/invalid/out-of-sync lockfile cases
+- [x] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`)
 
 ## 2. Validation
 
-- [ ] 2.1 Run `openspec validate add-policy-require-lockfile --strict`
-- [ ] 2.2 Run `cargo fmt --all -- --check`
-- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] 2.4 Run `cargo test --all --locked`
+- [x] 2.1 Run `openspec validate add-policy-require-lockfile --strict`
+- [x] 2.2 Run `cargo fmt --all -- --check`
+- [x] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 2.4 Run `cargo test --all --locked`

--- a/src/policy_pack.rs
+++ b/src/policy_pack.rs
@@ -45,6 +45,8 @@ pub(crate) struct DistributionPolicyConfig {
 pub(crate) struct SupplyChainPolicyConfig {
     #[serde(default)]
     pub allowed_git_remotes: Vec<String>,
+    #[serde(default)]
+    pub require_lockfile: bool,
 }
 
 impl OrgConfig {


### PR DESCRIPTION
Refs #379
Spec: add-policy-require-lockfile

## What
- Add supply_chain_policy.require_lockfile (opt-in).
- policy lint enforces that repo/agentpack.lock.json exists and contains entries for enabled git modules, with matching remote URLs and commit SHAs.
- Docs update: docs/SPEC.md, docs/GOVERNANCE.md.
- Tests: missing lockfile + in-sync lockfile cases.

## Validation
- openspec validate add-policy-require-lockfile --strict --no-interactive
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
