### PR TITLE
test: add assert_cmd + predicates (M2-TST-002)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,12 +7,14 @@ name = "agentpack"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "clap_complete",
  "crossterm",
  "dirs",
  "getrandom 0.3.4",
  "hex",
+ "predicates",
  "ratatui",
  "rmcp",
  "schemars",
@@ -25,6 +27,15 @@ dependencies = [
  "time",
  "tokio",
  "walkdir",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -99,6 +110,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert_cmd"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +160,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -418,6 +455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +539,15 @@ name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fnv"
@@ -847,6 +899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +998,36 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1067,6 +1155,35 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rmcp"
@@ -1375,6 +1492,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1668,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,7 @@ target-zed = []
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+[dev-dependencies]
+assert_cmd = "2.1.2"
+predicates = "3.1.3"

--- a/openspec/changes/add-assert-cmd/.openspec.yaml
+++ b/openspec/changes/add-assert-cmd/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-19

--- a/openspec/changes/add-assert-cmd/README.md
+++ b/openspec/changes/add-assert-cmd/README.md
@@ -1,0 +1,3 @@
+# add-assert-cmd
+
+Add assert_cmd + predicates for journey tests

--- a/openspec/changes/add-assert-cmd/proposal.md
+++ b/openspec/changes/add-assert-cmd/proposal.md
@@ -1,0 +1,15 @@
+# Change: Add `assert_cmd` + `predicates` for journey tests
+
+## Why
+
+Upcoming journey/E2E tests should use a consistent, readable CLI assertion style with good failure output.
+
+## What Changes
+
+- Add `assert_cmd` and `predicates` as dev-dependencies.
+
+## Impact
+
+- Affected specs: `agentpack-cli`
+- Affected code: tests only (dependency surface)
+- Affected runtime behavior: none

--- a/openspec/changes/add-assert-cmd/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-assert-cmd/specs/agentpack-cli/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: Journey tests use standard CLI assertion tooling
+
+The repository SHALL use standard CLI testing utilities (e.g., `assert_cmd` and `predicates`) for journey/E2E tests to keep assertions consistent and failure output actionable.
+
+#### Scenario: Journey tests can spawn the agentpack binary consistently
+- **WHEN** a journey test needs to run `agentpack` with a temp `AGENTPACK_HOME`
+- **THEN** it can use `assert_cmd` to execute the binary and `predicates` to assert on output

--- a/openspec/changes/add-assert-cmd/tasks.md
+++ b/openspec/changes/add-assert-cmd/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [x] Add `assert_cmd` and `predicates` under `[dev-dependencies]`.
+- [x] Ensure `Cargo.lock` is updated and `cargo test --all --locked` passes.
+
+## 2. Spec deltas
+
+- [x] Add a requirement noting journey tests use `assert_cmd`/`predicates`.
+
+## 3. Validation
+
+- [x] `openspec validate add-assert-cmd --strict`
+- [x] `cargo test --all --locked`


### PR DESCRIPTION
## Summary
- Adds `assert_cmd` + `predicates` as dev-dependencies for upcoming journey/E2E tests.
- Adds OpenSpec change `add-assert-cmd`.

## Tracking
- Closes #482

## Validation
- `openspec validate add-assert-cmd --strict`
- `cargo test --all --locked`
