### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ This project follows SemVer with the following clarifications (especially for au
 
 ### Security
 
+## [0.7.0] - 2026-01-18
+
+### Added
+- New built-in targets: `jetbrains` and `zed`.
+
+### Changed
+- Target manifests are now written as `.agentpack.manifest.<target>.json` to avoid collisions when multiple targets manage the same root.
+
 ## [0.6.0] - 2026-01-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentpack"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentpack"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.87.0"
 authors = ["liqiongyu <li@libiao.co>"]


### PR DESCRIPTION
## Summary
Prepares the next release by bumping the crate version and updating the changelog.

- `Cargo.toml`/`Cargo.lock`: 0.6.0 → 0.7.0
- `CHANGELOG.md`: add 0.7.0 section

## Verification
- `just check`

Closes #412.
