### PR TITLE
spec(targets): add jetbrains target

### DIFF
--- a/openspec/changes/add-target-jetbrains/.openspec.yaml
+++ b/openspec/changes/add-target-jetbrains/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-18

--- a/openspec/changes/add-target-jetbrains/README.md
+++ b/openspec/changes/add-target-jetbrains/README.md
@@ -1,0 +1,3 @@
+# add-target-jetbrains
+
+Add a feature-gated `jetbrains` target adapter (Junie guidelines).

--- a/openspec/changes/add-target-jetbrains/proposal.md
+++ b/openspec/changes/add-target-jetbrains/proposal.md
@@ -1,0 +1,27 @@
+# Change: Add JetBrains target adapter (Junie guidelines)
+
+## Why
+JetBrains users (and agents running inside JetBrains IDEs) benefit from a “first-class” target that writes the default Junie guideline file location. This reduces setup friction vs. manually configuring Junie to read `AGENTS.md`, while staying consistent with Agentpack’s safety model (manifests, drift detection, rollback).
+
+## What Changes
+- Add a new target id: `jetbrains` (files mode).
+- Render `instructions` modules into `<project_root>/.junie/guidelines.md`.
+  - Multi-module output uses per-module section markers to preserve attribution.
+- Add a Cargo feature flag `target-jetbrains`.
+  - Include the feature in the default feature set so official binaries support JetBrains out-of-the-box (while still allowing minimal builds via `--no-default-features`).
+- Add conformance coverage for the new target, including per-root manifests, delete protection, drift classification, and rollback.
+- Update target documentation (mapping rules, examples, migration notes).
+
+## Non-goals
+- Managing JetBrains user-level settings.
+- Managing `.aiignore` (repo root collisions with other targets must be solved separately).
+- Managing JetBrains prompts/skills/commands formats (if any); this change focuses on Junie guidelines.
+
+## Impact
+- Affected OpenSpec capabilities:
+  - `openspec/specs/agentpack/spec.md` (new target behavior and conformance coverage)
+  - `openspec/specs/agentpack-cli/spec.md` (feature-gated target list)
+- User-visible docs:
+  - `docs/TARGETS.md` and `docs/zh-CN/TARGETS.md`
+  - `docs/SPEC.md` (supported targets list / target section)
+- Tracking issue: #392

--- a/openspec/changes/add-target-jetbrains/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-target-jetbrains/specs/agentpack-cli/spec.md
@@ -1,0 +1,21 @@
+# agentpack-cli (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Target adapters can be feature-gated at build time
+The system SHALL support building agentpack with a subset of target adapters enabled via Cargo features:
+- `target-codex`
+- `target-claude-code`
+- `target-cursor`
+- `target-vscode`
+- `target-jetbrains`
+
+The default feature set SHOULD include all built-in targets (to preserve the default user experience).
+
+If a user selects a target that is not compiled into the running binary, the CLI MUST treat it as unsupported.
+
+#### Scenario: selecting a non-compiled target fails with E_TARGET_UNSUPPORTED
+- **GIVEN** an agentpack binary built without `target-cursor`
+- **WHEN** the user runs `agentpack plan --target cursor --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_TARGET_UNSUPPORTED`

--- a/openspec/changes/add-target-jetbrains/specs/agentpack/spec.md
+++ b/openspec/changes/add-target-jetbrains/specs/agentpack/spec.md
@@ -1,0 +1,37 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: JetBrains target writes Junie guidelines file
+The system SHALL support a `jetbrains` target (files mode, project scope) that renders `instructions` modules into:
+`<project_root>/.junie/guidelines.md`.
+
+If multiple `instructions` modules target `jetbrains`, the output SHOULD preserve attribution via per-module section markers.
+
+#### Scenario: deploy writes jetbrains guidelines and manifests
+- **GIVEN** at least one enabled `instructions` module targeting `jetbrains`
+- **WHEN** the user runs `agentpack --target jetbrains deploy --apply`
+- **THEN** `<project_root>/.junie/guidelines.md` exists
+- **AND** `<project_root>/.junie/.agentpack.manifest.json` exists
+
+## MODIFIED Requirements
+
+### Requirement: Target rendering is routed via a TargetAdapter registry
+The system SHALL centralize target-specific rendering and validation behind a `TargetAdapter` abstraction, so adding a new target does not require scattering conditional logic across the engine and CLI.
+
+#### Scenario: Known targets are resolved via registry
+- **GIVEN** the system supports the `codex`, `claude_code`, `cursor`, `vscode`, and `jetbrains` targets
+- **WHEN** the engine renders desired state for a selected target
+- **THEN** the corresponding target adapter is used to compute target roots and desired output paths
+
+### Requirement: Target conformance tests cover critical safety semantics
+The repository SHALL include conformance tests that validate critical cross-target safety semantics, including:
+- delete protection (only manifest-managed paths can be deleted)
+- per-root manifest write/read
+- drift classification (missing/modified/extra)
+- rollback restoring previous outputs
+
+#### Scenario: conformance tests exist for built-in targets
+- **GIVEN** built-in targets `codex`, `claude_code`, `cursor`, `vscode`, and `jetbrains`
+- **WHEN** the test suite is run
+- **THEN** conformance tests execute these semantics for all built-in targets

--- a/openspec/changes/add-target-jetbrains/tasks.md
+++ b/openspec/changes/add-target-jetbrains/tasks.md
@@ -1,0 +1,20 @@
+## 1. Contract (M3-E2 / #392)
+- [x] Define target behavior in OpenSpec deltas (`agentpack`, `agentpack-cli`)
+- [x] Run `openspec validate add-target-jetbrains --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add Cargo feature `target-jetbrains` (and include in default features)
+- [ ] Register the `jetbrains` target in the target registry and config validation
+- [ ] Implement the `jetbrains` TargetAdapter (render `.junie/guidelines.md`)
+
+## 3. Tests
+- [ ] Add conformance coverage for `jetbrains` target
+- [ ] Update CI conformance feature matrix to include `target-jetbrains`
+- [ ] Update JSON/golden snapshots if `help --json` changes
+
+## 4. Docs
+- [ ] Document JetBrains target mapping + examples + migration notes
+
+## 5. Archive
+- [ ] After shipping: `openspec archive add-target-jetbrains --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Motivation
- Add a spec-driven proposal for a feature-gated `jetbrains` target that writes JetBrains Junie guidelines to the default path.

Scope
- OpenSpec change only (no implementation yet).
- Defines mapping + conformance expectations.

Non-goals
- No `.aiignore` management (repo-root collision)
- No JetBrains user-level settings

Tracking
- Refs #392 (implementation will follow in a separate PR)

Validation
- `openspec validate add-target-jetbrains --strict --no-interactive`
