### PR TITLE
docs: clarify quickstart versioning

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,4 +1,4 @@
-# Quickstart (v0.6.0)
+# Quickstart
 
 > Language: English | [Chinese (Simplified)](zh-CN/QUICKSTART.md)
 
@@ -36,7 +36,8 @@ Common “heavy user” setups (pick one to start):
   - From crates.io:
     - `cargo install agentpack --locked`
   - If you see `could not find \`agentpack\` in registry \`crates-io\``, install from source:
-    - `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked`
+    - Latest tagged release (recommended): `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked`
+    - Bleeding edge (`main`): `cargo install --git https://github.com/liqiongyu/agentpack --branch main --locked`
 - Non-Rust users:
   - Download a prebuilt binary from GitHub Releases (see the repository README).
 

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -1,4 +1,4 @@
-# 快速开始（v0.6.0）
+# 快速开始
 
 > Language: 简体中文 | [English](../QUICKSTART.md)
 
@@ -36,7 +36,8 @@
   - 从 crates.io 安装：
     - `cargo install agentpack --locked`
   - 如果你遇到 `could not find \`agentpack\` in registry \`crates-io\``，可以从源码安装：
-    - `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked`
+    - 最新 tag（推荐）：`cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked`
+    - main 分支（尝鲜）：`cargo install --git https://github.com/liqiongyu/agentpack --branch main --locked`
 - 非 Rust 用户：
   - 从 GitHub Releases 下载对应平台二进制（见仓库 README）。
 


### PR DESCRIPTION
## Motivation
Quickstart currently reads like it is strictly for v0.6.0, but `main` has moved on and users may install from either the latest tag or directly from `main`.

Closes #423.

## Scope
- Remove the hard-coded v0.6.0 title from Quickstart.
- Clarify install options:
  - latest tagged release (v0.6.0)
  - `main` branch (bleeding edge)

## Non-goals
- No behavior changes.

## Verification
- CI (docs-only change).
