### PR TITLE
feat(policy): add policy audit report command

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -157,6 +157,16 @@ Tip: choose targets via global `--target`:
 - `agentpack evolve restore [--module-id <id>]`
   - Restore missing desired outputs (create-only; supports `--dry-run`)
 
+## policy (governance, opt-in)
+
+Governance commands are CI-friendly and live under the `policy` namespace. Core commands do not read `repo/agentpack.org.yaml`.
+
+- `agentpack policy lint`: lint operator assets and org policy constraints (read-only)
+- `agentpack policy audit`: generate an audit report from `repo/agentpack.lock.json` (read-only)
+  - Includes a best-effort lockfile change summary when git history is available
+  - Includes `repo/agentpack.org.lock.json` details when present
+- `agentpack policy lock`: resolve and pin a configured policy pack (writes `repo/agentpack.org.lock.json`)
+
 ## completions
 
 `agentpack completions <shell>`

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -133,6 +133,19 @@ Enforcement:
 - Matching is case-insensitive and normalizes common git URL forms (e.g. `https://github.com/your-org/repo.git` and `git@github.com:your-org/repo.git`).
 - When `require_lockfile=true` and enabled git modules exist, `agentpack policy lint` requires `repo/agentpack.lock.json` to exist and include entries for those modules.
 
+## Policy audit report (supply chain / CI)
+
+Generate a CI-friendly audit report from lockfiles:
+
+```bash
+agentpack --repo . policy audit --json
+```
+
+Behavior:
+- Reads `repo/agentpack.lock.json` and emits module ids, pinned sources/versions, and content hashes.
+- When git history is available, includes a best-effort lockfile change summary (diff vs `HEAD^`), without any network access.
+- If `repo/agentpack.org.lock.json` exists, includes the pinned policy pack details.
+
 ## Future roadmap (high-level)
 
 The governance layer may evolve in stages:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -703,6 +703,21 @@ JSON mode:
 - `policy lock --json` requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
 - On success: `command="policy.lock"`, `ok=true`, and `data` includes `lockfile_path`, `resolved_version`, and `sha256`.
 
+### 4.21 `policy audit` (governance, read-only)
+
+`agentpack policy audit`
+
+Behavior:
+- Read-only governance command (opt-in) to generate a CI-friendly supply-chain audit report.
+- MUST NOT require network access.
+- Reads `repo/agentpack.lock.json` and emits module ids, types, resolved sources, pinned versions, and content hashes.
+- If `repo/agentpack.org.lock.json` exists, includes the pinned policy pack details.
+- SHOULD include a best-effort lockfile change summary from git history when available (diff vs `HEAD^`), and MUST NOT require network access.
+
+JSON mode:
+- On success: `command="policy.audit"`, `ok=true`, and `data` includes `root`, `lockfile`, `modules[]`, optional `org_policy_pack`, and optional `change_summary`.
+- Missing `repo/agentpack.lock.json` returns `E_LOCKFILE_MISSING`.
+
 ## 5. Target adapter details
 
 Build-time target selection:

--- a/openspec/changes/add-policy-audit-report/tasks.md
+++ b/openspec/changes/add-policy-audit-report/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Implementation
 
-- [ ] 1.1 Add `agentpack policy audit` CLI entry (read-only)
-- [ ] 1.2 Define audit JSON payload (modules + optional change summary)
-- [ ] 1.3 Include org policy pack lock info when available
-- [ ] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`, `docs/CLI.md`)
-- [ ] 1.5 Update `help --json` golden snapshot as needed
-- [ ] 1.6 Add tests for `policy audit --json`
+- [x] 1.1 Add `agentpack policy audit` CLI entry (read-only)
+- [x] 1.2 Define audit JSON payload (modules + optional change summary)
+- [x] 1.3 Include org policy pack lock info when available
+- [x] 1.4 Update docs (`docs/SPEC.md`, `docs/GOVERNANCE.md`, `docs/CLI.md`)
+- [x] 1.5 Update `help --json` golden snapshot as needed
+- [x] 1.6 Add tests for `policy audit --json`
 
 ## 2. Validation
 
-- [ ] 2.1 Run `openspec validate add-policy-audit-report --strict`
-- [ ] 2.2 Run `cargo fmt --all -- --check`
-- [ ] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
-- [ ] 2.4 Run `cargo test --all --locked`
+- [x] 2.1 Run `openspec validate add-policy-audit-report --strict`
+- [x] 2.2 Run `cargo fmt --all -- --check`
+- [x] 2.3 Run `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 2.4 Run `cargo test --all --locked`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -339,6 +339,9 @@ pub enum PolicyCommands {
     /// Lint operator assets and policy constraints (read-only)
     Lint,
 
+    /// Generate a supply-chain audit report from lockfiles (read-only)
+    Audit,
+
     /// Resolve and pin the configured policy pack (writes agentpack.org.lock.json)
     Lock,
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -13,14 +13,14 @@ use crate::user_error::UserError;
 
 const LOCKFILE_VERSION: u32 = 1;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Lockfile {
     pub version: u32,
     pub generated_at: String,
     pub modules: Vec<LockedModule>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LockedModule {
     pub id: String,
     #[serde(rename = "type")]
@@ -31,7 +31,7 @@ pub struct LockedModule {
     pub file_manifest: Vec<FileEntry>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResolvedSource {
     #[serde(default)]
     pub local_path: Option<ResolvedLocalPathSource>,
@@ -39,12 +39,12 @@ pub struct ResolvedSource {
     pub git: Option<ResolvedGitSource>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResolvedLocalPathSource {
     pub path: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResolvedGitSource {
     pub url: String,
     pub commit: String,
@@ -52,7 +52,7 @@ pub struct ResolvedGitSource {
     pub subdir: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileEntry {
     pub path: String,
     pub sha256: String,

--- a/tests/cli_policy_audit.rs
+++ b/tests/cli_policy_audit.rs
@@ -1,0 +1,153 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn git_in(cwd: &Path, args: &[&str]) -> anyhow::Result<String> {
+    let out = Command::new("git").current_dir(cwd).args(args).output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(String::from_utf8(out.stdout)?)
+}
+
+#[test]
+fn policy_audit_json_errors_when_lockfile_missing() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    let out = agentpack_in(tmp.path(), &["policy", "audit", "--json"]);
+    assert!(!out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["errors"][0]["code"], "E_LOCKFILE_MISSING");
+}
+
+#[test]
+fn policy_audit_emits_report_and_includes_optional_policy_pack_lock() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    // Add at least one module so the lockfile includes modules[].
+    assert!(
+        agentpack_in(
+            tmp.path(),
+            &[
+                "add",
+                "instructions",
+                "local:modules/instructions/base",
+                "--id",
+                "instructions:base",
+                "--tags",
+                "base",
+            ],
+        )
+        .status
+        .success()
+    );
+    assert!(agentpack_in(tmp.path(), &["lock"]).status.success());
+
+    // Create a local policy pack and lock it so audit can include org_policy_pack.
+    let repo = tmp.path().join("repo");
+    std::fs::create_dir_all(repo.join("policies/my-pack")).expect("mkdir pack");
+    std::fs::write(repo.join("policies/my-pack/rule.txt"), "hello").expect("write pack file");
+    std::fs::write(
+        repo.join("agentpack.org.yaml"),
+        r#"version: 1
+
+policy_pack:
+  source: "local:policies/my-pack"
+"#,
+    )
+    .expect("write org config");
+    assert!(
+        agentpack_in(tmp.path(), &["policy", "lock"])
+            .status
+            .success()
+    );
+
+    let out = agentpack_in(tmp.path(), &["policy", "audit", "--json"]);
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "policy.audit");
+    assert!(v["data"]["modules"].as_array().is_some());
+    assert!(!v["data"]["modules"].as_array().unwrap().is_empty());
+    assert!(v["data"]["org_policy_pack"].is_object());
+    assert_eq!(v["data"]["org_policy_pack"]["resolved_version"], "local");
+}
+
+#[test]
+fn policy_audit_includes_change_summary_when_git_history_available() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(agentpack_in(tmp.path(), &["init"]).status.success());
+
+    assert!(
+        agentpack_in(
+            tmp.path(),
+            &[
+                "add",
+                "instructions",
+                "local:modules/instructions/base",
+                "--id",
+                "instructions:base",
+                "--tags",
+                "base",
+            ],
+        )
+        .status
+        .success()
+    );
+    assert!(agentpack_in(tmp.path(), &["lock"]).status.success());
+
+    let repo = tmp.path().join("repo");
+    git_in(&repo, &["init"])?;
+    git_in(&repo, &["config", "user.email", "test@example.com"])?;
+    git_in(&repo, &["config", "user.name", "Test"])?;
+    git_in(&repo, &["add", "."])?;
+    git_in(&repo, &["commit", "-m", "init"])?;
+
+    // Modify module contents and regenerate the lockfile so audit can diff lockfiles.
+    let agents = repo.join("modules/instructions/base/AGENTS.md");
+    std::fs::write(
+        &agents,
+        format!("{}\nupdated\n", std::fs::read_to_string(&agents)?),
+    )?;
+    assert!(agentpack_in(tmp.path(), &["lock"]).status.success());
+    git_in(
+        &repo,
+        &[
+            "add",
+            "agentpack.lock.json",
+            "modules/instructions/base/AGENTS.md",
+        ],
+    )?;
+    git_in(&repo, &["commit", "-m", "update lockfile"])?;
+
+    let out = agentpack_in(tmp.path(), &["policy", "audit", "--json"]);
+    assert!(out.status.success());
+    let v = parse_stdout_json(&out);
+    assert!(v["data"]["change_summary"].is_object());
+    assert_eq!(v["data"]["change_summary"]["base_ref"], "HEAD^");
+    let changed = v["data"]["change_summary"]["modules_changed"]
+        .as_array()
+        .expect("modules_changed array");
+    assert!(changed.iter().any(|c| c["id"] == "instructions:base"));
+
+    Ok(())
+}

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -402,6 +402,16 @@
     },
     {
       "args": [],
+      "id": "policy audit",
+      "mutating": false,
+      "path": [
+        "policy",
+        "audit"
+      ],
+      "supports_json": true
+    },
+    {
+      "args": [],
       "id": "policy lint",
       "mutating": false,
       "path": [


### PR DESCRIPTION
## Summary
Adds a new read-only command, `agentpack policy audit`, to generate a CI-friendly audit report from `repo/agentpack.lock.json`.

## Scope
- CLI: `agentpack policy audit` (read-only; no network)
- JSON success id: `command="policy.audit"`
- Report includes: modules (ids/types/resolved sources/pinned versions/content hashes) + optional git-based change summary + optional `repo/agentpack.org.lock.json` details
- Docs: `docs/SPEC.md`, `docs/GOVERNANCE.md`, `docs/CLI.md`
- Tests: `tests/cli_policy_audit.rs`
- Golden: `tests/golden/help_json_data.json`

## Non-goals
- No network lookups or remote verification
- No changes to core command behavior or policy enforcement

## Acceptance
- `agentpack policy audit --json` succeeds when `repo/agentpack.lock.json` exists and emits a structured report
- Includes `org_policy_pack` when `repo/agentpack.org.lock.json` exists
- Includes `change_summary` when git history is available (best-effort)

## Testing
- `openspec validate add-policy-audit-report --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`

Closes #383.
