### PR TITLE
fix(fs): do not skip modules under ~/.agentpack

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -54,20 +54,22 @@ pub fn copy_tree(src: &Path, dst: &Path) -> anyhow::Result<()> {
     for entry in WalkDir::new(src).follow_links(false) {
         let entry = entry?;
         if entry.file_type().is_dir() {
-            if entry.file_name() == ".git" || entry.file_name() == ".agentpack" {
-                continue;
-            }
             continue;
         }
-        if entry
-            .path()
+
+        let rel = entry.path().strip_prefix(src).with_context(|| {
+            format!(
+                "path {} is not under {}",
+                entry.path().display(),
+                src.display()
+            )
+        })?;
+        if rel
             .components()
             .any(|c| c.as_os_str() == ".git" || c.as_os_str() == ".agentpack")
         {
             continue;
         }
-
-        let rel = entry.path().strip_prefix(src).unwrap_or(entry.path());
         let dst_path = dst.join(rel);
         copy_file(entry.path(), &dst_path)?;
     }
@@ -91,20 +93,22 @@ pub fn copy_tree_missing_only(src: &Path, dst: &Path) -> anyhow::Result<()> {
     for entry in WalkDir::new(src).follow_links(false) {
         let entry = entry?;
         if entry.file_type().is_dir() {
-            if entry.file_name() == ".git" || entry.file_name() == ".agentpack" {
-                continue;
-            }
             continue;
         }
-        if entry
-            .path()
+
+        let rel = entry.path().strip_prefix(src).with_context(|| {
+            format!(
+                "path {} is not under {}",
+                entry.path().display(),
+                src.display()
+            )
+        })?;
+        if rel
             .components()
             .any(|c| c.as_os_str() == ".git" || c.as_os_str() == ".agentpack")
         {
             continue;
         }
-
-        let rel = entry.path().strip_prefix(src).unwrap_or(entry.path());
         let dst_path = dst.join(rel);
         if dst_path.exists() {
             continue;

--- a/tests/fs_copy_tree_relative_filter.rs
+++ b/tests/fs_copy_tree_relative_filter.rs
@@ -1,0 +1,66 @@
+use std::fs;
+
+use agentpack::fs::{copy_tree, copy_tree_missing_only};
+
+#[test]
+fn copy_tree_does_not_skip_when_src_path_contains_dot_agentpack() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+
+    let src = tmp
+        .path()
+        .join(".agentpack")
+        .join("repo")
+        .join("modules")
+        .join("skills")
+        .join("imported")
+        .join("foo");
+    fs::create_dir_all(&src)?;
+    fs::write(src.join("SKILL.md"), "# test skill\n")?;
+    fs::create_dir_all(src.join(".agentpack"))?;
+    fs::write(src.join(".agentpack").join("ignored.txt"), "ignored")?;
+    fs::create_dir_all(src.join(".git"))?;
+    fs::write(src.join(".git").join("config"), "ignored")?;
+
+    let dst = tmp.path().join("out");
+    copy_tree(&src, &dst)?;
+
+    assert!(dst.join("SKILL.md").is_file());
+    assert!(!dst.join(".agentpack").join("ignored.txt").exists());
+    assert!(!dst.join(".git").join("config").exists());
+
+    Ok(())
+}
+
+#[test]
+fn copy_tree_missing_only_does_not_skip_when_src_path_contains_dot_agentpack() -> anyhow::Result<()>
+{
+    let tmp = tempfile::tempdir()?;
+
+    let src = tmp
+        .path()
+        .join(".agentpack")
+        .join("repo")
+        .join("modules")
+        .join("skills")
+        .join("imported")
+        .join("foo");
+    fs::create_dir_all(&src)?;
+    fs::write(src.join("SKILL.md"), "# test skill\n")?;
+    fs::create_dir_all(src.join(".agentpack"))?;
+    fs::write(src.join(".agentpack").join("ignored.txt"), "ignored")?;
+    fs::create_dir_all(src.join(".git"))?;
+    fs::write(src.join(".git").join("config"), "ignored")?;
+
+    let dst = tmp.path().join("out");
+    fs::create_dir_all(&dst)?;
+    fs::write(dst.join("already.txt"), "keep")?;
+
+    copy_tree_missing_only(&src, &dst)?;
+
+    assert!(dst.join("SKILL.md").is_file());
+    assert_eq!(fs::read_to_string(dst.join("already.txt"))?, "keep");
+    assert!(!dst.join(".agentpack").join("ignored.txt").exists());
+    assert!(!dst.join(".git").join("config").exists());
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation
`agentpack preview --diff` can fail with `E_CONFIG_INVALID` ("skill module ... is missing SKILL.md") even when `SKILL.md` exists, if the config repo lives under `~/.agentpack/repo`.

Root cause: `copy_tree`/`copy_tree_missing_only` were filtering `.agentpack`/`.git` using the absolute path, so *any* repo under `~/.agentpack/...` effectively copied zero files during materialization.

## Scope
- Filter `.agentpack`/`.git` only on paths *relative to the module root*.
- Add regression tests covering the `~/.agentpack/repo` materialization scenario.

## Non-goals
- No CLI output changes.
- No changes to validation rules beyond correct materialization.

## Acceptance Criteria
- Modules under `~/.agentpack/repo` materialize correctly (e.g. imported skills include `SKILL.md`).
- `.agentpack`/`.git` *inside* a module root remain ignored.

## Regression Tests
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`

Fixes #445.
