### PR TITLE
chore(deps): bump rmcp to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,12 +329,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -353,11 +353,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -378,11 +377,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1071,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df440eaa43f8573491ed4a5899719b6d29099500774abba12214a095a4083ed"
+checksum = "d1815dbc06c414d720f8bc1951eccd66bc99efc6376331f1e7093a119b3eb508"
 dependencies = [
  "async-trait",
  "base64",
@@ -1093,11 +1092,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef03779cccab8337dd8617c53fce5c98ec21794febc397531555472ca28f8c3"
+checksum = "11f0bc7008fa102e771a76c6d2c9b253be3f2baa5964e060464d038ae1cbc573"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tempfile = "3.20.0"
 time = { version = "0.3.41", features = ["formatting", "macros"] }
 dirs = "6.0.0"
 similar = "2.7.0"
-rmcp = { version = "0.11.0", features = ["transport-io"] }
+rmcp = { version = "0.13.0", features = ["transport-io"] }
 schemars = "1.0"
 tokio = { version = "1.43.0", features = ["rt", "macros"] }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -498,7 +498,7 @@ fn tool_result_from_user_error(command: &str, err: UserError) -> CallToolResult 
 }
 
 fn tool_input_schema<T: schemars::JsonSchema + 'static>() -> Arc<JsonObject> {
-    Arc::new(rmcp::handler::server::tool::schema_for_type::<T>())
+    rmcp::handler::server::tool::schema_for_type::<T>()
 }
 
 fn tool(


### PR DESCRIPTION
## Motivation

rmcp 0.13 is the latest MCP dependency and requires Rust 1.88+. Now that the toolchain bump is merged, we can upgrade rmcp.

Closes #413.
Supersedes #399.

## Scope
- Bump rmcp (and rmcp-macros) to 0.13.0.
- Adjust schema helper for rmcp API changes.

## Non-goals
- No CLI/MCP contract changes.

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
