### PR TITLE
chore(ci): add optional nextest job (M2-TST-020)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,39 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
         run: cargo test --all-features --all --locked
 
+  nextest:
+    name: Rust (ubuntu-latest, nextest)
+    needs: changed
+    runs-on: ubuntu-latest
+    # Optional / gradual adoption: keep this non-blocking by default.
+    continue-on-error: true
+    steps:
+      - name: Skip (no Rust changes)
+        if: ${{ github.event_name == 'pull_request' && needs.changed.outputs.rust != 'true' }}
+        run: echo "No Rust-related changes detected; skipping nextest."
+
+      - uses: actions/checkout@v6
+        if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
+
+      - name: Install Rust toolchain
+        if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
+
+      - name: Install cargo-nextest
+        if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: cargo nextest run
+        if: ${{ github.event_name != 'pull_request' || needs.changed.outputs.rust == 'true' }}
+        run: cargo nextest run --all --locked
+
   conformance_feature_matrix:
     name: Conformance (${{ matrix.name }})
     needs: changed

--- a/justfile
+++ b/justfile
@@ -15,6 +15,9 @@ clippy:
 test:
   cargo test --all --locked
 
+nextest:
+  cargo nextest run --all --locked
+
 audit:
   cargo audit
 

--- a/openspec/changes/add-ci-nextest/README.md
+++ b/openspec/changes/add-ci-nextest/README.md
@@ -1,0 +1,3 @@
+# add-ci-nextest
+
+Add an optional `cargo nextest run` path in CI.

--- a/openspec/changes/add-ci-nextest/proposal.md
+++ b/openspec/changes/add-ci-nextest/proposal.md
@@ -1,0 +1,16 @@
+# Change: Add optional nextest in CI
+
+## Why
+
+`cargo nextest` is a faster and often more stable test runner than the built-in `cargo test` harness. Providing an opt-in/gradual `nextest` job in CI helps us improve feedback time and reduce flaky test pain without changing runtime behavior.
+
+## What Changes
+
+- Add a `just nextest` task for local/CI use.
+- Add an **optional** GitHub Actions job that runs `cargo nextest run` on `ubuntu-latest` for Rust changes.
+
+## Impact
+
+- Affected specs: none (tooling-only)
+- Affected code: `.github/workflows/ci.yml`, `justfile`
+- Affected runtime behavior: none

--- a/openspec/changes/add-ci-nextest/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-ci-nextest/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: CI provides an optional nextest path
+
+The repository SHALL provide a CI path that runs tests via `cargo nextest run` (optional / gradual adoption) to improve test feedback time and stability.
+
+#### Scenario: CI can run nextest without changing runtime behavior
+- **WHEN** a PR changes Rust code or tests
+- **THEN** CI runs a `cargo nextest run` job (in addition to existing checks)
+- **AND** the job does not change the compiled artifact behavior

--- a/openspec/changes/add-ci-nextest/tasks.md
+++ b/openspec/changes/add-ci-nextest/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Add `just nextest` recipe.
+- [x] 1.2 Add CI job that installs and runs `cargo nextest run` (optional / non-blocking).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing the CI nextest path (archive with `--skip-specs` since this is tooling-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate add-ci-nextest --strict`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
## Backlog / Issue
- `docs/dev/roadmap.md`: **M2-TST-020 (P1)** CI: optional nextest
- Closes #512

## What
Adds an optional `cargo nextest run` path in CI and a local `just nextest` entrypoint.

## How
- `justfile`: adds `nextest` recipe.
- `.github/workflows/ci.yml`: adds a non-blocking `Rust (ubuntu-latest, nextest)` job that installs `cargo-nextest` and runs `cargo nextest run --all --locked`.
- OpenSpec (tooling-only): `openspec/changes/add-ci-nextest/`

## Validation
- `openspec validate add-ci-nextest --strict`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
