### PR TITLE
feat(targets): add zed target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ default = [
   "target-cursor",
   "target-vscode",
   "target-jetbrains",
+  "target-zed",
 ]
 tui = ["dep:crossterm", "dep:ratatui"]
 target-codex = []
@@ -46,6 +47,7 @@ target-claude-code = []
 target-cursor = []
 target-vscode = []
 target-jetbrains = []
+target-zed = []
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -8,7 +8,7 @@ This document is for quickly looking up how a command works. For workflow-orient
 
 - `--repo <path>`: path to the config repo (default: `$AGENTPACK_HOME/repo`)
 - `--profile <name>`: profile name (default: `default`)
-- `--target <codex|claude_code|cursor|vscode|jetbrains|all>`: target selection (default: `all`)
+- `--target <codex|claude_code|cursor|vscode|jetbrains|zed|all>`: target selection (default: `all`)
 - `--machine <id>`: override machine id (for machine overlays; default: auto-detect)
 - `--json`: machine-readable JSON output (envelope) on stdout
 - `--yes`: skip confirmations (note: in `--json` mode, mutating commands require explicit `--yes`)
@@ -45,7 +45,7 @@ Notes:
 
 ## add / remove
 
-- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode,jetbrains]`
+- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode,jetbrains,zed]`
 - `agentpack remove <module_id>`
 
 Source spec:

--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -96,7 +96,7 @@ Meaning:
 - The target is not compiled into the running agentpack binary (feature-gated builds).
 Retryable: yes.
 Recommended action:
-- `--target` must be `all|codex|claude_code|cursor|vscode|jetbrains` (but feature-gated builds may support a subset; see `agentpack help --json` `data.targets[]`).
+- `--target` must be `all|codex|claude_code|cursor|vscode|jetbrains|zed` (but feature-gated builds may support a subset; see `agentpack help --json` `data.targets[]`).
 - Manifest targets must be built-in targets that are compiled into the running binary.
 
 ### E_DESIRED_STATE_CONFLICT

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -426,7 +426,7 @@ Notes:
 
 ### 4.2 `add` / `remove`
 
-- `agentpack add <type> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode,jetbrains]`
+- `agentpack add <type> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode,jetbrains,zed]`
 - `agentpack remove <module_id>`
 
 Source expressions:
@@ -520,7 +520,7 @@ Notes:
 
 ### 4.9 `bootstrap` (AI-first operator assets)
 
-`agentpack bootstrap [--target all|codex|claude_code|cursor|vscode|jetbrains] [--scope user|project|both]`
+`agentpack bootstrap [--target all|codex|claude_code|cursor|vscode|jetbrains|zed] [--scope user|project|both]`
 - installs operator assets:
   - Codex: writes one skill (`agentpack-operator`)
   - Claude: writes a set of slash commands (`ap-doctor`, `ap-update`, `ap-preview`, `ap-plan`, `ap-diff`, `ap-deploy`, `ap-status`, `ap-explain`, `ap-evolve`)

--- a/docs/TARGETS.md
+++ b/docs/TARGETS.md
@@ -1,4 +1,4 @@
-# Targets (`codex` / `claude_code` / `cursor` / `vscode` / `jetbrains`)
+# Targets (`codex` / `claude_code` / `cursor` / `vscode` / `jetbrains` / `zed`)
 
 > Language: English | [Chinese (Simplified)](zh-CN/TARGETS.md)
 
@@ -10,6 +10,7 @@ Built-in targets:
 - `cursor`
 - `vscode`
 - `jetbrains`
+- `zed`
 
 For shared target fields, see `CONFIG.md`.
 
@@ -199,21 +200,37 @@ See:
 - `TARGET_SDK.md`
 - `TARGET_CONFORMANCE.md`
 
-## 8) Zed (compatibility)
+## 8) zed
 
-Agentpack does not currently ship a dedicated `zed` target. However, Zed can consume repository rules from files like `AGENTS.md` and `.github/copilot-instructions.md` (see: https://zed.dev/docs/context/rules).
+Zed supports repo-root `.rules` files for AI “rules”, and also supports other compatible filenames (see: https://zed.dev/docs/ai/rules.html).
 
-Recommended approach:
-- Prefer `vscode` instructions output (`.github/copilot-instructions.md`) and let Zed read it.
-- Alternatively, use `codex` project instructions output (`<project_root>/AGENTS.md`).
+### Managed roots
+
+- `<project_root>` (project scope only; `scan_extras=false`)
+
+### Module → output mapping
+
+- `instructions`
+  - Collects each instructions module’s `AGENTS.md` content into:
+    - `<project_root>/.rules`
+
+### Common options
+
+- `write_rules`: default true (requires project scope)
+
+Notes:
+- `.rules` takes precedence over other compatible rule filenames in Zed’s search order.
+- If you prefer not to create `.rules`, you can still use existing outputs like:
+  - `vscode` → `.github/copilot-instructions.md`
+  - `codex` (project) → `<project_root>/AGENTS.md`
 
 Example (minimal) snippet:
 
 ```yaml
 targets:
-  vscode:
+  zed:
     mode: files
     scope: project
     options:
-      write_instructions: true
+      write_rules: true
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -82,8 +82,8 @@ Symptom:
 - `--target` uses an unsupported value, or the manifest config contains an unknown target
 
 Fix:
-- `--target` must be `all|codex|claude_code|cursor|vscode|jetbrains`
-- Manifest targets must be one of: `codex|claude_code|cursor|vscode|jetbrains`
+- `--target` must be `all|codex|claude_code|cursor|vscode|jetbrains|zed`
+- Manifest targets must be one of: `codex|claude_code|cursor|vscode|jetbrains|zed`
 
 ## 7) Overlay errors
 

--- a/docs/zh-CN/CLI.md
+++ b/docs/zh-CN/CLI.md
@@ -8,7 +8,7 @@
 
 - `--repo <path>`：指定 config repo 路径（默认 `$AGENTPACK_HOME/repo`）
 - `--profile <name>`：选择 profile（默认 `default`）
-- `--target <codex|claude_code|cursor|vscode|jetbrains|all>`：选择 target（默认 `all`）
+- `--target <codex|claude_code|cursor|vscode|jetbrains|zed|all>`：选择 target（默认 `all`）
 - `--machine <id>`：覆盖 machineId（用于 machine overlays；默认自动探测）
 - `--json`：stdout 输出机器可读 JSON（envelope）
 - `--yes`：跳过确认（注意：`--json` 下写入类命令必须显式给）
@@ -32,7 +32,7 @@
 
 ## add / remove
 
-- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode,jetbrains]`
+- `agentpack add <instructions|skill|prompt|command> <source> [--id <id>] [--tags a,b] [--targets codex,claude_code,cursor,vscode,jetbrains,zed]`
 - `agentpack remove <module_id>`
 
 source spec：

--- a/docs/zh-CN/TARGETS.md
+++ b/docs/zh-CN/TARGETS.md
@@ -1,4 +1,4 @@
-# Targets（codex / claude_code / cursor / vscode / jetbrains）
+# Targets（codex / claude_code / cursor / vscode / jetbrains / zed）
 
 > Language: 简体中文 | [English](../TARGETS.md)
 
@@ -10,6 +10,7 @@ Target 决定 agentpack 要把“编译后的资产”写到哪里，以及哪�
 - `cursor`
 - `vscode`
 - `jetbrains`
+- `zed`
 
 Target 的通用字段见 `CONFIG.md`。
 
@@ -199,21 +200,37 @@ JetBrains Junie 默认会从 `.junie/guidelines.md` 加载 project guidelines（
 - `TARGET_SDK.md`
 - `TARGET_CONFORMANCE.md`
 
-## 8) Zed（兼容性）
+## 8) zed
 
-Agentpack 目前还没有内置 `zed` target。但 Zed 可以从 repo 内的规则文件（例如 `AGENTS.md`、`.github/copilot-instructions.md`）读取项目规则（见：https://zed.dev/docs/context/rules）。
+Zed 支持通过 repo 根目录的 `.rules` 文件加载 AI “rules”，并且也兼容其它一些规则文件命名（见：https://zed.dev/docs/ai/rules.html）。
 
-推荐方式：
-- 优先使用 `vscode` target 的 instructions 输出（`.github/copilot-instructions.md`），让 Zed 直接读取它。
-- 或者使用 `codex` target 的 project instructions 输出（`<project_root>/AGENTS.md`）。
+### 写入位置（roots）
+
+- `<project_root>`（仅 project scope；`scan_extras=false`）
+
+### module → 输出映射
+
+- `instructions`
+  - 收集每个 instructions module 的 `AGENTS.md` 内容并输出到：
+    - `<project_root>/.rules`
+
+### 常用 options
+
+- `write_rules`：默认 true（要求 project scope）
+
+说明：
+- 在 Zed 的规则文件搜索顺序里，`.rules` 优先级最高。
+- 如果你不想创建 `.rules`，仍然可以继续用已有输出，例如：
+  - `vscode` → `.github/copilot-instructions.md`
+  - `codex`（project）→ `<project_root>/AGENTS.md`
 
 最小示例：
 
 ```yaml
 targets:
-  vscode:
+  zed:
     mode: files
     scope: project
     options:
-      write_instructions: true
+      write_rules: true
 ```

--- a/docs/zh-CN/TROUBLESHOOTING.md
+++ b/docs/zh-CN/TROUBLESHOOTING.md
@@ -82,8 +82,8 @@
 - `--target` 传了不支持值，或 manifest 里 targets 配了未知 target
 
 解决：
-- `--target` 只能是 `all|codex|claude_code|cursor|vscode|jetbrains`
-- manifest targets 只能包含：`codex|claude_code|cursor|vscode|jetbrains`
+- `--target` 只能是 `all|codex|claude_code|cursor|vscode|jetbrains|zed`
+- manifest targets 只能包含：`codex|claude_code|cursor|vscode|jetbrains|zed`
 
 ## 7) Overlay 相关
 

--- a/openspec/changes/add-target-zed/tasks.md
+++ b/openspec/changes/add-target-zed/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Contract (#391)
-- [ ] Update OpenSpec deltas (agentpack + agentpack-cli) for `zed`
-- [ ] Run `openspec validate add-target-zed --strict --no-interactive`
+- [x] Update OpenSpec deltas (agentpack + agentpack-cli) for `zed`
+- [x] Run `openspec validate add-target-zed --strict --no-interactive`
 
 ## 2. Implementation
-- [ ] Add Cargo feature `target-zed` (default-enabled)
-- [ ] Validate `targets.zed` config (project scope only)
-- [ ] Add `zed` to target registry + adapter routing
-- [ ] Implement rendering:
+- [x] Add Cargo feature `target-zed` (default-enabled)
+- [x] Validate `targets.zed` config (project scope only)
+- [x] Add `zed` to target registry + adapter routing
+- [x] Implement rendering:
   - root: `<project_root>` (`scan_extras=false`)
   - output: `<project_root>/.rules` from `instructions` modules
-- [ ] Ensure manifest is written as `<project_root>/.agentpack.manifest.zed.json`
+- [x] Ensure manifest is written as `<project_root>/.agentpack.manifest.zed.json`
 
 ## 3. Tests
-- [ ] Add conformance smoke test for `zed`
-- [ ] Update golden snapshots impacted by target list changes (e.g. `help --json`)
+- [x] Add conformance smoke test for `zed`
+- [x] Update golden snapshots impacted by target list changes (e.g. `help --json`)
 
 ## 4. Docs
-- [ ] Update `docs/TARGETS.md` + `docs/zh-CN/TARGETS.md` with `zed` mapping
-- [ ] Update any other relevant docs/spec references
+- [x] Update `docs/TARGETS.md` + `docs/zh-CN/TARGETS.md` with `zed` mapping
+- [x] Update any other relevant docs/spec references
 
 ## 5. Archive
 - [ ] After shipping: `openspec archive add-target-zed --yes`

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -17,7 +17,7 @@ pub struct Cli {
     #[arg(long, default_value = "default", global = true)]
     pub(crate) profile: String,
 
-    /// Target name: codex|claude_code|cursor|vscode|jetbrains|all (default: "all")
+    /// Target name: codex|claude_code|cursor|vscode|jetbrains|zed|all (default: "all")
     #[arg(long, default_value = "all", global = true)]
     pub(crate) target: String,
 
@@ -110,7 +110,7 @@ pub enum Commands {
         #[arg(long, value_delimiter = ',')]
         tags: Vec<String>,
 
-        /// Comma-separated target names (codex, claude_code, cursor, vscode). Empty = all.
+        /// Comma-separated target names (codex, claude_code, cursor, vscode, jetbrains, zed). Empty = all.
         #[arg(long, value_delimiter = ',')]
         targets: Vec<String>,
     },

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -274,6 +274,24 @@ fn guided_manifest(targets: &[String], scope: TargetScope) -> (Manifest, Vec<Str
                     },
                 );
             }
+            "zed" => {
+                if matches!(scope, TargetScope::Both | TargetScope::User) {
+                    warnings
+                        .push("zed supports project scope only; using scope=project".to_string());
+                }
+
+                let mut options = BTreeMap::new();
+                options.insert("write_rules".to_string(), serde_yaml::Value::Bool(true));
+
+                out_targets.insert(
+                    "zed".to_string(),
+                    TargetConfig {
+                        mode: TargetMode::Files,
+                        scope: TargetScope::Project,
+                        options,
+                    },
+                );
+            }
             _ => {}
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,6 +246,21 @@ fn validate_manifest(manifest: &Manifest) -> anyhow::Result<()> {
                     ));
                 }
             }
+            #[cfg(feature = "target-zed")]
+            "zed" => {
+                if matches!(_cfg.scope, TargetScope::User) {
+                    return Err(anyhow::Error::new(
+                        UserError::new(
+                            "E_CONFIG_INVALID",
+                            "zed target does not support user scope",
+                        )
+                        .with_details(serde_json::json!({
+                            "target": "zed",
+                            "allowed_scopes": ["project","both"],
+                        })),
+                    ));
+                }
+            }
             _ => {
                 return Err(anyhow::Error::new(
                     UserError::new(

--- a/src/target_adapters.rs
+++ b/src/target_adapters.rs
@@ -25,6 +25,8 @@ struct CursorAdapter;
 struct VscodeAdapter;
 #[cfg(feature = "target-jetbrains")]
 struct JetbrainsAdapter;
+#[cfg(feature = "target-zed")]
+struct ZedAdapter;
 
 #[cfg(feature = "target-codex")]
 impl TargetAdapter for CodexAdapter {
@@ -116,6 +118,24 @@ impl TargetAdapter for JetbrainsAdapter {
     }
 }
 
+#[cfg(feature = "target-zed")]
+impl TargetAdapter for ZedAdapter {
+    fn id(&self) -> &'static str {
+        "zed"
+    }
+
+    fn render(
+        &self,
+        engine: &Engine,
+        modules: &[&crate::config::Module],
+        desired: &mut DesiredState,
+        warnings: &mut Vec<String>,
+        roots: &mut Vec<TargetRoot>,
+    ) -> anyhow::Result<()> {
+        engine.render_zed(modules, desired, warnings, roots)
+    }
+}
+
 pub fn adapter_for(target: &str) -> Option<&'static dyn TargetAdapter> {
     #[cfg(feature = "target-codex")]
     static CODEX: CodexAdapter = CodexAdapter;
@@ -127,6 +147,8 @@ pub fn adapter_for(target: &str) -> Option<&'static dyn TargetAdapter> {
     static VSCODE: VscodeAdapter = VscodeAdapter;
     #[cfg(feature = "target-jetbrains")]
     static JETBRAINS: JetbrainsAdapter = JetbrainsAdapter;
+    #[cfg(feature = "target-zed")]
+    static ZED: ZedAdapter = ZedAdapter;
 
     match target {
         #[cfg(feature = "target-codex")]
@@ -139,6 +161,8 @@ pub fn adapter_for(target: &str) -> Option<&'static dyn TargetAdapter> {
         "vscode" => Some(&VSCODE),
         #[cfg(feature = "target-jetbrains")]
         "jetbrains" => Some(&JETBRAINS),
+        #[cfg(feature = "target-zed")]
+        "zed" => Some(&ZED),
         _ => None,
     }
 }

--- a/src/target_registry.rs
+++ b/src/target_registry.rs
@@ -9,6 +9,8 @@ pub const COMPILED_TARGETS: &[&str] = &[
     "vscode",
     #[cfg(feature = "target-jetbrains")]
     "jetbrains",
+    #[cfg(feature = "target-zed")]
+    "zed",
 ];
 
 pub fn is_compiled_target(target: &str) -> bool {

--- a/tests/golden/help_json_data.json
+++ b/tests/golden/help_json_data.json
@@ -674,6 +674,7 @@
     "claude_code",
     "cursor",
     "vscode",
-    "jetbrains"
+    "jetbrains",
+    "zed"
   ]
 }


### PR DESCRIPTION
## Summary
Adds a first-party `zed` target that writes Zed AI Rules as a repo-root `.rules` file.

- New Cargo feature: `target-zed` (enabled by default)
- Output mapping:
  - `instructions` → `<project_root>/.rules`
- Writes per-target manifest: `<project_root>/.agentpack.manifest.zed.json`

## Docs
- Updates `docs/TARGETS.md` + `docs/zh-CN/TARGETS.md` to document `zed` mapping and Zed rules link.

## Tests
- Adds `conformance_zed_smoke`
- Updates `help --json` golden snapshot to include `zed`

## Verification
- `just check`
- `openspec validate add-target-zed --strict --no-interactive`

Closes #391.
