### PR TITLE
M1-DOC-010: Add docs/index.md entrypoint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,44 @@
+# Agentpack Docs
+
+> Language: English | [Chinese (Simplified)](zh-CN/index.md)
+
+This page is the single “start here” entrypoint for Agentpack documentation.
+
+## Choose your path
+
+### 1) From scratch (first-time setup)
+
+- Follow the Quickstart to install, initialize a config repo, and do your first deploy:
+  - `QUICKSTART.md`
+- Learn the daily loop (update → preview → deploy → status → rollback):
+  - `WORKFLOWS.md`
+
+### 2) Adopt existing assets (import)
+
+- If you already have skills/prompts/commands on disk and want Agentpack to manage them:
+  - CLI reference: `CLI.md#import`
+  - Daily workflow context: `WORKFLOWS.md`
+
+## Common workflows
+
+- Local customization with overlays (including patch overlays):
+  - `OVERLAYS.md` (see `overlay edit --kind patch`)
+- Drift → proposal → review → merge:
+  - `WORKFLOWS.md`
+  - `EVOLVE.md`
+- AI-first bootstrap (operator assets for Codex / Claude Code):
+  - `BOOTSTRAP.md`
+
+## Automation / integrations
+
+- Stable `--json` envelope contract and examples:
+  - `JSON_API.md`
+  - `ERROR_CODES.md`
+- Codex MCP integration (`agentpack mcp serve`):
+  - `MCP.md`
+
+## Reference
+
+- CLI reference: `CLI.md`
+- Config reference (`agentpack.yaml`): `CONFIG.md`
+- Targets reference: `TARGETS.md`

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -1,0 +1,44 @@
+# Agentpack 文档（入口）
+
+> Language: 简体中文 | [English](../index.md)
+
+本页是 Agentpack 文档的唯一“从这里开始”入口。
+
+## 选择你的路径
+
+### 1) 从 0 开始（第一次使用）
+
+- 按 Quickstart 完成安装、初始化配置仓库，并完成第一次部署：
+  - `../QUICKSTART.md`
+- 了解日常闭环（update → preview → deploy → status → rollback）：
+  - `../WORKFLOWS.md`
+
+### 2) 纳管已有资产（import）
+
+- 如果你已经在磁盘上有 skills/prompts/commands，希望交给 Agentpack 管理：
+  - CLI 参考：`CLI.md#import`
+  - 工作流背景：`../WORKFLOWS.md`
+
+## 常用工作流
+
+- 用 overlays 做本地定制（包括 patch overlays）：
+  - `OVERLAYS.md`（见 `overlay edit --kind patch`）
+- 漂移 → 提案 → review → 合入：
+  - `../WORKFLOWS.md`
+  - `EVOLVE.md`
+- AI 自举（为 Codex / Claude Code 安装 operator assets）：
+  - `../BOOTSTRAP.md`
+
+## 自动化 / 集成
+
+- 稳定的 `--json` 输出契约与示例：
+  - `../JSON_API.md`
+  - `../ERROR_CODES.md`
+- Codex MCP 集成（`agentpack mcp serve`）：
+  - `../MCP.md`
+
+## 参考
+
+- CLI 命令参考：`CLI.md`
+- 配置参考（`agentpack.yaml`）：`../CONFIG.md`
+- Targets 参考：`../TARGETS.md`

--- a/openspec/changes/add-docs-index-entrypoint/proposal.md
+++ b/openspec/changes/add-docs-index-entrypoint/proposal.md
@@ -1,0 +1,18 @@
+# Change: Add docs/index.md as the single user entrypoint
+
+## Why
+New users currently have multiple competing “start here” documents. A single, task-oriented entrypoint improves discoverability and reduces onboarding friction.
+
+## What Changes
+- Add `docs/index.md` as the canonical user entrypoint (English), with a clear decision tree linking to:
+  - Quickstart (from scratch)
+  - Import (adopt existing assets)
+  - Daily workflow
+  - Automation (`--json` / MCP)
+  - Reference docs (CLI/config/targets/overlays/error codes)
+- Add a Simplified Chinese counterpart at `docs/zh-CN/index.md`.
+
+## Impact
+- Affected specs: `agentpack-cli`
+- Affected docs: `docs/index.md`, `docs/zh-CN/index.md`
+- Compatibility: no CLI/JSON behavior changes

--- a/openspec/changes/add-docs-index-entrypoint/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-docs-index-entrypoint/specs/agentpack-cli/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Single user entrypoint in docs
+
+The repository SHALL provide `docs/index.md` as the canonical user entrypoint, linking to tutorials/how-to guides/reference docs such that a new user can reliably find the next step for common workflows (from-scratch setup, import, daily loop, automation).
+
+#### Scenario: Entry point enables first-day success
+- **WHEN** a new user opens `docs/index.md`
+- **THEN** they can choose a path (from-scratch vs import) and reach a next action in ≤ 3 clicks

--- a/openspec/changes/add-docs-index-entrypoint/tasks.md
+++ b/openspec/changes/add-docs-index-entrypoint/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 Add `docs/index.md` with a task-oriented decision tree and links
+- [x] 1.2 Add `docs/zh-CN/index.md` (translation of the entrypoint)
+- [x] 1.3 Run `cargo test --all --locked`


### PR DESCRIPTION
Closes #458.

## What
- Add `docs/index.md` as the single user entrypoint (English) with a task-oriented decision tree.
- Add `docs/zh-CN/index.md` as the Simplified Chinese counterpart.
- OpenSpec change: `openspec/changes/add-docs-index-entrypoint/`.

## Tests
- `cargo test --all --locked`
