### PR TITLE
docs: add Zed compatibility guidance

### DIFF
--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -172,3 +172,22 @@ See:
 - `TARGET_MAPPING_TEMPLATE.md`
 - `TARGET_SDK.md`
 - `TARGET_CONFORMANCE.md`
+
+## 7) Zed (compatibility)
+
+Agentpack does not currently ship a dedicated `zed` target. However, Zed can consume repository rules from files like `AGENTS.md` and `.github/copilot-instructions.md` (see: https://zed.dev/docs/context/rules).
+
+Recommended approach:
+- Prefer `vscode` instructions output (`.github/copilot-instructions.md`) and let Zed read it.
+- Alternatively, use `codex` project instructions output (`<project_root>/AGENTS.md`).
+
+Example (minimal) snippet:
+
+```yaml
+targets:
+  vscode:
+    mode: files
+    scope: project
+    options:
+      write_instructions: true
+```

--- a/docs/zh-CN/TARGETS.md
+++ b/docs/zh-CN/TARGETS.md
@@ -172,3 +172,22 @@ VS Code / GitHub Copilot 使用 repo 级别的 “custom instructions” 和 “
 - `TARGET_MAPPING_TEMPLATE.md`
 - `TARGET_SDK.md`
 - `TARGET_CONFORMANCE.md`
+
+## 7) Zed（兼容性）
+
+Agentpack 目前还没有内置 `zed` target。但 Zed 可以从 repo 内的规则文件（例如 `AGENTS.md`、`.github/copilot-instructions.md`）读取项目规则（见：https://zed.dev/docs/context/rules）。
+
+推荐方式：
+- 优先使用 `vscode` target 的 instructions 输出（`.github/copilot-instructions.md`），让 Zed 直接读取它。
+- 或者使用 `codex` target 的 project instructions 输出（`<project_root>/AGENTS.md`）。
+
+最小示例：
+
+```yaml
+targets:
+  vscode:
+    mode: files
+    scope: project
+    options:
+      write_instructions: true
+```


### PR DESCRIPTION
Adds a short "Zed (compatibility)" section to the targets docs, describing how to use existing targets to generate Zed-readable project rules.

- `docs/TARGETS.md`
- `docs/zh-CN/TARGETS.md`

This is docs-only; no new target adapter is introduced.

Closes #400.
