### PR TITLE
spec(targets): add zed target

### DIFF
--- a/openspec/changes/add-target-zed/.openspec.yaml
+++ b/openspec/changes/add-target-zed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-18

--- a/openspec/changes/add-target-zed/proposal.md
+++ b/openspec/changes/add-target-zed/proposal.md
@@ -1,0 +1,24 @@
+# Change: add target zed
+
+## Why
+Zed supports project-level AI “rules” via a repo-root `.rules` file (and other compatible filenames). Agentpack can already generate Zed-compatible rules today via existing targets (e.g., `vscode` → `.github/copilot-instructions.md`, `codex` → `AGENTS.md`), but a dedicated `zed` target:
+- provides a first-class mapping to Zed’s preferred `.rules` filename, and
+- keeps drift/rollback boundaries explicit via a target-specific manifest.
+
+With per-target manifest filenames shipped, `zed` can safely share the repo root as a managed root alongside other targets (e.g., `codex` project instructions).
+
+## What Changes
+- Add a new built-in target adapter `zed` (Cargo feature: `target-zed`).
+- Map `instructions` modules into a single repo-root rules file: `<project_root>/.rules`.
+- Write a per-target manifest at `<project_root>/.agentpack.manifest.zed.json` for safe deletes and drift detection.
+- Add target conformance coverage and update docs.
+
+## Impact
+- Specs: `agentpack`, `agentpack-cli`
+- Code: target registry + config validation + engine rendering + conformance tests
+- CLI output: `help --json` `targets[]` includes `zed` when compiled (additive)
+
+## Non-Goals
+- Managing Zed’s user-level Rules Library files.
+- Managing `.zed/settings.json` / editor configuration wiring.
+- Adding `evolve propose` support for `.rules` drift (can be added later).

--- a/openspec/changes/add-target-zed/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-target-zed/specs/agentpack-cli/spec.md
@@ -1,0 +1,22 @@
+# agentpack-cli (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Target adapters can be feature-gated at build time
+The system SHALL support building agentpack with a subset of target adapters enabled via Cargo features:
+- `target-codex`
+- `target-claude-code`
+- `target-cursor`
+- `target-vscode`
+- `target-jetbrains`
+- `target-zed`
+
+The default feature set SHOULD include all built-in targets (to preserve the default user experience).
+
+If a user selects a target that is not compiled into the running binary, the CLI MUST treat it as unsupported.
+
+#### Scenario: selecting a non-compiled target fails with E_TARGET_UNSUPPORTED
+- **GIVEN** an agentpack binary built without `target-cursor`
+- **WHEN** the user runs `agentpack plan --target cursor --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_TARGET_UNSUPPORTED`

--- a/openspec/changes/add-target-zed/specs/agentpack/spec.md
+++ b/openspec/changes/add-target-zed/specs/agentpack/spec.md
@@ -1,0 +1,34 @@
+# agentpack (delta)
+
+## ADDED Requirements
+
+### Requirement: Zed target writes AI rules file
+The system SHALL support a built-in `zed` target (files mode) that renders `instructions` modules into a repo-root `.rules` file for Zed AI Rules consumption.
+
+#### Scenario: deploy writes zed rules and a manifest
+- **GIVEN** at least one enabled `instructions` module targeting `zed`
+- **WHEN** the user runs `agentpack --target zed deploy --apply`
+- **THEN** `<project_root>/.rules` exists
+- **AND** `<project_root>/.agentpack.manifest.zed.json` exists
+
+## MODIFIED Requirements
+
+### Requirement: Target rendering is routed via a TargetAdapter registry
+The system SHALL centralize target-specific rendering and validation behind a `TargetAdapter` abstraction, so adding a new target does not require scattering conditional logic across the engine and CLI.
+
+#### Scenario: Known targets are resolved via registry
+- **GIVEN** the system supports the `codex`, `claude_code`, `cursor`, `vscode`, `jetbrains`, and `zed` targets
+- **WHEN** the engine renders desired state for a selected target
+- **THEN** the corresponding target adapter is used to compute target roots and desired output paths
+
+### Requirement: Target conformance tests cover critical safety semantics
+The repository SHALL include conformance tests that validate critical cross-target safety semantics, including:
+- delete protection (only manifest-managed paths can be deleted)
+- per-root manifest write/read
+- drift classification (missing/modified/extra)
+- rollback restoring previous outputs
+
+#### Scenario: conformance tests exist for built-in targets
+- **GIVEN** built-in targets `codex`, `claude_code`, `cursor`, `vscode`, `jetbrains`, and `zed`
+- **WHEN** the test suite is run
+- **THEN** conformance tests execute these semantics for all built-in targets

--- a/openspec/changes/add-target-zed/tasks.md
+++ b/openspec/changes/add-target-zed/tasks.md
@@ -1,0 +1,24 @@
+## 1. Contract (#391)
+- [ ] Update OpenSpec deltas (agentpack + agentpack-cli) for `zed`
+- [ ] Run `openspec validate add-target-zed --strict --no-interactive`
+
+## 2. Implementation
+- [ ] Add Cargo feature `target-zed` (default-enabled)
+- [ ] Validate `targets.zed` config (project scope only)
+- [ ] Add `zed` to target registry + adapter routing
+- [ ] Implement rendering:
+  - root: `<project_root>` (`scan_extras=false`)
+  - output: `<project_root>/.rules` from `instructions` modules
+- [ ] Ensure manifest is written as `<project_root>/.agentpack.manifest.zed.json`
+
+## 3. Tests
+- [ ] Add conformance smoke test for `zed`
+- [ ] Update golden snapshots impacted by target list changes (e.g. `help --json`)
+
+## 4. Docs
+- [ ] Update `docs/TARGETS.md` + `docs/zh-CN/TARGETS.md` with `zed` mapping
+- [ ] Update any other relevant docs/spec references
+
+## 5. Archive
+- [ ] After shipping: `openspec archive add-target-zed --yes`
+- [ ] Run `openspec validate --all --strict --no-interactive`


### PR DESCRIPTION
## Summary
Adds the OpenSpec change proposal `add-target-zed` for implementing a true `zed` target (Zed AI Rules via repo-root `.rules`).

- Proposal: `openspec/changes/add-target-zed/proposal.md`
- Tasks: `openspec/changes/add-target-zed/tasks.md`
- Deltas: `openspec/changes/add-target-zed/specs/*`

## Verification
- `openspec validate add-target-zed --strict --no-interactive`

Refs #391.
