### PR TITLE
docs: add target mapping template

### DIFF
--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -169,5 +169,6 @@ Some roots enable `scan_extras`:
 ## 6) Adding a new target?
 
 See:
+- `TARGET_MAPPING_TEMPLATE.md`
 - `TARGET_SDK.md`
 - `TARGET_CONFORMANCE.md`

--- a/docs/TARGET_MAPPING_TEMPLATE.md
+++ b/docs/TARGET_MAPPING_TEMPLATE.md
@@ -1,0 +1,121 @@
+# Target mapping template
+
+Goal: make target additions predictable, reviewable, and testable.
+
+Use this template when proposing or adding a new target adapter (e.g., `zed`, `jetbrains`, …).
+
+## 1) Overview
+
+- **Target id**: `<target_id>` (kebab-case)
+- **Supported scope**: `user|project|both` (and any constraints)
+- **Primary user value**: what problem this target solves, concretely
+- **Non-goals**: what this target explicitly does not do
+
+## 2) Managed roots
+
+List every managed root (each root MUST write/update `.agentpack.manifest.json`):
+
+- Root A: `<path>` (how it’s computed; what it contains)
+- Root B: `<path>` …
+
+Notes:
+- If the target uses project identity, define how `project_root` is determined.
+- Specify whether each root uses `scan_extras=true|false`.
+
+## 3) Module → output mapping
+
+For each supported module type, define the mapping rules:
+
+### `instructions`
+
+- Output path(s):
+  - `<root>/<path>`
+- Composition rules:
+  - single vs multi-module aggregation
+  - if aggregated: how attribution is preserved (e.g., per-module section markers)
+
+### `skill`
+
+- Output path(s):
+  - `<root>/<path>`
+- How the skill name is derived (module id parsing + filesystem-safe fallback)
+- Copy semantics (copy directory; no symlinks)
+
+### `prompt`
+
+- Output path(s):
+  - `<root>/<path>`
+- Filename normalization rules (extensions; discovery conventions)
+
+### `command`
+
+- Output path(s):
+  - `<root>/<path>`
+- Naming rules (how a filename maps to the command name)
+
+## 4) Target options and environment variables
+
+Document all options under `targets.<target_id>.options`:
+
+- `option_name`: type, default, constraints, effect
+
+If the target supports env overrides, document them here:
+
+- `ENV_VAR_NAME`: meaning, precedence vs config, examples
+
+## 5) Validation rules (linting / safety)
+
+List any validation rules enforced by agentpack for this target:
+
+- Required frontmatter fields (if applicable)
+- Forbidden patterns or dangerous defaults
+- Unsupported combinations (e.g., scope restrictions)
+
+Also include error behavior:
+- Stable `--json` error codes to use for common failures
+
+## 6) Examples
+
+### Minimal manifest example
+
+```yaml
+version: 1
+
+profiles:
+  default:
+    include_tags: ["base"]
+
+targets:
+  <target_id>:
+    mode: files
+    scope: <user|project|both>
+    options:
+      # ...
+
+modules:
+  # ...
+```
+
+### Output example (paths)
+
+- `instructions:<name>` → `<path>`
+- `skill:<name>` → `<path>`
+- …
+
+## 7) Migration notes
+
+If users already have existing files/config:
+
+- What file locations are expected to already exist?
+- Any rename rules or backwards-compat patterns?
+- How to roll back safely (snapshots + manifests)
+
+## 8) Conformance checklist
+
+Add conformance tests (see `TARGET_CONFORMANCE.md`) and link them here:
+
+- [ ] Deploy/apply writes manifests per root
+- [ ] Safe delete: only manifest-managed files are deleted
+- [ ] Status drift: missing/modified/extra works (extras are never auto-deleted)
+- [ ] Rollback restores create/update/delete effects
+- [ ] JSON envelope + stable error codes remain stable

--- a/docs/TARGET_SDK.md
+++ b/docs/TARGET_SDK.md
@@ -3,6 +3,7 @@
 Goal: make adding a new target predictable and reviewable.
 
 ## New target checklist
+0. Start from `TARGET_MAPPING_TEMPLATE.md` and fill it out.
 1. Pick a stable target id (e.g., `cursor`).
 2. Define managed roots (each root MUST write `.agentpack.manifest.json`).
 3. Define mapping rules (modules → output paths under roots).

--- a/docs/zh-CN/TARGETS.md
+++ b/docs/zh-CN/TARGETS.md
@@ -169,5 +169,6 @@ VS Code / GitHub Copilot 使用 repo 级别的 “custom instructions” 和 “
 ## 6) 想加新 target？
 
 看：
+- `TARGET_MAPPING_TEMPLATE.md`
 - `TARGET_SDK.md`
 - `TARGET_CONFORMANCE.md`


### PR DESCRIPTION
Adds a target mapping template doc to make new target additions predictable and reviewable.

- New: `docs/TARGET_MAPPING_TEMPLATE.md`
- Links from `docs/TARGETS.md`, `docs/TARGET_SDK.md`, and `docs/zh-CN/TARGETS.md`

Closes #389.
