### PR TITLE
M0-DOC-001: Document patch overlays

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -135,7 +135,7 @@ Tip: choose targets via global `--target`:
 
 ## overlay
 
-- `agentpack overlay edit <module_id> [--scope global|machine|project] [--sparse|--materialize]`
+- `agentpack overlay edit <module_id> [--scope global|machine|project] [--kind dir|patch] [--sparse|--materialize]`
 - `agentpack overlay rebase <module_id> [--scope ...] [--sparsify]` (3-way merge; supports `--dry-run`)
 - `agentpack overlay path <module_id> [--scope ...]`
 

--- a/docs/OVERLAYS.md
+++ b/docs/OVERLAYS.md
@@ -38,7 +38,7 @@ Rule:
 ## 4) Create/edit: `overlay edit`
 
 Command:
-- `agentpack overlay edit <module_id> [--scope global|machine|project] [--sparse|--materialize]`
+- `agentpack overlay edit <module_id> [--scope global|machine|project] [--kind dir|patch] [--sparse|--materialize]`
 
 Behavior:
 - Default (no `--sparse/--materialize`):
@@ -52,6 +52,36 @@ Behavior:
 
 Note:
 - `overlay edit` is mutating; in `--json` mode you must pass `--yes`.
+
+Overlay kinds:
+- `--kind dir` (default): a directory overlay, where you override files by placing the desired versions in the overlay directory.
+- `--kind patch`: a patch overlay, where you store unified diff patches under `.agentpack/patches/` and they are applied to upstream files during desired-state generation.
+
+Patch overlays (kind = `patch`):
+- Intended for small, reviewable edits without copying whole upstream files into the overlay tree.
+- Constraints:
+  - UTF-8 text files only (no binary patching).
+  - Each patch file MUST represent a single-file unified diff.
+- Layout:
+  - `.agentpack/patches/<relpath>.patch` (example: `.agentpack/patches/SKILL.md.patch`)
+- Creation:
+  - `agentpack overlay edit <module_id> --kind patch` creates metadata and `.agentpack/patches/` without copying upstream files.
+- Example: patch a single file
+  1) Create a patch overlay:
+     - `agentpack overlay edit <module_id> --kind patch --scope global`
+  2) Add a patch file (example: `.agentpack/patches/SKILL.md.patch`):
+     ```diff
+     --- a/SKILL.md
+     +++ b/SKILL.md
+     @@ -1,4 +1,4 @@
+      ---
+      name: my-skill
+     -description: base
+     +description: base (patched)
+      ---
+     ```
+- Failure handling:
+  - If a patch cannot be applied during `plan`/`deploy`, the command fails with stable error code `E_OVERLAY_PATCH_APPLY_FAILED`.
 
 ## 5) Rebase after upstream updates: `overlay rebase` (3-way merge)
 
@@ -70,6 +100,7 @@ Key behaviors:
 Conflicts:
 - On conflicts, the command fails with `E_OVERLAY_REBASE_CONFLICT`; `details` includes the conflict file list.
 - Resolve conflicts manually in the overlay directory, then re-run `overlay rebase` (or commit the overlay changes directly).
+ - For patch overlays, conflicts also write a copy of the conflicted merged file under `.agentpack/conflicts/<relpath>` (example: `.agentpack/conflicts/SKILL.md`).
 
 ## 6) `overlay path`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ If you just want to start using Agentpack, begin with **Quickstart**.
 6) **Overlays**: `OVERLAYS.md`
 - global/machine/project overlays
 - `overlay edit --sparse/--materialize` and `overlay rebase` (3-way merge)
+- patch overlays: `overlay edit --kind patch`
 
 7) **Bootstrap (AI operator assets)**: `BOOTSTRAP.md`
 - Install operator assets so agents can self-serve with agentpack.

--- a/docs/zh-CN/CLI.md
+++ b/docs/zh-CN/CLI.md
@@ -122,7 +122,7 @@ source spec：
 
 ## overlay
 
-- `agentpack overlay edit <module_id> [--scope global|machine|project] [--sparse|--materialize]`
+- `agentpack overlay edit <module_id> [--scope global|machine|project] [--kind dir|patch] [--sparse|--materialize]`
 - `agentpack overlay rebase <module_id> [--scope ...] [--sparsify]`（3-way merge；支持 `--dry-run`）
 - `agentpack overlay path <module_id> [--scope ...]`
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -31,6 +31,7 @@
 6) **Overlays**：`OVERLAYS.md`
 - global/machine/project 三层 overlay
 - `overlay edit --sparse/--materialize` 与 `overlay rebase`（3-way merge）
+- patch overlays：`overlay edit --kind patch`
 
 7) **AI 自举（Bootstrap）**：`BOOTSTRAP.md`
 - 安装 operator assets：让 AI 自己会用 agentpack

--- a/openspec/changes/add-patch-overlays-user-docs/proposal.md
+++ b/openspec/changes/add-patch-overlays-user-docs/proposal.md
@@ -1,0 +1,17 @@
+# Change: Add patch overlays user documentation
+
+## Why
+Patch overlays (`overlay_kind=patch` / `agentpack overlay edit --kind patch`) are implemented and covered by tests, but user-facing docs do not mention how to create or use them. This creates a “feature exists but users can’t find it” gap.
+
+## What Changes
+- Document patch overlays in the user docs:
+  - `docs/OVERLAYS.md` and `docs/zh-CN/OVERLAYS.md`
+  - `docs/CLI.md` and `docs/zh-CN/CLI.md` (include `--kind dir|patch`)
+- Include at least one conflict/failure example and point to the stable error codes:
+  - `E_OVERLAY_PATCH_APPLY_FAILED`
+  - `E_OVERLAY_REBASE_CONFLICT` + conflict artifacts under `.agentpack/conflicts/`
+
+## Impact
+- Affected specs: `agentpack-cli`
+- Affected docs: overlays + CLI reference
+- Compatibility: no CLI/JSON behavior changes

--- a/openspec/changes/add-patch-overlays-user-docs/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-patch-overlays-user-docs/specs/agentpack-cli/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: User docs cover patch overlays
+
+The repository SHALL document patch overlays (`overlay_kind=patch`) in the user-facing overlays documentation and CLI reference, including how to create a patch overlay and how failures/conflicts are reported.
+
+#### Scenario: Docs describe patch overlay creation and constraints
+- **WHEN** a user reads the overlays docs and CLI reference
+- **THEN** they can find `agentpack overlay edit --kind patch`
+- **AND** the docs explain that patch overlays are for UTF-8 text files and store unified diffs under `.agentpack/patches/`
+
+#### Scenario: Docs describe failure/conflict handling
+- **WHEN** a patch cannot be applied during plan/deploy
+- **THEN** the docs mention `E_OVERLAY_PATCH_APPLY_FAILED`
+- **AND** they mention that `overlay rebase` conflicts return `E_OVERLAY_REBASE_CONFLICT` and write conflict artifacts under `.agentpack/conflicts/`

--- a/openspec/changes/add-patch-overlays-user-docs/tasks.md
+++ b/openspec/changes/add-patch-overlays-user-docs/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 Update overlays docs to describe patch overlays, limitations, and conflict handling
+- [x] 1.2 Update CLI reference to include `overlay edit --kind dir|patch`
+- [x] 1.3 Run `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all --locked`


### PR DESCRIPTION
Closes #453.

## What
- Document patch overlays (`overlay edit --kind patch`) in overlays docs and CLI reference (EN + zh-CN).
- Add conflict/failure notes referencing stable error codes (`E_OVERLAY_PATCH_APPLY_FAILED`, `E_OVERLAY_REBASE_CONFLICT`) and conflict artifacts under `.agentpack/conflicts/`.
- OpenSpec change: `openspec/changes/add-patch-overlays-user-docs/`.

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
