### PR TITLE
test(docs): add docs link checker (M1-DOC-016)

### DIFF
--- a/openspec/changes/add-docs-link-check/.openspec.yaml
+++ b/openspec/changes/add-docs-link-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-19

--- a/openspec/changes/add-docs-link-check/README.md
+++ b/openspec/changes/add-docs-link-check/README.md
@@ -1,0 +1,3 @@
+# add-docs-link-check
+
+Add CI markdown link checking for docs

--- a/openspec/changes/add-docs-link-check/proposal.md
+++ b/openspec/changes/add-docs-link-check/proposal.md
@@ -1,0 +1,16 @@
+# Change: Add docs markdown link checking in CI
+
+## Why
+
+As documentation is reorganized and extended, it’s easy for internal links to drift or break (especially with tombstones, renames, and language toggles). Broken links reduce discoverability and user trust.
+
+## What Changes
+
+- Add a deterministic, offline markdown link checker that validates internal/relative links in `docs/` resolve to existing files.
+- Run it in CI (via `cargo test`) so broken links are caught before merge.
+
+## Impact
+
+- Affected specs: `agentpack-cli`
+- Affected code: tests only (no runtime behavior)
+- Affected docs: none (except fixing any newly-detected broken links)

--- a/openspec/changes/add-docs-link-check/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-docs-link-check/specs/agentpack-cli/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Docs internal links are validated in CI
+
+The repository SHALL include an automated check that detects broken internal links in documentation under `docs/` (no network required).
+
+#### Scenario: CI fails on broken doc links
+- **WHEN** a documentation page links to a non-existent file path
+- **THEN** CI fails with an actionable message identifying the source file and broken link target

--- a/openspec/changes/add-docs-link-check/tasks.md
+++ b/openspec/changes/add-docs-link-check/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] Add a markdown link checker test (offline, deterministic) that scans relevant `docs/**/*.md` files and validates internal links resolve.
+- [x] Exclude code fences from link parsing to avoid false positives.
+- [x] Ensure failures are actionable (source file + broken target).
+
+## 2. Spec deltas
+
+- [x] Add a requirement for docs link checking to `openspec/changes/add-docs-link-check/specs/agentpack-cli/spec.md`.
+
+## 3. Validation
+
+- [x] `openspec validate add-docs-link-check --strict`
+- [x] `cargo test --all --locked`

--- a/tests/docs_markdown_links.rs
+++ b/tests/docs_markdown_links.rs
@@ -1,0 +1,160 @@
+use std::path::{Component, Path, PathBuf};
+
+fn should_skip_target(target: &str) -> bool {
+    let target = target.trim();
+    if target.is_empty() {
+        return true;
+    }
+
+    if target.starts_with('#') {
+        return true;
+    }
+
+    if let Some(scheme) = target.split(':').next() {
+        if matches!(scheme, "http" | "https" | "mailto") {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+fn resolve_link_target(source_path: &Path, raw_target: &str) -> Option<PathBuf> {
+    let mut target = raw_target.trim();
+    if target.starts_with('<') && target.ends_with('>') && target.len() >= 2 {
+        target = &target[1..target.len() - 1];
+    }
+
+    let target = target
+        .split('#')
+        .next()
+        .unwrap_or("")
+        .split('?')
+        .next()
+        .unwrap_or("")
+        .trim();
+
+    if should_skip_target(target) {
+        return None;
+    }
+
+    let target = target.split_whitespace().next().unwrap_or("").trim();
+    if target.is_empty() || should_skip_target(target) {
+        return None;
+    }
+
+    let base = if let Some(stripped) = target.strip_prefix('/') {
+        PathBuf::from(stripped)
+    } else {
+        let dir = source_path.parent().unwrap_or_else(|| Path::new("."));
+        dir.join(target)
+    };
+
+    Some(normalize_path(&base))
+}
+
+fn extract_link_targets(markdown: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_code_fence = false;
+
+    for line in markdown.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            in_code_fence = !in_code_fence;
+            continue;
+        }
+        if in_code_fence {
+            continue;
+        }
+
+        let mut rest = line;
+        while let Some(idx) = rest.find("](") {
+            let after = &rest[idx + 2..];
+            let Some(end) = after.find(')') else {
+                break;
+            };
+            let target = after[..end].trim().to_string();
+            out.push(target);
+            rest = &after[end + 1..];
+        }
+    }
+
+    out
+}
+
+fn target_exists(resolved: &Path) -> bool {
+    if resolved.exists() {
+        return true;
+    }
+    if resolved.extension().is_none() && resolved.with_extension("md").exists() {
+        return true;
+    }
+    false
+}
+
+#[test]
+fn docs_links_do_not_point_to_missing_files() {
+    let mut broken = Vec::new();
+
+    for entry in walkdir::WalkDir::new("docs")
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_file())
+    {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+        if path.strip_prefix("docs/archive").is_ok() {
+            continue;
+        }
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(err) => {
+                broken.push(format!("{}: failed to read: {err}", path.display()));
+                continue;
+            }
+        };
+
+        for raw_target in extract_link_targets(&content) {
+            let Some(resolved) = resolve_link_target(path, &raw_target) else {
+                continue;
+            };
+            if !target_exists(&resolved) {
+                broken.push(format!(
+                    "{}: broken link target '{}' (resolved: {})",
+                    path.display(),
+                    raw_target,
+                    resolved.display()
+                ));
+            }
+        }
+    }
+
+    if !broken.is_empty() {
+        broken.sort();
+        panic!(
+            "Found broken markdown links:\n{}",
+            broken
+                .into_iter()
+                .map(|s| format!("- {s}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an offline, deterministic markdown link checker for `docs/**/*.md` (excluding `docs/archive/`).
- Fails CI with actionable output when a relative/internal link target is missing.
- Adds OpenSpec change `add-docs-link-check`.

## Tracking
- Closes #479

## Validation
- `openspec validate add-docs-link-check --strict`
- `cargo test --all --locked`
