### PR TITLE
chore(github): align PR template with roadmap

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,22 @@
-## Summary
+## Motivation
 
-Describe what this PR changes and why.
+Why is this change needed? What problem does it solve?
 
-## Checklist
+## Scope
+
+What is included in this PR (and what is not)?
+
+## Non-goals
+
+Explicitly list anything intentionally out of scope.
+
+## Acceptance Criteria
+
+How do we know this is correct? (expected behavior / output / edge cases)
+
+## Regression Tests
+
+Commands run (or planned) for this PR:
 
 - [ ] `cargo fmt --all`
 - [ ] `cargo clippy --all-targets --all-features -- -D warnings`


### PR DESCRIPTION
## Motivation
The roadmap/spec snapshot expects each PR description to capture motivation, scope, non-goals, acceptance criteria, and regression test commands. The current PR template only prompts for a summary + a checklist, so important context is often missing.

## Scope
- Expand `.github/PULL_REQUEST_TEMPLATE.md` to include Motivation / Scope / Non-goals / Acceptance Criteria / Regression Tests sections.

## Non-goals
- No CI enforcement (this is guidance-only).

## Acceptance Criteria
- New PRs created using the template prompt authors for the required context.

## Regression Tests
N/A (docs/process-only change).

Fixes #449.
