### PR TITLE
chore: skip rust pre-commit hooks on docs-only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,14 @@ repos:
         entry: just fmt-check
         language: system
         pass_filenames: false
+        files: '^(src/|tests/|Cargo\.(toml|lock)$|deny\.toml$|rust-toolchain\.toml$|dist-workspace\.toml$|justfile$)'
 
       - id: cargo-clippy
         name: cargo clippy
         entry: just clippy
         language: system
         pass_filenames: false
+        files: '^(src/|tests/|Cargo\.(toml|lock)$|deny\.toml$|rust-toolchain\.toml$|dist-workspace\.toml$|justfile$)'
 
       - id: cargo-test
         name: cargo test (manual)


### PR DESCRIPTION
Closes #443.

Adds `files:` filters to the Rust pre-commit hooks so `just fmt-check` / `just clippy` only run when Rust-related files are staged (docs-only commits no longer trigger them).
