### PR TITLE
docs: add deprecation notes for planning snapshots

### DIFF
--- a/docs/Agentpack_Roadmap_Spec_Epics_Backlog_CodexReady_v0.6.md
+++ b/docs/Agentpack_Roadmap_Spec_Epics_Backlog_CodexReady_v0.6.md
@@ -1,5 +1,8 @@
 # Agentpack 后续迭代方向 + Codex 可执行 Spec/Epics/Backlog
 
+> 注意：本文档是以 **v0.6.0（2026-01-15）** 为基线生成的规划快照，可能与当前 `main` 分支实现存在偏差。
+> 当前实现级契约请以 `docs/SPEC.md` 为准；`--json` 合约请以 `docs/JSON_API.md` / `docs/ERROR_CODES.md` 为准；需要走提案流程的变更请使用 `openspec/`。
+
 > 当前基线：Agentpack **v0.6.0**（本仓库状态）。
 > 文档生成日期：**2026-01-15**。
 > 面向对象：维护者、人类贡献者、以及 **Codex/Claude/Cursor/VS Code** 等 coding agent（作为自动化执行者）。

--- a/docs/Agentpack_Spec_Epics_Backlog_CodexReady.md
+++ b/docs/Agentpack_Spec_Epics_Backlog_CodexReady.md
@@ -1,5 +1,8 @@
 # Agentpack — Unified Spec + Epics + Backlog (Codex-ready)
 
+> 注意：本文档是以 **v0.6.0（2026-01-15）** 为基线生成的规划快照，可能与当前 `main` 分支实现存在偏差。
+> 当前实现级契约请以 `docs/SPEC.md` 为准；`--json` 合约请以 `docs/JSON_API.md` / `docs/ERROR_CODES.md` 为准；需要走提案流程的变更请使用 `openspec/`。
+
 > 这份文档的目标是：把 Agentpack 的 **实现级 Spec**、**迭代 Epic**、**可执行 Backlog** 合并成一份“可直接喂给 Codex 开发”的 Markdown。
 > 重点是 **一致性无冲突** + **细粒度** + **每个 Backlog 条目都能对应一个小 PR**。
 


### PR DESCRIPTION
## Motivation
We have multiple long-form planning docs from the v0.6 era. They’re still useful as historical context, but it should be obvious (at a glance) which docs are authoritative for current behavior and spec-driven changes.

Closes #424.

## Scope
- Add a short banner to:
  - `docs/Agentpack_Spec_Epics_Backlog_CodexReady.md`
  - `docs/Agentpack_Roadmap_Spec_Epics_Backlog_CodexReady_v0.6.md`

Pointing readers to:
- `docs/SPEC.md`
- `docs/JSON_API.md` / `docs/ERROR_CODES.md`
- `openspec/`

## Non-goals
- No rewrites of the documents.

## Verification
- CI (docs-only change).
