### PR TITLE
spec(manifests): isolate target manifest filenames

### DIFF
--- a/openspec/changes/update-target-manifest-isolation/.openspec.yaml
+++ b/openspec/changes/update-target-manifest-isolation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-18

--- a/openspec/changes/update-target-manifest-isolation/README.md
+++ b/openspec/changes/update-target-manifest-isolation/README.md
@@ -1,0 +1,3 @@
+# update-target-manifest-isolation
+
+Isolate target manifest filenames per target to avoid collisions when multiple targets share the same managed root directory.

--- a/openspec/changes/update-target-manifest-isolation/proposal.md
+++ b/openspec/changes/update-target-manifest-isolation/proposal.md
@@ -1,0 +1,32 @@
+# Change: Isolate target manifest filenames per target
+
+## Why
+Agentpack currently writes one manifest per managed root at:
+
+`<root>/.agentpack.manifest.json`
+
+This becomes unsafe when multiple targets share the same managed root directory (e.g. repo-root outputs like `AGENTS.md` plus a future `zed` repo-root rules file). The targets would overwrite each other’s manifest, breaking:
+- safe-delete boundaries,
+- drift detection, and
+- rollback restoration for manifests.
+
+## What Changes
+- Write a target-specific manifest filename per root:
+  - new: `<root>/.agentpack.manifest.<target>.json`
+- Preserve backwards compatibility by reading the legacy manifest:
+  - legacy: `<root>/.agentpack.manifest.json`
+  - only when it belongs to the expected target (based on the manifest `tool` field).
+- Update `doctor --fix` and `init --git` to ignore `/.agentpack.manifest*.json` to cover both legacy and new names.
+- Update rollback logic to restore all manifest files (legacy and new).
+
+## Non-goals
+- Implementing `targets.zed` itself (tracked in #391).
+- Changing the JSON envelope schema version (CLI `--json` remains additive only).
+
+## Impact
+- Affected OpenSpec capabilities:
+  - `openspec/specs/agentpack/spec.md`
+  - `openspec/specs/agentpack-cli/spec.md`
+- Affected docs:
+  - `docs/SPEC.md`, `docs/ARCHITECTURE.md`, `docs/TARGET_CONFORMANCE.md`, and related references
+- Tracking issue: #405 (blocks #391)

--- a/openspec/changes/update-target-manifest-isolation/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-target-manifest-isolation/specs/agentpack-cli/spec.md
@@ -1,0 +1,18 @@
+# agentpack-cli (delta)
+
+## MODIFIED Requirements
+
+### Requirement: init can optionally initialize a git repo
+The system SHALL support `agentpack init --git` to initialize the created repo directory as a git repository and to write/update a minimal `.gitignore` file.
+
+The `.gitignore` file MUST ignore target manifest files, including both:
+- `.agentpack.manifest.json` (legacy), and
+- `.agentpack.manifest.<target>.json` (per-target)
+
+An ignore rule like `.agentpack.manifest*.json` is sufficient.
+
+#### Scenario: init --git creates a git-backed repo skeleton
+- **GIVEN** a fresh machine state (empty `AGENTPACK_HOME`)
+- **WHEN** the user runs `agentpack init --git`
+- **THEN** the repo directory contains a `.git/` directory
+- **AND** the repo directory contains `.gitignore` that ignores `.agentpack.manifest*.json`

--- a/openspec/changes/update-target-manifest-isolation/specs/agentpack/spec.md
+++ b/openspec/changes/update-target-manifest-isolation/specs/agentpack/spec.md
@@ -1,0 +1,36 @@
+# agentpack (delta)
+
+## MODIFIED Requirements
+
+### Requirement: target manifests define the managed file boundary
+`agentpack deploy --apply` MUST write a target manifest file into each managed target root directory that records the managed files and their hashes.
+
+To avoid collisions when multiple targets share the same root, the manifest filename MUST be target-specific:
+- `<root>/.agentpack.manifest.<target>.json`
+
+For backwards compatibility, the implementation MAY also read the legacy manifest filename:
+- `<root>/.agentpack.manifest.json`
+
+The legacy manifest MUST be treated as belonging to the expected target only when the manifest `tool` field matches the selected target id. Otherwise, it MUST be ignored (treated as missing) to avoid cross-target deletion risks.
+
+#### Scenario: per-target manifest is written and used
+- **GIVEN** a deployment writes a manifest for target `codex`
+- **WHEN** the user runs `agentpack deploy --apply`
+- **THEN** the managed root contains `.agentpack.manifest.codex.json`
+
+#### Scenario: legacy manifest is ignored when tool does not match target
+- **GIVEN** a target root contains a legacy `.agentpack.manifest.json` whose `tool="codex"`
+- **WHEN** the user runs `agentpack --target zed status --json`
+- **THEN** that manifest is treated as missing for `zed`
+
+### Requirement: doctor enforces gitignore safety for target manifests
+When a target root is inside a git repository, `doctor` MUST warn if target manifest files are not ignored, and `doctor --fix` MUST be able to idempotently add an ignore rule.
+
+The ignore rule SHOULD cover both legacy and per-target manifest filenames:
+- `.agentpack.manifest*.json`
+
+#### Scenario: doctor --fix adds wildcard ignore rule
+- **GIVEN** a target root directory is inside a git repo
+- **AND** target manifest files are not ignored
+- **WHEN** the user runs `agentpack doctor --fix --yes`
+- **THEN** the repo’s `.gitignore` contains an ignore entry for `.agentpack.manifest*.json`

--- a/openspec/changes/update-target-manifest-isolation/tasks.md
+++ b/openspec/changes/update-target-manifest-isolation/tasks.md
@@ -1,0 +1,19 @@
+## 1. Contract (#405)
+- [x] Update OpenSpec deltas for target manifest naming + backwards compatibility
+- [x] Run `openspec validate update-target-manifest-isolation --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Write manifests as `<root>/.agentpack.manifest.<target>.json`
+- [ ] Read legacy `.agentpack.manifest.json` only when `tool == <target>`
+- [ ] Update rollback manifest restore logic to cover new filenames
+- [ ] Update `doctor --fix` / `init --git` to ignore `.agentpack.manifest*.json`
+
+## 3. Tests
+- [ ] Update conformance + unit/integration tests that assert manifest filenames
+
+## 4. Docs
+- [ ] Update `docs/SPEC.md` (target manifest section) and any other relevant docs
+
+## 5. Archive
+- [ ] After shipping: `openspec archive update-target-manifest-isolation --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
Motivation
- Unblock targets that share the same managed root (e.g. future `zed` repo-root rules) by eliminating `<root>/.agentpack.manifest.json` collisions.

Scope
- OpenSpec proposal only (no implementation in this PR).
- Defines per-target manifest naming (`.agentpack.manifest.<target>.json`) + legacy read constraints.
- Updates gitignore guidance to use `.agentpack.manifest*.json`.

Tracking
- Refs #405 (blocks #391)

Validation
- `openspec validate update-target-manifest-isolation --strict --no-interactive`
