### PR TITLE
chore(deps): bump getrandom to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "clap_complete",
  "crossterm",
  "dirs",
- "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "hex",
  "ratatui",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.143"
 serde_yaml = "0.9.34"
 sha2 = "0.10.9"
 hex = "0.4.3"
-getrandom = "0.2.15"
+getrandom = "0.3.4"
 walkdir = "2.5.0"
 tempfile = "3.20.0"
 time = { version = "0.3.41", features = ["formatting", "macros"] }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -471,7 +471,7 @@ fn compute_confirm_plan_hash(
 
 fn generate_confirm_token() -> anyhow::Result<String> {
     let mut bytes = [0u8; CONFIRM_TOKEN_LEN_BYTES];
-    getrandom::getrandom(&mut bytes).map_err(|e| anyhow::anyhow!("generate confirm_token: {e}"))?;
+    getrandom::fill(&mut bytes).map_err(|e| anyhow::anyhow!("generate confirm_token: {e}"))?;
     Ok(hex::encode(bytes))
 }
 


### PR DESCRIPTION
## Summary
Upgrades `getrandom` to v0.3.4 and updates MCP confirm_token generation to the new API (`getrandom::fill`).

## Verification
- `just check`

Closes #414.
