### PR TITLE
fix(manifests): isolate target manifest filenames

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ Inputs:
 
 Outputs:
 - target-discoverable directories/files (e.g. `~/.codex/skills/...`, `~/.claude/commands/...`)
-- per-root `.agentpack.manifest.json` (safe deletes + drift/status)
+- per-root `.agentpack.manifest.<target>.json` (safe deletes + drift/status)
 - state snapshots (deploy/bootstrap/rollback snapshots)
 
 ## 2. Three-layer storage model (separate by design)
@@ -68,7 +68,7 @@ Default `AGENTPACK_HOME=~/.agentpack` (overridable):
 
 5) Apply
 - Backup before writing
-- Refresh target manifests (`.agentpack.manifest.json`) after writing
+- Refresh target manifests (`.agentpack.manifest.<target>.json`) after writing
 - Record a snapshot (for rollback)
 
 ## 5. Overlays

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -30,7 +30,7 @@ After running bootstrap once:
   - user (optional): `~/.claude/skills/agentpack-operator/SKILL.md`
   - project (optional): `<project_root>/.claude/skills/agentpack-operator/SKILL.md`
 
-These files are also included in the per-root target manifest (`.agentpack.manifest.json`), which means:
+These files are also included in the per-root target manifest (`.agentpack.manifest.<target>.json`), which means:
 - `status` can detect them
 - `rollback` can revert them
 - deletes remove managed files only

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -24,7 +24,7 @@ Tips:
 - Initializes a config repo skeleton (creates `agentpack.yaml` and example directories)
 - By default it does not run `git init`
 - `--guided`: interactive wizard (TTY only) to generate a minimal `agentpack.yaml` (targets, scope, optional bootstrap)
-- `--git`: also initializes the repo directory as a git repo and ensures `.gitignore` ignores `.agentpack.manifest.json`
+- `--git`: also initializes the repo directory as a git repo and ensures `.gitignore` ignores `.agentpack.manifest*.json`
 - `--bootstrap`: also installs operator assets into the config repo (equivalent to `agentpack bootstrap --scope project`)
 
 Notes:
@@ -80,7 +80,7 @@ Notes:
 `agentpack deploy [--apply] [--adopt]`
 
 - Without `--apply`: show plan + diff only
-- With `--apply`: write to target roots, create a snapshot, and update per-root `.agentpack.manifest.json`
+- With `--apply`: write to target roots, create a snapshot, and update per-root `.agentpack.manifest.<target>.json`
 - If the plan contains `adopt_update`: you must pass `--adopt` or the command fails with `E_ADOPT_CONFIRM_REQUIRED`
 
 Common:
@@ -91,7 +91,7 @@ Common:
 ## status
 
 `agentpack status [--only <missing|modified|extra>[,...]]`
-- Detects drift (missing/modified/extra) using `.agentpack.manifest.json`
+- Detects drift (missing/modified/extra) using `.agentpack.manifest.<target>.json` (legacy manifests are supported for backwards compatibility)
 - If no manifests exist (first run or migration), it falls back to “desired vs FS” and emits a warning
 - `--only`: filter the reported drift list to a subset of kinds (repeatable or comma-separated)
 
@@ -116,7 +116,7 @@ See `TUI.md` for key bindings.
 
 `agentpack doctor [--fix]`
 - Checks machine id, target path writability, and common config issues
-- `--fix`: idempotently appends `.agentpack.manifest.json` to `.gitignore` for detected git repos (avoid accidental commits)
+- `--fix`: idempotently appends `.agentpack.manifest*.json` to `.gitignore` for detected git repos (avoid accidental commits)
 
 ## remote / sync
 

--- a/docs/CODEX_EXEC_PLAN.md
+++ b/docs/CODEX_EXEC_PLAN.md
@@ -56,7 +56,7 @@ P0-2 Target conformance harness
 - Goal: any new target must pass semantic consistency tests.
 - Coverage (see `docs/TARGET_CONFORMANCE.md`):
   - delete protection (delete managed only)
-  - manifests (`.agentpack.manifest.json` per root)
+  - manifests (`.agentpack.manifest.<target>.json` per root)
   - drift detection (missing/modified/extra)
   - rollback (restorable)
 - Acceptance criteria:

--- a/docs/CODEX_WORKPLAN.md
+++ b/docs/CODEX_WORKPLAN.md
@@ -27,7 +27,7 @@ P0-2 Conformance harness
 - Goal: before adding a new target, you must be able to run a suite of “semantic consistency tests”.
 - Coverage (see `TARGET_CONFORMANCE.md`):
   - delete protection (delete managed only)
-  - manifests (per-root `.agentpack.manifest.json`)
+  - manifests (per-root `.agentpack.manifest.<target>.json`)
   - drift (missing/modified/extra)
   - rollback (restorable)
 

--- a/docs/CONTRIBUTING_SPECS.md
+++ b/docs/CONTRIBUTING_SPECS.md
@@ -22,7 +22,7 @@ Use OpenSpec when your change impacts any stable/external contract, including:
   - `agentpack.yaml` (manifest)
   - `agentpack.lock.json` (lockfile)
   - overlay metadata under `.agentpack/`
-  - `.agentpack.manifest.json` (managed file boundary)
+  - `.agentpack.manifest.<target>.json` (managed file boundary)
 - **Architecture shifts** that change observable behavior (performance/security work that changes outcomes).
 
 ## When you can skip OpenSpec

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -32,7 +32,7 @@ Closed-loop capabilities:
 - Config repo (manifest + overlays) as the single source of truth
 - Lockfile (`agentpack.lock.json`) + store/cache (git checkout)
 - plan/diff/deploy: planning, diffs, backed-up writes, and snapshots
-- Per-root `.agentpack.manifest.json`: safe deletes and reliable drift/status
+- Per-root `.agentpack.manifest.<target>.json`: safe deletes and reliable drift/status
 - Overwrite protection: `adopt_update` requires `--adopt`
 
 UX and AI-first:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -125,7 +125,7 @@ To actually write files, you must pass `--apply`:
 - `agentpack deploy --apply`
 
 Safety model:
-- Deletes only remove **managed files** (tracked via `.agentpack.manifest.json` per target root), never arbitrary user files.
+- Deletes only remove **managed files** (tracked via `.agentpack.manifest.<target>.json` per target root), never arbitrary user files.
 - Overwrite protection: if a destination path exists but is **not managed**, it is classified as `adopt_update` and is refused by default.
 
 If you want to explicitly take over and overwrite those unmanaged existing files:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -239,7 +239,7 @@ Where:
 - `policy_pack.resolved_source.git.commit` pins git sources to an immutable commit SHA.
 - `sha256` and `file_manifest[]` are deterministic content hashes (diff-friendly; stable ordering).
 
-### 2.5 `<target root>/.agentpack.manifest.json` (target manifest)
+### 2.5 `<target root>/.agentpack.manifest.<target>.json` (target manifest)
 
 Goals:
 - Safe delete (delete managed files only)
@@ -267,6 +267,7 @@ Requirements:
 - `path` must be a relative path and must not contain `..`.
 - The manifest records only files written by agentpack deployments; never treat user-native files as managed files.
 - Readers MUST tolerate unsupported `schema_version` by emitting a warning and treating the manifest as missing (fall back behavior).
+- For backwards compatibility, agentpack MAY read the legacy filename `<target root>/.agentpack.manifest.json`, but MUST treat it as belonging to the selected target only when `tool == <target>`.
 
 ### 2.4 `state/logs/events.jsonl` (event log)
 
@@ -405,7 +406,7 @@ Optional:
   - prompts (minimum): targets, target scope (`project` or `both`), and whether to bootstrap after init
   - if stdin or stdout is not a terminal: MUST fail early and MUST NOT write any files
   - in `--json` mode, non-TTY usage MUST return stable error code `E_TTY_REQUIRED`
-- `--git`: ensure `.gitignore` contains `.agentpack.manifest.json` (idempotent).
+- `--git`: ensure `.gitignore` contains `.agentpack.manifest*.json` (idempotent).
 - `--bootstrap`: install operator assets into the config repo after init (equivalent to `agentpack bootstrap --scope project`).
 
 ### 4.1.1 `import`
@@ -489,7 +490,7 @@ Default behavior:
 - shows diff
 - when `--apply` is set:
   - performs apply (with backup) and writes a state snapshot
-  - writes `.agentpack.manifest.json` under each target root
+  - writes `.agentpack.manifest.<target>.json` under each target root
 - delete protection: only deletes managed files recorded in the manifest (never deletes unmanaged user files)
 - overwrite protection: refuses to overwrite existing unmanaged files (`adopt_update`) unless `--adopt` is provided
 - without `--apply`: show plan only (equivalent to `plan` + `diff`)
@@ -502,7 +503,7 @@ Notes:
 ### 4.7 `status`
 
 `agentpack status [--only <missing|modified|extra>[,...]]`
-- if the target root contains `.agentpack.manifest.json`: compute drift (`modified` / `missing` / `extra`) based on the manifest
+- if the target root contains a compatible target manifest (`.agentpack.manifest.<target>.json`, or legacy `.agentpack.manifest.json` when `tool` matches): compute drift (`modified` / `missing` / `extra`) based on the manifest
 - if there is no manifest (or the manifest has an unsupported `schema_version`): fall back to comparing desired outputs vs filesystem, and emit a warning
 - if installed operator assets (bootstrap) are missing or outdated: emit a warning and suggest running `agentpack bootstrap`
 - `--only`: filters the drift list to the selected kinds (repeatable or comma-separated)
@@ -540,8 +541,8 @@ Notes:
 - prints machineId (used for machine overlays)
 - checks target roots exist and are writable, with actionable suggestions (mkdir/permissions/config)
 - git hygiene (v0.3+):
-  - if a target root is inside a git repo and `.agentpack.manifest.json` is not ignored: emit a warning (avoid accidental commits)
-  - `--fix`: idempotently appends `.agentpack.manifest.json` to that repo’s `.gitignore`
+  - if a target root is inside a git repo and `.agentpack.manifest*.json` is not ignored: emit a warning (avoid accidental commits)
+  - `--fix`: idempotently appends `.agentpack.manifest*.json` to that repo’s `.gitignore`
     - in `--json` mode, `doctor --fix` requires `--yes` (otherwise `E_CONFIRM_REQUIRED`)
 - in `--json` mode, `data.next_actions` MAY be included (additive) to suggest common follow-up commands
 

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -2,7 +2,7 @@
 
 > Language: English | [Chinese (Simplified)](zh-CN/TARGETS.md)
 
-Targets define where agentpack writes the “compiled assets”, and which directories must write `.agentpack.manifest.json` to enable safe deletes and drift detection.
+Targets define where agentpack writes the “compiled assets”, and which directories must write `.agentpack.manifest.<target>.json` to enable safe deletes and drift detection.
 
 Built-in targets:
 - `codex`
@@ -26,7 +26,7 @@ Determined by `targets.codex.scope` and `targets.codex.options.*`, and may inclu
 
 Notes:
 - `project_root` is derived from the current working directory’s project identity (usually the git repo root).
-- Each root writes (or updates) `.agentpack.manifest.json` for safe deletes and drift detection.
+- Each root writes (or updates) `.agentpack.manifest.<target>.json` for safe deletes and drift detection.
 
 ### Module → output mapping
 

--- a/docs/TARGET_CONFORMANCE.md
+++ b/docs/TARGET_CONFORMANCE.md
@@ -4,7 +4,7 @@ Conformance tests are the quality bar for targets.
 
 ## Required semantics
 1. Delete protection: plan/apply only delete manifest-managed paths.
-2. Manifest: apply writes per-root `.agentpack.manifest.json`.
+2. Manifest: apply writes per-root `.agentpack.manifest.<target>.json`.
 3. Drift: status distinguishes `missing`/`modified`/`extra` (extras are not auto-deleted).
 4. Rollback: restores create/update/delete effects.
 5. JSON contract: envelope fields and key error codes remain stable.

--- a/docs/TARGET_MAPPING_TEMPLATE.md
+++ b/docs/TARGET_MAPPING_TEMPLATE.md
@@ -13,7 +13,7 @@ Use this template when proposing or adding a new target adapter (e.g., `zed`, `j
 
 ## 2) Managed roots
 
-List every managed root (each root MUST write/update `.agentpack.manifest.json`):
+List every managed root (each root MUST write/update `.agentpack.manifest.<target>.json`):
 
 - Root A: `<path>` (how it’s computed; what it contains)
 - Root B: `<path>` …

--- a/docs/TARGET_SDK.md
+++ b/docs/TARGET_SDK.md
@@ -5,7 +5,7 @@ Goal: make adding a new target predictable and reviewable.
 ## New target checklist
 0. Start from `TARGET_MAPPING_TEMPLATE.md` and fill it out.
 1. Pick a stable target id (e.g., `cursor`).
-2. Define managed roots (each root MUST write `.agentpack.manifest.json`).
+2. Define managed roots (each root MUST write `.agentpack.manifest.<target>.json`).
 3. Define mapping rules (modules → output paths under roots).
 4. Define minimal validation (structure/frontmatter requirements).
 5. Pass conformance tests (see `TARGET_CONFORMANCE.md`).

--- a/docs/zh-CN/BOOTSTRAP.md
+++ b/docs/zh-CN/BOOTSTRAP.md
@@ -30,7 +30,7 @@ Bootstrap 的目标：把“会用 agentpack”这件事交给 AI 自己完成�
   - user（可选）：`~/.claude/skills/agentpack-operator/SKILL.md`
   - project（可选）：`<project_root>/.claude/skills/agentpack-operator/SKILL.md`
 
-这些文件也会被纳入 target manifest（`.agentpack.manifest.json`），因此：
+这些文件也会被纳入 target manifest（`.agentpack.manifest.<target>.json`），因此：
 - 可以被 `status` 检测
 - 可以被 `rollback` 回滚
 - 删除只会删托管文件

--- a/docs/zh-CN/CLI.md
+++ b/docs/zh-CN/CLI.md
@@ -24,7 +24,7 @@
 - 初始化 config repo skeleton（创建 `agentpack.yaml` 与示例目录）
 - 默认不会自动 `git init`
 - `--guided`：交互式引导（需要真实 TTY）来生成最小可用的 `agentpack.yaml`（targets、scope、是否 bootstrap）
-- `--git`：同时初始化 git repo，并确保 `.gitignore` 忽略 `.agentpack.manifest.json`
+- `--git`：同时初始化 git repo，并确保 `.gitignore` 忽略 `.agentpack.manifest*.json`
 - `--bootstrap`：同时安装 operator assets 到 config repo（等价于执行 `agentpack bootstrap --scope project`）
 
 说明：
@@ -67,7 +67,7 @@ source spec：
 `agentpack deploy [--apply] [--adopt]`
 
 - 不带 `--apply`：只展示计划与 diff（相当于“plan + diff”）
-- 带 `--apply`：写入目标目录、生成 snapshot，并写入每个 target root 的 `.agentpack.manifest.json`
+- 带 `--apply`：写入目标目录、生成 snapshot，并写入每个 target root 的 `.agentpack.manifest.<target>.json`
 - 若计划包含 `adopt_update`：必须显式给 `--adopt` 才允许覆盖写入（否则报 `E_ADOPT_CONFIRM_REQUIRED`）
 
 常用：
@@ -78,7 +78,7 @@ source spec：
 ## status
 
 `agentpack status [--only <missing|modified|extra>[,...]]`
-- 基于 `.agentpack.manifest.json` 检测 drift（missing/modified/extra）
+- 基于 `.agentpack.manifest.<target>.json` 检测 drift（missing/modified/extra）（出于兼容性也会读取 legacy manifests）
 - 若缺少 manifest（首次使用或旧版本迁移），会降级为“desired vs FS”的对比并给 warning
 - `--only`：只展示指定 kind 的 drift（可重复传参或用逗号分隔）
 
@@ -103,7 +103,7 @@ source spec：
 
 `agentpack doctor [--fix]`
 - 检查 machineId、目标目录可写性、常见配置错误
-- `--fix`：在检测到的 git repo 的 `.gitignore` 中追加 `.agentpack.manifest.json`（避免误提交）
+- `--fix`：在检测到的 git repo 的 `.gitignore` 中追加 `.agentpack.manifest*.json`（避免误提交）
 
 ## remote / sync
 

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -125,7 +125,7 @@ Agentpack 默认在 `~/.agentpack/repo` 创建/读取配置仓库（可用 `AGEN
 - `agentpack deploy --apply`
 
 安全边界：
-- 删除只会删除“托管文件”（见每个 target root 的 `.agentpack.manifest.json`），不会删用户非托管文件。
+- 删除只会删除“托管文件”（见每个 target root 的 `.agentpack.manifest.<target>.json`），不会删用户非托管文件。
 - 覆盖保护：如果目标路径存在但**不属于托管文件**，会被标记为 `adopt_update`，默认拒绝覆盖。
 
 如果你确认要“接管并覆盖”这类文件：

--- a/docs/zh-CN/TARGETS.md
+++ b/docs/zh-CN/TARGETS.md
@@ -2,7 +2,7 @@
 
 > Language: 简体中文 | [English](../TARGETS.md)
 
-Target 决定 agentpack 要把“编译后的资产”写到哪里，以及哪些目录需要写 `.agentpack.manifest.json` 来实现安全删除和漂移检测。
+Target 决定 agentpack 要把“编译后的资产”写到哪里，以及哪些目录需要写 `.agentpack.manifest.<target>.json` 来实现安全删除和漂移检测。
 
 目前内置 targets：
 - `codex`
@@ -26,7 +26,7 @@ Target 的通用字段见 `CONFIG.md`。
 
 说明：
 - `project_root` 来自当前工作目录的 project 识别（通常是 git repo root）。
-- 每个 root 都会写入（或更新）`.agentpack.manifest.json`，用于安全删除与 drift。
+- 每个 root 都会写入（或更新）`.agentpack.manifest.<target>.json`，用于安全删除与 drift。
 
 ### module → 输出映射
 

--- a/openspec/changes/update-target-manifest-isolation/tasks.md
+++ b/openspec/changes/update-target-manifest-isolation/tasks.md
@@ -3,16 +3,16 @@
 - [x] Run `openspec validate update-target-manifest-isolation --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Write manifests as `<root>/.agentpack.manifest.<target>.json`
-- [ ] Read legacy `.agentpack.manifest.json` only when `tool == <target>`
-- [ ] Update rollback manifest restore logic to cover new filenames
-- [ ] Update `doctor --fix` / `init --git` to ignore `.agentpack.manifest*.json`
+- [x] Write manifests as `<root>/.agentpack.manifest.<target>.json`
+- [x] Read legacy `.agentpack.manifest.json` only when `tool == <target>`
+- [x] Update rollback manifest restore logic to cover new filenames
+- [x] Update `doctor --fix` / `init --git` to ignore `.agentpack.manifest*.json`
 
 ## 3. Tests
-- [ ] Update conformance + unit/integration tests that assert manifest filenames
+- [x] Update conformance + unit/integration tests that assert manifest filenames
 
 ## 4. Docs
-- [ ] Update `docs/SPEC.md` (target manifest section) and any other relevant docs
+- [x] Update `docs/SPEC.md` (target manifest section) and any other relevant docs
 
 ## 5. Archive
 - [ ] After shipping: `openspec archive update-target-manifest-isolation --yes`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -177,7 +177,7 @@ pub enum Commands {
 
     /// Check local environment and target paths
     Doctor {
-        /// Idempotently add `.agentpack.manifest.json` to `.gitignore` for detected repos
+        /// Idempotently add `.agentpack.manifest*.json` to `.gitignore` for detected repos
         #[arg(long)]
         fix: bool,
     },

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -346,8 +346,10 @@ pub(crate) fn run(ctx: &Ctx<'_>, guided: bool, git: bool, bootstrap: bool) -> an
         let mut gitignore_updated = false;
         if git {
             crate::git::git_in(&ctx.repo.repo_dir, &["init"]).context("git init")?;
-            gitignore_updated |=
-                ensure_gitignore_contains(&ctx.repo.repo_dir, ".agentpack.manifest.json")?;
+            gitignore_updated |= ensure_gitignore_contains(
+                &ctx.repo.repo_dir,
+                crate::target_manifest::TARGET_MANIFEST_GITIGNORE_LINE,
+            )?;
             gitignore_updated |= ensure_gitignore_contains(&ctx.repo.repo_dir, ".DS_Store")?;
         }
 
@@ -478,8 +480,10 @@ pub(crate) fn run(ctx: &Ctx<'_>, guided: bool, git: bool, bootstrap: bool) -> an
     let mut gitignore_updated = false;
     if git {
         crate::git::git_in(&ctx.repo.repo_dir, &["init"]).context("git init")?;
-        gitignore_updated |=
-            ensure_gitignore_contains(&ctx.repo.repo_dir, ".agentpack.manifest.json")?;
+        gitignore_updated |= ensure_gitignore_contains(
+            &ctx.repo.repo_dir,
+            crate::target_manifest::TARGET_MANIFEST_GITIGNORE_LINE,
+        )?;
         gitignore_updated |= ensure_gitignore_contains(&ctx.repo.repo_dir, ".DS_Store")?;
     }
 

--- a/src/tui_apply.rs
+++ b/src/tui_apply.rs
@@ -150,7 +150,23 @@ fn manifests_missing_for_desired(
     }
 
     for (idx, root) in roots.iter().enumerate() {
-        if used[idx] && !crate::target_manifest::manifest_path(&root.root).exists() {
+        if !used[idx] {
+            continue;
+        }
+
+        let preferred = crate::target_manifest::manifest_path_for_target(&root.root, &root.target);
+        if preferred.exists() {
+            continue;
+        }
+
+        let legacy = crate::target_manifest::legacy_manifest_path(&root.root);
+        if !legacy.exists() {
+            return true;
+        }
+
+        let (manifest, _warnings) =
+            crate::target_manifest::read_target_manifest_soft(&legacy, &root.target);
+        if manifest.is_none() {
             return true;
         }
     }

--- a/src/tui_core.rs
+++ b/src/tui_core.rs
@@ -197,16 +197,34 @@ fn render_status_text(
 
     let mut manifests: Vec<Option<crate::target_manifest::TargetManifest>> =
         vec![None; roots.len()];
+    let mut manifest_paths: Vec<Option<std::path::PathBuf>> = vec![None; roots.len()];
     for (idx, root) in roots.iter().enumerate() {
-        let path = crate::target_manifest::manifest_path(&root.root);
-        if !path.exists() {
+        let preferred = crate::target_manifest::manifest_path_for_target(&root.root, &root.target);
+        let legacy = crate::target_manifest::legacy_manifest_path(&root.root);
+
+        let (path, used_legacy) = if preferred.exists() {
+            (preferred, false)
+        } else if legacy.exists() {
+            (legacy, true)
+        } else {
             continue;
+        };
+
+        if used_legacy {
+            warnings.push(format!(
+                "target manifest ({}): using legacy manifest filename {} (consider running `agentpack deploy --apply` to migrate)",
+                root.target,
+                path.display(),
+            ));
         }
 
         let (manifest, manifest_warnings) =
             crate::target_manifest::read_target_manifest_soft(&path, &root.target);
         warnings.extend(manifest_warnings);
         manifests[idx] = manifest;
+        if manifests[idx].is_some() {
+            manifest_paths[idx] = Some(path);
+        }
     }
 
     let any_manifest = manifests.iter().any(Option::is_some);
@@ -314,7 +332,10 @@ fn render_status_text(
                         "target manifest ({}): skipped invalid entry path {:?} in {}",
                         root.target,
                         f.path,
-                        crate::target_manifest::manifest_path(&root.root).display(),
+                        manifest_paths[idx]
+                            .as_ref()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_else(|| "<unknown>".to_string()),
                     ));
                     continue;
                 }
@@ -377,9 +398,7 @@ fn render_status_text(
             let mut files = crate::fs::list_files(&root.root)?;
             files.sort();
             for path in files {
-                if path.file_name().and_then(|s| s.to_str())
-                    == Some(crate::target_manifest::TARGET_MANIFEST_FILENAME)
-                {
+                if crate::target_manifest::is_target_manifest_path(&path) {
                     continue;
                 }
 

--- a/tests/cli_bootstrap_claude_skill.rs
+++ b/tests/cli_bootstrap_claude_skill.rs
@@ -80,7 +80,7 @@ fn bootstrap_installs_claude_operator_skill_when_enabled() {
     );
     assert!(
         workspace
-            .join(".claude/skills/.agentpack.manifest.json")
+            .join(".claude/skills/.agentpack.manifest.claude_code.json")
             .exists()
     );
 }

--- a/tests/cli_deploy_claude_skill.rs
+++ b/tests/cli_deploy_claude_skill.rs
@@ -89,7 +89,7 @@ modules:
     assert!(workspace.join(".claude/skills/my-skill/SKILL.md").exists());
     assert!(
         workspace
-            .join(".claude/skills/.agentpack.manifest.json")
+            .join(".claude/skills/.agentpack.manifest.claude_code.json")
             .exists()
     );
 }

--- a/tests/cli_doctor_gitignore.rs
+++ b/tests/cli_doctor_gitignore.rs
@@ -73,7 +73,7 @@ modules: []
         warnings.iter().any(|w| w
             .as_str()
             .unwrap_or_default()
-            .contains(".agentpack.manifest.json")),
+            .contains(".agentpack.manifest*.json")),
         "expected gitignore warning"
     );
 
@@ -90,7 +90,7 @@ modules: []
     if gitignore_path.exists() {
         let before = std::fs::read_to_string(&gitignore_path).expect("read .gitignore");
         assert!(
-            !before.contains(".agentpack.manifest.json"),
+            !before.contains(".agentpack.manifest*.json"),
             "doctor --fix without --yes must not write"
         );
     }
@@ -104,7 +104,7 @@ modules: []
     let after = std::fs::read_to_string(&gitignore_path).expect("read .gitignore");
     let occurrences = after
         .lines()
-        .filter(|l| l.trim() == ".agentpack.manifest.json")
+        .filter(|l| l.trim() == ".agentpack.manifest*.json")
         .count();
     assert_eq!(occurrences, 1);
 
@@ -117,7 +117,7 @@ modules: []
         !warnings.iter().any(|w| w
             .as_str()
             .unwrap_or_default()
-            .contains(".agentpack.manifest.json")),
+            .contains(".agentpack.manifest*.json")),
         "expected warning to be resolved after doctor --fix"
     );
 
@@ -130,7 +130,7 @@ modules: []
     let after_again = std::fs::read_to_string(&gitignore_path).expect("read .gitignore");
     let occurrences = after_again
         .lines()
-        .filter(|l| l.trim() == ".agentpack.manifest.json")
+        .filter(|l| l.trim() == ".agentpack.manifest*.json")
         .count();
     assert_eq!(occurrences, 1);
 }

--- a/tests/cli_init_git.rs
+++ b/tests/cli_init_git.rs
@@ -19,6 +19,6 @@ fn init_git_initializes_repo_and_writes_gitignore() {
     assert!(
         gitignore
             .lines()
-            .any(|l| l.trim() == ".agentpack.manifest.json")
+            .any(|l| l.trim() == ".agentpack.manifest*.json")
     );
 }

--- a/tests/cli_manifest_forward_compat.rs
+++ b/tests/cli_manifest_forward_compat.rs
@@ -52,7 +52,7 @@ modules: []
     std::fs::write(repo_dir.join("agentpack.yaml"), manifest).expect("write manifest");
 
     std::fs::write(
-        codex_home.join("prompts/.agentpack.manifest.json"),
+        codex_home.join("prompts/.agentpack.manifest.codex.json"),
         r#"{"schema_version": 999}"#,
     )
     .expect("write unsupported manifest");

--- a/tests/conformance_targets.rs
+++ b/tests/conformance_targets.rs
@@ -251,11 +251,11 @@ fn conformance_codex_smoke() {
         .expect("snapshot_id")
         .to_string();
 
-    assert!(codex_home.join(".agentpack.manifest.json").exists());
+    assert!(codex_home.join(".agentpack.manifest.codex.json").exists());
     assert!(
         codex_home
             .join("prompts")
-            .join(".agentpack.manifest.json")
+            .join(".agentpack.manifest.codex.json")
             .exists()
     );
 
@@ -377,7 +377,11 @@ Hello v1
         .to_string();
 
     let commands_dir = workspace.join(".claude").join("commands");
-    assert!(commands_dir.join(".agentpack.manifest.json").exists());
+    assert!(
+        commands_dir
+            .join(".agentpack.manifest.claude_code.json")
+            .exists()
+    );
 
     let changes = deploy1_json["data"]["changes"]
         .as_array()
@@ -509,7 +513,7 @@ fn conformance_cursor_smoke() {
         .to_string();
 
     let rules_dir = workspace.join(".cursor").join("rules");
-    assert!(rules_dir.join(".agentpack.manifest.json").exists());
+    assert!(rules_dir.join(".agentpack.manifest.cursor.json").exists());
 
     let changes = deploy1_json["data"]["changes"]
         .as_array()
@@ -628,8 +632,8 @@ fn conformance_vscode_smoke() {
 
     let github_dir = workspace.join(".github");
     let prompts_dir = github_dir.join("prompts");
-    assert!(github_dir.join(".agentpack.manifest.json").exists());
-    assert!(prompts_dir.join(".agentpack.manifest.json").exists());
+    assert!(github_dir.join(".agentpack.manifest.vscode.json").exists());
+    assert!(prompts_dir.join(".agentpack.manifest.vscode.json").exists());
 
     let instructions_path = github_dir.join("copilot-instructions.md");
     let prompt_path = prompts_dir.join("hello.prompt.md");
@@ -746,7 +750,11 @@ fn conformance_jetbrains_smoke() {
         .to_string();
 
     let junie_dir = workspace.join(".junie");
-    assert!(junie_dir.join(".agentpack.manifest.json").exists());
+    assert!(
+        junie_dir
+            .join(".agentpack.manifest.jetbrains.json")
+            .exists()
+    );
 
     let guidelines_path = junie_dir.join("guidelines.md");
     assert!(

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -17,7 +17,7 @@ use agentpack::paths::AgentpackHome;
 use agentpack::paths::RepoPaths;
 use agentpack::source::parse_source_spec;
 use agentpack::state::DeploymentSnapshot;
-use agentpack::target_manifest::{ManagedManifestFile, TargetManifest, manifest_path};
+use agentpack::target_manifest::{ManagedManifestFile, TargetManifest, manifest_path_for_target};
 use agentpack::targets::TargetRoot;
 use agentpack::validate::validate_materialized_module;
 
@@ -656,7 +656,7 @@ fn load_managed_paths_from_manifests_reads_rel_paths() -> anyhow::Result<()> {
         sha256: "deadbeef".to_string(),
         module_ids: vec!["module:x".to_string()],
     });
-    manifest.save(&manifest_path(&root))?;
+    manifest.save(&manifest_path_for_target(&root, "codex"))?;
 
     let roots = vec![TargetRoot {
         target: "codex".to_string(),
@@ -686,7 +686,7 @@ fn plan_deletes_only_manifest_managed_files() -> anyhow::Result<()> {
         sha256: agentpack::hash::sha256_hex(b"x"),
         module_ids: vec!["module:x".to_string()],
     });
-    manifest.save(&manifest_path(root))?;
+    manifest.save(&manifest_path_for_target(root, "codex"))?;
 
     let roots = vec![TargetRoot {
         target: "codex".to_string(),
@@ -752,7 +752,7 @@ fn apply_plan_writes_target_manifests() -> anyhow::Result<()> {
     let snapshot = agentpack::apply::apply_plan(&home, "deploy", &plan, &desired, None, &roots)?;
 
     assert!(managed_path.is_file());
-    let mf = manifest_path(&target_root);
+    let mf = manifest_path_for_target(&target_root, "codex");
     assert!(mf.is_file());
 
     let manifest = TargetManifest::load(&mf)?;


### PR DESCRIPTION
## Summary
- Write per-target manifests: `<root>/.agentpack.manifest.<target>.json`
- Read legacy `<root>/.agentpack.manifest.json` only when `manifest.tool == <target>`
- Update rollback restore logic to handle new manifest filenames
- Update `init --git` and `doctor --fix` to ignore `.agentpack.manifest*.json`

## Why
Multiple targets can share the same repo root. A single repo-root manifest filename causes collisions (target A overwrites target B). This is a prerequisite for adding a future `zed` target.

## Verification
- `just check`
- `openspec validate update-target-manifest-isolation --strict --no-interactive`

Closes #405
Prereq for #391
