### PR TITLE
M0-DOC-003: Add patch overlays doc-sync test

### DIFF
--- a/openspec/changes/add-patch-overlays-doc-sync-check/proposal.md
+++ b/openspec/changes/add-patch-overlays-doc-sync-check/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add doc-sync check for patch overlays documentation
+
+## Why
+Patch overlays are easy to regress in docs (missing `--kind patch`, missing error codes, or missing conflict artifact hints). A small automated check prevents “feature exists but docs drift” from recurring.
+
+## What Changes
+- Add an integration test that asserts the patch overlay feature is documented in:
+  - `docs/CLI.md` (flag discoverability)
+  - `docs/OVERLAYS.md` (behavior + failure/conflict handling)
+- The test fails with actionable messages when key strings are missing.
+
+## Impact
+- Affected specs: `agentpack-cli`
+- Affected code: `tests/`
+- Compatibility: no CLI/JSON behavior changes

--- a/openspec/changes/add-patch-overlays-doc-sync-check/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-patch-overlays-doc-sync-check/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Patch overlays docs stay consistent with the CLI
+
+The repository SHALL include an automated check that ensures patch overlays are documented, including the `overlay edit --kind patch` flag and stable error codes used for patch failures and rebase conflicts.
+
+#### Scenario: CI catches missing patch overlay docs
+- **WHEN** CI runs the doc-sync check
+- **THEN** it passes when required patch overlay documentation is present
+- **AND** it fails with an actionable message when documentation drifts

--- a/openspec/changes/add-patch-overlays-doc-sync-check/tasks.md
+++ b/openspec/changes/add-patch-overlays-doc-sync-check/tasks.md
@@ -1,0 +1,3 @@
+## 1. Implementation
+- [x] 1.1 Add doc-sync test for patch overlays documentation
+- [x] 1.2 Run `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all --locked`

--- a/tests/cli_patch_overlays_doc_sync.rs
+++ b/tests/cli_patch_overlays_doc_sync.rs
@@ -1,0 +1,32 @@
+fn read_to_string(path: &str) -> anyhow::Result<String> {
+    std::fs::read_to_string(path).map_err(|e| anyhow::anyhow!("read {path}: {e}"))
+}
+
+fn assert_contains(path: &str, haystack: &str, needle: &str) -> anyhow::Result<()> {
+    if haystack.contains(needle) {
+        return Ok(());
+    }
+    anyhow::bail!("{path} is out of sync.\n\nExpected to find:\n  {needle}");
+}
+
+#[test]
+fn patch_overlays_docs_cover_cli_flag_and_error_codes() -> anyhow::Result<()> {
+    let cli = read_to_string("docs/CLI.md")?;
+    assert_contains(
+        "docs/CLI.md",
+        &cli,
+        "overlay edit <module_id> [--scope global|machine|project] [--kind dir|patch]",
+    )?;
+
+    let overlays = read_to_string("docs/OVERLAYS.md")?;
+    assert_contains("docs/OVERLAYS.md", &overlays, "Patch overlays")?;
+    assert_contains(
+        "docs/OVERLAYS.md",
+        &overlays,
+        "E_OVERLAY_PATCH_APPLY_FAILED",
+    )?;
+    assert_contains("docs/OVERLAYS.md", &overlays, "E_OVERLAY_REBASE_CONFLICT")?;
+    assert_contains("docs/OVERLAYS.md", &overlays, ".agentpack/conflicts/")?;
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #455.

## What
- Add `tests/cli_patch_overlays_doc_sync.rs` to prevent patch overlay docs from drifting.
- OpenSpec change: `openspec/changes/add-patch-overlays-doc-sync-check/`.

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
