### PR TITLE
M2-TST-013: add Journey J4 overlay rebase test

### DIFF
--- a/openspec/changes/add-journey-j4-overlay-rebase/.openspec.yaml
+++ b/openspec/changes/add-journey-j4-overlay-rebase/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-19

--- a/openspec/changes/add-journey-j4-overlay-rebase/README.md
+++ b/openspec/changes/add-journey-j4-overlay-rebase/README.md
@@ -1,0 +1,3 @@
+# add-journey-j4-overlay-rebase
+
+Add journey test J4: overlay sparse → materialize → rebase → deploy

--- a/openspec/changes/add-journey-j4-overlay-rebase/proposal.md
+++ b/openspec/changes/add-journey-j4-overlay-rebase/proposal.md
@@ -1,0 +1,25 @@
+# Change: Add journey test J4 (overlay sparse/materialize/rebase/deploy)
+
+## Why
+
+Overlay workflows are a core customization path: users create sparse overlays, materialize upstream files for editing, and later rebase overlays as upstream changes.
+
+We need an end-to-end journey test that verifies:
+- sparse overlay creation does not copy upstream files by default,
+- `--materialize` brings upstream files into the overlay (missing-only),
+- `overlay rebase` detects merge conflicts and returns stable `--json` error codes, and
+- deploy uses the overlay-composed desired state.
+
+## What Changes
+
+- Add an integration test for Journey J4 using `tests/journeys/common::TestEnv`:
+  - create a sparse directory overlay for a base module
+  - materialize upstream files into the overlay
+  - simulate an upstream update that conflicts with overlay edits and verify `E_OVERLAY_REBASE_CONFLICT`
+  - resolve and deploy, asserting the deployed output matches overlay content
+
+## Impact
+
+- Affected specs: none (tests-only)
+- Affected code: `tests/` only
+- Affected runtime behavior: none

--- a/openspec/changes/add-journey-j4-overlay-rebase/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-journey-j4-overlay-rebase/specs/agentpack-cli/spec.md
@@ -1,0 +1,15 @@
+# agentpack-cli Delta
+
+## ADDED Requirements
+
+### Requirement: Journey J4 is covered by an integration test
+The project SHALL include a deterministic, offline integration test for Journey J4 (overlay sparse/materialize/rebase/deploy) that validates rebase behavior and deploy output.
+
+#### Scenario: sparse overlay can materialize, rebase, and deploy
+- **GIVEN** a directory overlay created with `--sparse`
+- **WHEN** the user materializes upstream files into the overlay
+- **THEN** upstream files become editable under the overlay directory
+- **WHEN** upstream changes conflict with overlay edits and the user runs `agentpack overlay rebase --json --yes`
+- **THEN** the command fails with `errors[0].code = E_OVERLAY_REBASE_CONFLICT` and conflict-marked artifacts exist
+- **WHEN** the conflicts are resolved
+- **THEN** `agentpack deploy --apply --json --yes` deploys the overlay-composed content

--- a/openspec/changes/add-journey-j4-overlay-rebase/tasks.md
+++ b/openspec/changes/add-journey-j4-overlay-rebase/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] Add Journey J4 integration test covering sparse overlay creation, materialize, rebase conflict behavior, and deploy using overlay-composed desired state.
+
+## 2. Spec deltas
+
+- [x] Add a delta requirement describing Journey J4 coverage (archive with `--skip-specs` since this is tests-only).
+
+## 3. Validation
+
+- [x] `openspec validate add-journey-j4-overlay-rebase --strict`
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo test --all --locked`

--- a/tests/journey_j4_overlay_rebase.rs
+++ b/tests/journey_j4_overlay_rebase.rs
@@ -1,0 +1,174 @@
+mod journeys;
+
+use std::path::{Path, PathBuf};
+use std::process::Output;
+
+use journeys::common::TestEnv;
+
+fn write_file(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    std::fs::write(path, contents).expect("write file");
+}
+
+fn run_out(env: &TestEnv, args: &[&str]) -> Output {
+    env.agentpack().args(args).output().expect("run agentpack")
+}
+
+fn run_ok(env: &TestEnv, args: &[&str]) -> Output {
+    let out = run_out(env, args);
+    assert!(
+        out.status.success(),
+        "command failed: agentpack {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    out
+}
+
+fn run_fail(env: &TestEnv, args: &[&str]) -> Output {
+    let out = run_out(env, args);
+    assert!(
+        !out.status.success(),
+        "command unexpectedly succeeded: agentpack {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    out
+}
+
+fn parse_json(out: &Output) -> serde_json::Value {
+    serde_json::from_slice(&out.stdout).expect("parse json stdout")
+}
+
+fn git_out(dir: &Path, args: &[&str]) -> Output {
+    std::process::Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("run git")
+}
+
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = git_out(dir, args);
+    assert!(
+        out.status.success(),
+        "git command failed: git {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn journey_j4_overlay_sparse_materialize_rebase_conflict_then_deploy() {
+    let env = TestEnv::new();
+    let module_id = "instructions:base";
+
+    env.init_repo_with_base_modules();
+    run_ok(&env, &["--json", "--yes", "update"]);
+
+    // Make the upstream file deterministic (this is what the overlay will be based on).
+    let upstream_agents = env
+        .repo_dir()
+        .join("modules")
+        .join("instructions")
+        .join("base")
+        .join("AGENTS.md");
+    let base_text = "line: BASE\n";
+    write_file(&upstream_agents, base_text);
+
+    // Local-path rebase requires a git merge base; initialize and commit the repo state.
+    let repo_dir = env.repo_dir();
+    git_ok(&repo_dir, &["init"]);
+    git_ok(&repo_dir, &["config", "user.email", "test@example.com"]);
+    git_ok(&repo_dir, &["config", "user.name", "Test User"]);
+    git_ok(&repo_dir, &["add", "."]);
+    git_ok(&repo_dir, &["commit", "-m", "baseline"]);
+
+    // overlay edit --sparse should not copy upstream files into the overlay.
+    let edit_sparse = parse_json(&run_ok(
+        &env,
+        &["--json", "--yes", "overlay", "edit", module_id, "--sparse"],
+    ));
+    let overlay_dir = PathBuf::from(
+        edit_sparse["data"]["overlay_dir"]
+            .as_str()
+            .expect("overlay_dir"),
+    );
+    let overlay_agents = overlay_dir.join("AGENTS.md");
+    assert!(!overlay_agents.exists());
+
+    // overlay edit --materialize should populate upstream files missing-only.
+    let edit_materialize = parse_json(&run_ok(
+        &env,
+        &[
+            "--json",
+            "--yes",
+            "overlay",
+            "edit",
+            module_id,
+            "--materialize",
+        ],
+    ));
+    assert_eq!(
+        edit_materialize["data"]["materialized"].as_bool(),
+        Some(true)
+    );
+    assert!(overlay_agents.exists());
+    assert_eq!(
+        std::fs::read_to_string(&overlay_agents).expect("read overlay agents"),
+        base_text
+    );
+
+    // Edit the overlay ("ours") and then update upstream ("theirs") in a conflicting way.
+    let ours_text = "line: OURS\n";
+    let theirs_text = "line: THEIRS\n";
+    write_file(&overlay_agents, ours_text);
+    write_file(&upstream_agents, theirs_text);
+    git_ok(&repo_dir, &["add", "modules/instructions/base/AGENTS.md"]);
+    git_ok(&repo_dir, &["commit", "-m", "upstream update"]);
+
+    // overlay rebase should surface the stable conflict error code and write conflict markers.
+    let rebase = parse_json(&run_fail(
+        &env,
+        &["--json", "--yes", "overlay", "rebase", module_id],
+    ));
+    assert_eq!(rebase["ok"].as_bool(), Some(false));
+    assert_eq!(
+        rebase["errors"][0]["code"].as_str(),
+        Some("E_OVERLAY_REBASE_CONFLICT")
+    );
+    let conflicts = rebase["errors"][0]["details"]["conflicts"]
+        .as_array()
+        .expect("conflicts array");
+    assert!(
+        conflicts.iter().any(|c| c.as_str() == Some("AGENTS.md")),
+        "expected conflicts to include AGENTS.md; got {conflicts:?}"
+    );
+    let conflict_marked = std::fs::read_to_string(&overlay_agents).expect("read conflict overlay");
+    assert!(
+        conflict_marked.contains("<<<<<<<"),
+        "expected conflict markers in overlay file; got:\n{conflict_marked}"
+    );
+
+    // Resolve conflict manually and ensure deploy uses the overlay-composed content.
+    let resolved_text = "line: RESOLVED\n";
+    write_file(&overlay_agents, resolved_text);
+
+    let deploy = parse_json(&run_ok(
+        &env,
+        &["--target", "codex", "--json", "--yes", "deploy", "--apply"],
+    ));
+    assert_eq!(deploy["ok"].as_bool(), Some(true));
+    assert_eq!(deploy["data"]["applied"].as_bool(), Some(true));
+
+    let deployed_agents = env.home().join(".codex").join("AGENTS.md");
+    assert_eq!(
+        std::fs::read_to_string(&deployed_agents).expect("read deployed AGENTS.md"),
+        resolved_text
+    );
+}


### PR DESCRIPTION
## What
- Add Journey J4 integration test: overlay `--sparse` → `--materialize` → `overlay rebase` conflict → deploy uses overlay-composed output.
- Add OpenSpec change `add-journey-j4-overlay-rebase` (tests-only; will be archived in a follow-up PR).

## Why
Covers a high-value overlay workflow and protects the stable `--json` error contract for rebase conflicts (`E_OVERLAY_REBASE_CONFLICT`).

## Validation
- `openspec validate add-journey-j4-overlay-rebase --strict`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`

Closes #497.
