### PR TITLE
docs: bump 'Current as of' headers to v0.7.0

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md
 
-> Current as of **v0.6.0** (2026-01-15). Historical content is tracked in git history.
+> Current as of **v0.7.0** (2026-01-18). Historical content is tracked in git history.
 
 ## 1. One-line summary
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,6 +1,6 @@
 # BACKLOG.md
 
-> Current as of **v0.6.0** (2026-01-15). Historical content is tracked in git history.
+> Current as of **v0.7.0** (2026-01-18). Historical content is tracked in git history.
 
 ## Status
 

--- a/docs/CODEX_EXEC_PLAN.md
+++ b/docs/CODEX_EXEC_PLAN.md
@@ -2,7 +2,7 @@
 
 Agentpack “AI-first” execution roadmap (task-shaped, designed to be executable by Codex CLI / automation)
 
-> Current as of **v0.6.0** (2026-01-15). This file consolidates the discussion around:
+> Current as of **v0.7.0** (2026-01-18). This file consolidates the discussion around:
 > - how agents (Codex / Claude Code) should use Agentpack
 > - how Agentpack should evolve next (UX, integrations, overlays, targets, testing)
 > - concrete engineering tasks (P0/P1/P2), each intended to fit in a single PR

--- a/docs/CODEX_WORKPLAN.md
+++ b/docs/CODEX_WORKPLAN.md
@@ -2,7 +2,7 @@
 
 Agentpack engineering + OSS workplan (designed to be executable by Codex CLI / automation)
 
-> Current as of **v0.6.0** (2026-01-15). v0.5.0 delivered a round of correctness hardening (fs_key prefix length cap, end-to-end atomic writes, adopt protection, sparse overlays + rebase, CLI split, overlay metadata + doctor checks, etc.). This workplan focuses on the next steps to make the project “truly great” as open source.
+> Current as of **v0.7.0** (2026-01-18). v0.5.0 delivered a round of correctness hardening (fs_key prefix length cap, end-to-end atomic writes, adopt protection, sparse overlays + rebase, CLI split, overlay metadata + doctor checks, etc.). This workplan focuses on the next steps to make the project “truly great” as open source.
 
 Recommended usage:
 - One task per PR (or per commit group). PR description should include: intent, acceptance criteria, and regression test commands.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,6 +1,6 @@
 # PRD.md
 
-> Current as of **v0.6.0** (2026-01-15). Historical content is tracked in git history.
+> Current as of **v0.7.0** (2026-01-18). Historical content is tracked in git history.
 
 ## 1. Background
 


### PR DESCRIPTION
Closes #431.

Docs-only: update the version stamp/dates to reflect the v0.7.0 release (2026-01-18).