### PR TITLE
chore(openspec): propose add-policy-audit-report

### DIFF
--- a/openspec/changes/add-policy-audit-report/proposal.md
+++ b/openspec/changes/add-policy-audit-report/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+Governance features need a CI-friendly way to generate an audit report of what is being consumed and pinned:
+- module sources and pinned versions (from `repo/agentpack.lock.json`), and
+- (optionally) the pinned policy pack version (from `repo/agentpack.org.lock.json`).
+
+This supports supply-chain review and makes changes easier to inspect in PRs.
+
+## What changes
+
+- Add a new read-only command: `agentpack policy audit`.
+- In `--json` mode, the command outputs a structured audit report including:
+  - module ids, types, sources, pinned versions, and content hashes from `repo/agentpack.lock.json`
+  - an optional lockfile change summary when git history is available (best-effort; no network)
+  - optional governance policy pack lock info when `repo/agentpack.org.lock.json` exists
+
+## Impact
+
+- Adds a new CLI command (additive).
+- No changes to existing `--json` schemas for existing commands (except `help --json` command catalog, which is additive).

--- a/openspec/changes/add-policy-audit-report/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-policy-audit-report/specs/agentpack-cli/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Provide a policy audit command
+The system SHALL provide a read-only governance audit command:
+
+`agentpack policy audit`
+
+The command SHALL be CI-friendly and SHALL NOT require network access.
+
+In `--json` mode, on success:
+- stdout MUST be valid JSON with `ok=true`
+- `data` MUST include an audit report derived from `repo/agentpack.lock.json`, including module ids, sources, pinned versions, and content hashes.
+- `data` SHOULD include a best-effort change summary derived from git history when available.
+
+#### Scenario: policy audit emits a JSON report
+- **GIVEN** `repo/agentpack.lock.json` exists
+- **WHEN** the user runs `agentpack policy audit --json`
+- **THEN** stdout is valid JSON with `ok=true`
+- **AND** `data.modules[]` contains at least one module entry

--- a/openspec/changes/add-policy-audit-report/tasks.md
+++ b/openspec/changes/add-policy-audit-report/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [ ] 1.1 Add `agentpack policy audit` CLI entry (read-only)
+- [ ] 1.2 Define audit JSON payload (modules + optional change summary)
+- [ ] 1.3 Include org policy pack lock info when available
+- [ ] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`, `docs/CLI.md`)
+- [ ] 1.5 Update `help --json` golden snapshot as needed
+- [ ] 1.6 Add tests for `policy audit --json`
+
+## 2. Validation
+
+- [ ] 2.1 Run `openspec validate add-policy-audit-report --strict`
+- [ ] 2.2 Run `cargo fmt --all -- --check`
+- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] 2.4 Run `cargo test --all --locked`


### PR DESCRIPTION
Refs #383

## Why
Add a CI-friendly governance audit report for pinned module sources/versions (lockfile-driven) and optional change summary.

## What
- OpenSpec change: add-policy-audit-report
- Defines a new read-only command: agentpack policy audit

## Validation
- openspec validate add-policy-audit-report --strict --no-interactive
