### PR TITLE
docs: refresh contract docs to v0.7.0

### DIFF
--- a/docs/ERROR_CODES.md
+++ b/docs/ERROR_CODES.md
@@ -1,6 +1,6 @@
 # ERROR_CODES.md (stable error code registry)
 
-> Current as of **v0.6.0** (2026-01-15). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
+> Current as of **v0.7.0** (2026-01-18). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
 
 This file defines stable, externally-consumable error codes for `--json` mode (`errors[0].code`).
 

--- a/docs/JSON_API.md
+++ b/docs/JSON_API.md
@@ -1,6 +1,6 @@
 # JSON API (the `--json` output contract)
 
-> Current as of **v0.6.0** (2026-01-15). `SPEC.md` is the semantic source of truth; this file focuses on the stable `--json` contract.
+> Current as of **v0.7.0** (2026-01-18). `SPEC.md` is the semantic source of truth; this file focuses on the stable `--json` contract.
 
 ## 1) Stability guarantees (principles)
 
@@ -31,7 +31,7 @@ Failure example:
   "schema_version": 1,
   "ok": false,
   "command": "deploy",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "data": {},
   "warnings": [],
   "errors": [

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # Spec (implementation contract)
 
-> Current as of **v0.6.0** (2026-01-15). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
+> Current as of **v0.7.0** (2026-01-18). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
 
 ## 0. Conventions
 
@@ -16,8 +16,8 @@ Default data directory: `~/.agentpack` (override via `AGENTPACK_HOME`), with:
 
 Optional durability mode: set `AGENTPACK_FSYNC=1` to request `fsync` on atomic writes (slower, but more crash-consistent).
 
-Supported as of v0.6.0:
-- targets: `codex`, `claude_code`, `cursor`, `vscode`, `jetbrains`
+Supported as of v0.7.0:
+- targets: `codex`, `claude_code`, `cursor`, `vscode`, `jetbrains`, `zed`
 - module types: `instructions`, `skill`, `prompt`, `command`
 - source types: `local_path`, `git` (`url` + `ref` + `subdir`)
 
@@ -379,7 +379,7 @@ Additional (v0.3+):
 - Patch overlay rebase conflicts may be written under `<overlay_dir>/.agentpack/conflicts/` (not deployed).
 - `.agentpack/` is a reserved metadata directory: it is never deployed to target roots and must not appear in module outputs.
 
-## 4. CLI commands (v0.6.0)
+## 4. CLI commands (v0.7.0)
 
 Global flags:
 - `--repo <path>`: config repo location


### PR DESCRIPTION
## Motivation
Contract docs should match the current implementation. `main` is now v0.7.0 (and includes targets like `zed`), but some contract docs still claimed to be "Current as of v0.6.0".

Closes #422.

## Scope
- Update version/date stamps in:
  - `docs/SPEC.md`
  - `docs/JSON_API.md`
  - `docs/ERROR_CODES.md`
- Fix the supported target list in `docs/SPEC.md` to include `zed`.

## Non-goals
- No behavior changes.

## Verification
- CI (docs-only change).
