### PR TITLE
docs(adr): add initial ADRs (M1-DOC-014)

### DIFF
--- a/docs/adr/0001-json-contract-stability.md
+++ b/docs/adr/0001-json-contract-stability.md
@@ -1,0 +1,35 @@
+# ADR 0001: JSON contract stability (`--json` schema_version=1)
+
+- Status: accepted
+- Date: 2026-01-19
+
+## Context
+
+Agentpack is used both interactively and in automation (CI, scripts, MCP clients). For automation, `--json` output is part of the public contract: consumers parse it, persist it, and depend on stable error codes and stable meanings.
+
+Breaking the JSON schema (renaming fields, changing semantics, removing fields) forces downstream consumers to update in lockstep and makes upgrades risky.
+
+## Decision
+
+- Treat `--json` as a stable API contract with `schema_version=1`.
+- Changes to the JSON envelope SHALL be additive-only:
+  - adding new top-level fields is allowed
+  - adding new error codes is allowed (with docs + tests)
+  - removing/renaming fields or changing semantics is not allowed within `schema_version=1`
+- Stable error codes remain stable; new error codes require documentation and test coverage.
+
+## Consequences
+
+- Pros:
+  - automation stays reliable across upgrades
+  - CI and tooling can safely pin to `schema_version=1`
+  - regressions are caught early when docs + golden tests are updated together
+- Cons:
+  - we must be disciplined about introducing new fields rather than “fixing” existing ones
+  - occasional redundancy or deprecated fields may accumulate until a future `schema_version=2`
+
+## References
+
+- `docs/SPEC.md`
+- `docs/reference/json-api.md`
+- `docs/reference/error-codes.md`

--- a/docs/adr/0002-patch-overlays-design.md
+++ b/docs/adr/0002-patch-overlays-design.md
@@ -1,0 +1,38 @@
+# ADR 0002: Patch overlays design
+
+- Status: accepted
+- Date: 2026-01-19
+
+## Context
+
+Overlays let users customize upstream modules without forking. Traditional “dir overlays” materialize full files, but that makes updates expensive: rebases produce large diffs, and small upstream changes can require re-copying files.
+
+Users often want a minimal, reviewable customization that:
+- keeps the upstream content as the source of truth
+- stores only the delta in version control
+- can be rebased when upstream changes
+
+## Decision
+
+Introduce “patch overlays” as a first-class overlay kind:
+- `overlay_kind=patch` overlays store unified diff patches under `.agentpack/patches/`.
+- Patch overlays are intended for UTF-8 text files.
+- During desired-state generation, patches are applied to the upstream content to produce the final materialized files.
+- Failures are treated as actionable, deterministic errors:
+  - patch apply failures surface as `E_OVERLAY_PATCH_APPLY_FAILED`
+  - rebase conflicts surface as `E_OVERLAY_REBASE_CONFLICT` and write conflict artifacts under `.agentpack/conflicts/`
+
+## Consequences
+
+- Pros:
+  - small diffs and clean review surface
+  - upstream updates are easier to rebase onto
+  - changes remain local and auditable
+- Cons:
+  - patching is less suitable for binary files or non-UTF-8 content
+  - patch failures require conflict resolution (but with deterministic artifacts)
+
+## References
+
+- `docs/explanation/overlays.md`
+- `docs/reference/error-codes.md`

--- a/docs/adr/0003-mcp-confirm-token.md
+++ b/docs/adr/0003-mcp-confirm-token.md
@@ -1,0 +1,39 @@
+# ADR 0003: MCP confirm_token for mutating operations
+
+- Status: accepted
+- Date: 2026-01-19
+
+## Context
+
+Agentpack supports automation surfaces beyond the CLI, including MCP tools. Mutating operations (writing files, deploying, adopting, patching) must be:
+- safe by default
+- auditable
+- explicitly confirmable
+
+In interactive CLI usage, `--yes` can serve as explicit confirmation. In MCP, calls can be programmatic and repeated; a simple boolean flag is easy to misuse and hard to audit.
+
+## Decision
+
+For MCP, require a two-phase workflow for mutating actions:
+1) **plan**: compute and return the proposed changes, and generate a `confirm_token` that binds to the plan.
+2) **apply**: perform the mutation only if the caller provides the matching `confirm_token`.
+
+The `confirm_token` is designed to:
+- make the “what I reviewed” → “what I applied” relationship explicit
+- reduce accidental repeated writes
+- enable safer automation and better logs/audit trails
+
+## Consequences
+
+- Pros:
+  - safer defaults for automation
+  - clearer auditability of applied changes
+  - enables “preview then apply” workflows consistently across CLI/MCP
+- Cons:
+  - slightly more complex client flow (plan + apply)
+  - tokens must be handled carefully to avoid stale or mismatched applies
+
+## References
+
+- `docs/SPEC.md`
+- `docs/dev/roadmap.md`

--- a/docs/dev/roadmap.md
+++ b/docs/dev/roadmap.md
@@ -49,10 +49,12 @@ scope: docs
 ### 2.1 外部契约优先（Do not break userspace）
 - `--json` **schema_version=1**：只允许新增字段，不允许删除/重命名/改变语义。
 - `ERROR_CODES`：稳定错误码不随便改；新增错误码需同时更新文档与测试。
+- ADR（why）：`../adr/0001-json-contract-stability.md`
 
 ### 2.2 变更类命令必须可拒绝
 - CLI：`--json` 模式下，任何写入动作必须要求 `--yes`（或等价的显式确认）。
 - MCP：写入类工具必须两阶段（plan -> apply），且 apply 必须携带 **confirm_token**（或等价绑定）。
+- ADR（why）：`../adr/0003-mcp-confirm-token.md`
 
 ### 2.3 Docs-as-code：代码改动必须带 docs/测试
 - 任何新增 CLI flags/子命令：必须更新 reference，且加 doc-sync test 防漂移。
@@ -88,6 +90,7 @@ scope: docs
 #### 3.1.3 文档漂移防护（Doc-sync）
 - 必须有 CI 检查：当 CLI/flags 变更时，reference 必须同步（生成或 doc-sync test）。
 - patch overlay 相关至少有 1 条 doc-sync test：确保 reference 与 overlays explanation 提到 `--kind patch`。
+- ADR（why）：`../adr/0002-patch-overlays-design.md`
 
 ### 3.2 测试 Spec（分层 + 真实旅程 E2E）
 目标：不只验证函数正确，更要验证“真实操作不会把用户环境搞坏”。

--- a/openspec/changes/add-adrs/.openspec.yaml
+++ b/openspec/changes/add-adrs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-19

--- a/openspec/changes/add-adrs/README.md
+++ b/openspec/changes/add-adrs/README.md
@@ -1,0 +1,3 @@
+# add-adrs
+
+Introduce ADRs for key architectural decisions

--- a/openspec/changes/add-adrs/proposal.md
+++ b/openspec/changes/add-adrs/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add ADRs for key architectural decisions
+
+## Why
+
+Some core design decisions (e.g., JSON contract stability, patch overlays, MCP confirm tokens) are critical to long-term maintenance and contributor onboarding. Keeping the rationale only in workplans or scattered docs makes it hard to find, easy to regress, and encourages duplicating “why” across documents.
+
+## What Changes
+
+- Introduce an ADR directory under `docs/adr/`.
+- Add at least three initial ADRs covering:
+  - JSON contract stability (`--json` schema_version=1, additive-only).
+  - Patch overlays design (unified diffs under `.agentpack/patches/`, failure modes).
+  - MCP `confirm_token` design (two-phase plan/apply, binding and auditability).
+- Update `docs/dev/roadmap.md` to link to ADRs for “why” rather than embedding long rationale inline.
+
+## Impact
+
+- Affected specs: `agentpack-cli`
+- Affected code: none (docs/spec only)
+- Affected docs:
+  - `docs/adr/*`
+  - `docs/dev/roadmap.md`

--- a/openspec/changes/add-adrs/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-adrs/specs/agentpack-cli/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Architecture decisions are recorded as ADRs
+
+The repository SHALL record major architecture decisions as Architecture Decision Records (ADRs) under `docs/adr/`, using stable numbering and a consistent structure (status, context, decision, consequences).
+
+The maintainer roadmap (`docs/dev/roadmap.md`) SHOULD link to ADRs for “why” instead of duplicating long-form rationale inline.
+
+#### Scenario: ADRs exist for core contracts and workflows
+- **WHEN** a contributor needs to understand the rationale for key product contracts and workflows
+- **THEN** ADRs exist that cover:
+  - JSON contract stability (`--json` schema_version=1, additive-only)
+  - Patch overlays design
+  - MCP `confirm_token` two-phase apply design
+
+#### Scenario: Roadmap links to ADRs for rationale
+- **WHEN** a maintainer reads the roadmap’s principles/spec sections
+- **THEN** the roadmap includes links to relevant ADRs for deeper rationale

--- a/openspec/changes/add-adrs/tasks.md
+++ b/openspec/changes/add-adrs/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] Add `docs/adr/` with 3 ADRs:
+  - [x] `docs/adr/0001-json-contract-stability.md`
+  - [x] `docs/adr/0002-patch-overlays-design.md`
+  - [x] `docs/adr/0003-mcp-confirm-token.md`
+- [x] Link ADRs from `docs/dev/roadmap.md` in relevant “principles/spec” sections.
+
+## 2. Spec deltas
+
+- [x] Add a new requirement to `openspec/changes/add-adrs/specs/agentpack-cli/spec.md` covering ADR presence and roadmap links.
+
+## 3. Validation
+
+- [x] `openspec validate add-adrs --strict`


### PR DESCRIPTION
## Summary
- Adds `docs/adr/` with three initial ADRs for key design decisions.
- Links ADRs from `docs/dev/roadmap.md` so “why” is discoverable.
- Adds OpenSpec change `add-adrs` with spec delta for ADR requirement.

## Tracking
- Closes #473

## Validation
- `openspec validate add-adrs --strict`
