### PR TITLE
docs: update quickstart install tag to v0.7.0

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -36,7 +36,7 @@ Common “heavy user” setups (pick one to start):
   - From crates.io:
     - `cargo install agentpack --locked`
   - If you see `could not find \`agentpack\` in registry \`crates-io\``, install from source:
-    - Latest tagged release (recommended): `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked`
+    - Latest tagged release (recommended): `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.7.0 --locked`
     - Bleeding edge (`main`): `cargo install --git https://github.com/liqiongyu/agentpack --branch main --locked`
 - Non-Rust users:
   - Download a prebuilt binary from GitHub Releases (see the repository README).

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -36,7 +36,7 @@
   - 从 crates.io 安装：
     - `cargo install agentpack --locked`
   - 如果你遇到 `could not find \`agentpack\` in registry \`crates-io\``，可以从源码安装：
-    - 最新 tag（推荐）：`cargo install --git https://github.com/liqiongyu/agentpack --tag v0.6.0 --locked`
+    - 最新 tag（推荐）：`cargo install --git https://github.com/liqiongyu/agentpack --tag v0.7.0 --locked`
     - main 分支（尝鲜）：`cargo install --git https://github.com/liqiongyu/agentpack --branch main --locked`
 - 非 Rust 用户：
   - 从 GitHub Releases 下载对应平台二进制（见仓库 README）。


### PR DESCRIPTION
## Motivation
Quickstart should point at the latest tagged release for stable installs. Now that `v0.7.0` is tagged and published, we should recommend it instead of `v0.6.0`.

Closes #429.

## Scope
- Update Quickstart (EN + zh-CN) install instructions to use `--tag v0.7.0`.

## Non-goals
- No behavior changes.

## Verification
- CI (docs-only change).
