### PR TITLE
chore(toolchain): bump Rust to 1.88.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2
@@ -99,7 +99,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
 
       - uses: Swatinem/rust-cache@v2
         if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
@@ -139,7 +139,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
 
       - uses: Swatinem/rust-cache@v2
         if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
@@ -182,7 +182,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.87.0
+          toolchain: 1.88.0
 
       - uses: Swatinem/rust-cache@v2
         if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agentpack"
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.87.0"
+rust-version = "1.88.0"
 authors = ["liqiongyu <li@libiao.co>"]
 description = "AI-first local asset control plane for Codex/Claude tooling"
 license = "MIT"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -265,15 +265,10 @@ pub fn rollback(home: &AgentpackHome, snapshot_id: &str) -> anyhow::Result<Deplo
         .with_context(|| format!("load snapshot {}", target_path.display()))?;
     if target_snapshot.kind == "rollback" {
         if let Some(to) = &target_snapshot.rolled_back_to {
-            anyhow::bail!(
-                "snapshot {} is a rollback event; use --to {} instead",
-                snapshot_id,
-                to
-            );
+            anyhow::bail!("snapshot {snapshot_id} is a rollback event; use --to {to} instead");
         }
         anyhow::bail!(
-            "snapshot {} is a rollback event and cannot be used as a rollback target",
-            snapshot_id
+            "snapshot {snapshot_id} is a rollback event and cannot be used as a rollback target"
         );
     }
 
@@ -447,9 +442,7 @@ pub fn rollback(home: &AgentpackHome, snapshot_id: &str) -> anyhow::Result<Deplo
 
             cursor = parents.get(&cursor).cloned().flatten().ok_or_else(|| {
                 anyhow::anyhow!(
-                    "snapshot {} is not reachable from current deployment state {}",
-                    snapshot_id,
-                    current_head
+                    "snapshot {snapshot_id} is not reachable from current deployment state {current_head}"
                 )
             })?;
         }

--- a/src/cli/commands/remote.rs
+++ b/src/cli/commands/remote.rs
@@ -36,7 +36,7 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &RemoteCommands) -> anyhow::Result<()>
                 );
                 print_json(&envelope)?;
             } else {
-                println!("Set remote {} -> {}", name, url);
+                println!("Set remote {name} -> {url}");
             }
         }
     }

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -29,14 +29,14 @@ pub(crate) fn run(ctx: &Ctx<'_>, rebase: bool, remote: &str) -> anyhow::Result<(
 
     let mut ran = Vec::new();
     if rebase {
-        ran.push(format!("git pull --rebase {} {}", remote, branch));
+        ran.push(format!("git pull --rebase {remote} {branch}"));
         let _ = crate::git::git_in(repo_dir, &["pull", "--rebase", remote, branch])?;
     } else {
-        ran.push(format!("git pull {} {}", remote, branch));
+        ran.push(format!("git pull {remote} {branch}"));
         let _ = crate::git::git_in(repo_dir, &["pull", remote, branch])?;
     }
 
-    ran.push(format!("git push {} {}", remote, branch));
+    ran.push(format!("git push {remote} {branch}"));
     let _ = crate::git::git_in(repo_dir, &["push", remote, branch])?;
 
     if ctx.cli.json {

--- a/src/cli/human.rs
+++ b/src/cli/human.rs
@@ -111,7 +111,7 @@ fn summarize_json_string_array(value: Option<&serde_json::Value>, max: usize) ->
 
     let mut out = shown.join(", ");
     if remaining > 0 {
-        out.push_str(&format!(" ...({} more)", remaining));
+        out.push_str(&format!(" ...({remaining} more)"));
     }
 
     out

--- a/src/git.rs
+++ b/src/git.rs
@@ -116,7 +116,7 @@ pub fn git_in(cwd: &Path, args: &[&str]) -> anyhow::Result<String> {
         .current_dir(cwd)
         .args(args)
         .output()
-        .with_context(|| format!("git {:?}", args))?;
+        .with_context(|| format!("git {args:?}"))?;
     if !out.status.success() {
         anyhow::bail!(
             "git {:?} failed: {}",

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -346,8 +346,7 @@ fn apply_patch_overlays(
                 UserError::new(
                     "E_CONFIG_INVALID",
                     format!(
-                        "invalid patch relpath for module {module_id} ({scope}): {rel_target}",
-                        scope = scope
+                        "invalid patch relpath for module {module_id} ({scope}): {rel_target}"
                     ),
                 )
                 .with_details(serde_json::json!({
@@ -367,8 +366,7 @@ fn apply_patch_overlays(
                 UserError::new(
                     "E_CONFIG_INVALID",
                     format!(
-                        "patch target is missing for module {module_id} ({scope}): {rel_target}",
-                        scope = scope
+                        "patch target is missing for module {module_id} ({scope}): {rel_target}"
                     ),
                 )
                 .with_details(serde_json::json!({
@@ -389,8 +387,7 @@ fn apply_patch_overlays(
                 UserError::new(
                     "E_CONFIG_INVALID",
                     format!(
-                        "patch overlays only support UTF-8 text files: {rel_target} (module {module_id}, {scope})",
-                        scope = scope
+                        "patch overlays only support UTF-8 text files: {rel_target} (module {module_id}, {scope})"
                     ),
                 )
                 .with_details(serde_json::json!({
@@ -448,8 +445,7 @@ fn apply_patch_overlays(
                 UserError::new(
                     "E_OVERLAY_PATCH_APPLY_FAILED",
                     format!(
-                        "failed to apply patch overlay for module {module_id} ({scope}): {rel_target}",
-                        scope = scope
+                        "failed to apply patch overlay for module {module_id} ({scope}): {rel_target}"
                     ),
                 )
                 .with_details(serde_json::json!({
@@ -481,8 +477,7 @@ fn validate_patch_text_matches_file(
             UserError::new(
                 "E_CONFIG_INVALID",
                 format!(
-                    "patch overlays do not support binary patches (module {module_id}, {scope})",
-                    scope = scope
+                    "patch overlays do not support binary patches (module {module_id}, {scope})"
                 ),
             )
             .with_details(serde_json::json!({
@@ -511,8 +506,7 @@ fn validate_patch_text_matches_file(
             UserError::new(
                 "E_CONFIG_INVALID",
                 format!(
-                    "invalid patch file (expected a single unified diff) for module {module_id} ({scope})",
-                    scope = scope
+                    "invalid patch file (expected a single unified diff) for module {module_id} ({scope})"
                 ),
             )
             .with_details(serde_json::json!({
@@ -533,8 +527,7 @@ fn validate_patch_text_matches_file(
             UserError::new(
                 "E_CONFIG_INVALID",
                 format!(
-                    "patch overlays do not currently support file create/delete (module {module_id}, {scope})",
-                    scope = scope
+                    "patch overlays do not currently support file create/delete (module {module_id}, {scope})"
                 ),
             )
             .with_details(serde_json::json!({
@@ -555,8 +548,7 @@ fn validate_patch_text_matches_file(
             UserError::new(
                 "E_CONFIG_INVALID",
                 format!(
-                    "patch file paths do not match filename-derived relpath for module {module_id} ({scope})",
-                    scope = scope
+                    "patch file paths do not match filename-derived relpath for module {module_id} ({scope})"
                 ),
             )
             .with_details(serde_json::json!({
@@ -733,9 +725,7 @@ pub fn overlay_drift_warnings(
 
     if warnings.is_empty() && baseline_hash != current_hash {
         warnings.push(format!(
-            "overlay drift ({overlay_kind}) module {module_id}: upstream changed ({baseline} -> {current})",
-            baseline = baseline_hash,
-            current = current_hash
+            "overlay drift ({overlay_kind}) module {module_id}: upstream changed ({baseline_hash} -> {current_hash})"
         ));
     }
 

--- a/tests/cli_org_config_isolation.rs
+++ b/tests/cli_org_config_isolation.rs
@@ -58,9 +58,9 @@ modules: []
 
     for args in [["plan", "--json"], ["status", "--json"]] {
         let out = agentpack_in(tmp.path(), &args);
-        assert!(out.status.success(), "agentpack {:?} should succeed", args);
+        assert!(out.status.success(), "agentpack {args:?} should succeed");
         let v = parse_stdout_json(&out);
-        assert_eq!(v["ok"], true, "agentpack {:?} ok=true", args);
+        assert_eq!(v["ok"], true, "agentpack {args:?} ok=true");
         assert_eq!(v["errors"].as_array().unwrap().len(), 0);
     }
 }

--- a/tests/mcp_server_stdio.rs
+++ b/tests/mcp_server_stdio.rs
@@ -123,8 +123,7 @@ modules: []
     {
         let req_id = 3 + idx;
         let req = format!(
-            r#"{{"jsonrpc":"2.0","id":{},"method":"tools/call","params":{{"name":"{}","arguments":{}}}}}"#,
-            req_id, tool, args
+            r#"{{"jsonrpc":"2.0","id":{req_id},"method":"tools/call","params":{{"name":"{tool}","arguments":{args}}}}}"#
         );
         stdin.write_all(req.as_bytes()).expect("write tools/call");
         stdin.write_all(b"\n").expect("write newline");

--- a/tests/mcp_server_stdio_mutating.rs
+++ b/tests/mcp_server_stdio_mutating.rs
@@ -191,8 +191,7 @@ modules:
 
     // deploy_apply with approval and correct confirm_token
     let deploy_apply_req = format!(
-        r#"{{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{{"name":"deploy_apply","arguments":{{"yes":true,"confirm_token":"{}"}}}}}}"#,
-        confirm_token
+        r#"{{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{{"name":"deploy_apply","arguments":{{"yes":true,"confirm_token":"{confirm_token}"}}}}}}"#
     );
     stdin
         .write_all(deploy_apply_req.as_bytes())
@@ -242,8 +241,7 @@ modules:
 
     // rollback with approval
     let rollback_req = format!(
-        r#"{{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{{"name":"rollback","arguments":{{"to":"{}","yes":true}}}}}}"#,
-        snapshot_id
+        r#"{{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{{"name":"rollback","arguments":{{"to":"{snapshot_id}","yes":true}}}}}}"#
     );
     stdin
         .write_all(rollback_req.as_bytes())


### PR DESCRIPTION
## Motivation\n\nrmcp 0.13 pulls in dependencies that require Rust 1.88+, which currently blocks our dependency upgrade path. This PR bumps the toolchain/MSRV to Rust 1.88.0 to unblock that work.\n\nCloses #417.\n\n## Scope\n- Bump Rust toolchain/MSRV to 1.88.0 (local + CI).\n- Mechanical clippy fixes triggered by the toolchain bump.\n\n## Non-goals\n- No behavior changes to CLI/MCP output contracts.\n- No dependency upgrades besides the Rust version.\n\n## Verification\n- \\n- \\n- \\n