### PR TITLE
refactor(handlers): share read-only planning pipeline

### DIFF
--- a/openspec/changes/refactor-command-handlers-readonly/proposal.md
+++ b/openspec/changes/refactor-command-handlers-readonly/proposal.md
@@ -1,0 +1,19 @@
+# Change: Refactor read-only command logic into handlers
+
+## Why
+
+Read-only commands (`plan`, `diff`, `preview`, and read-only views for TUI) duplicate the same “load engine → render desired state → resolve managed paths → compute plan” pipeline in multiple places. This increases maintenance cost and makes it easier for CLI/TUI to drift in behavior over time.
+
+Introducing a small handlers layer for the shared read-only planning pipeline improves maintainability while preserving user-facing behavior and stable JSON contracts.
+
+## What Changes
+
+- Add `src/handlers/` for shared command business logic.
+- Introduce a read-only planning helper (compute desired state + managed paths + plan).
+- Refactor CLI commands (`plan`, `diff`, `preview`, `deploy` plan-only path) and TUI read-only views to reuse the handler.
+
+## Impact
+
+- Affected specs: none (no user-facing behavior change)
+- Affected code: `src/cli/commands/*`, `src/tui_core.rs`, new `src/handlers/*`
+- Affected runtime behavior: none expected

--- a/openspec/changes/refactor-command-handlers-readonly/specs/agentpack/spec.md
+++ b/openspec/changes/refactor-command-handlers-readonly/specs/agentpack/spec.md
@@ -1,0 +1,11 @@
+# agentpack Delta
+
+## ADDED Requirements
+
+### Requirement: Read-only command planning logic is centralized
+
+The repository SHALL keep the shared read-only planning pipeline (desired-state rendering + managed-path resolution + plan computation) centralized in a handlers module to reduce drift between CLI and TUI implementations, without changing user-facing behavior.
+
+#### Scenario: readonly handler refactor preserves behavior
+- **WHEN** read-only command logic is reorganized
+- **THEN** the existing CLI, TUI, and journey tests continue to pass

--- a/openspec/changes/refactor-command-handlers-readonly/tasks.md
+++ b/openspec/changes/refactor-command-handlers-readonly/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add `src/handlers/read_only.rs` for shared planning pipeline.
+- [x] 1.2 Update CLI `plan`/`diff`/`preview`/`deploy` to use the handler.
+- [x] 1.3 Update `tui_core` read-only views to use the handler.
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing read-only handler modularization (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-command-handlers-readonly --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`

--- a/src/cli/commands/deploy.rs
+++ b/src/cli/commands/deploy.rs
@@ -1,36 +1,19 @@
-use crate::deploy::load_managed_paths_from_snapshot;
-use crate::deploy::plan as compute_plan;
 use crate::engine::Engine;
+use crate::handlers::read_only::read_only_context_in;
 use crate::output::{JsonEnvelope, print_json};
-use crate::state::latest_snapshot;
 use crate::user_error::UserError;
 
 use super::Ctx;
 
 pub(crate) fn run(ctx: &Ctx<'_>, apply: bool, adopt: bool) -> anyhow::Result<()> {
     let engine = Engine::load(ctx.cli.repo.as_deref(), ctx.cli.machine.as_deref())?;
-    let targets = super::super::util::selected_targets(&engine.manifest, &ctx.cli.target)?;
-    let render = engine.desired_state(&ctx.cli.profile, &ctx.cli.target)?;
-    let desired = render.desired;
-    let mut warnings = render.warnings;
-    let roots = render.roots;
-    let managed_paths_from_manifest =
-        crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
-    warnings.extend(managed_paths_from_manifest.warnings);
-    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
-    let managed_paths = if !managed_paths_from_manifest.is_empty() {
-        Some(super::super::util::filter_managed(
-            managed_paths_from_manifest,
-            &ctx.cli.target,
-        ))
-    } else {
-        latest_snapshot(&engine.home, &["deploy", "rollback"])?
-            .as_ref()
-            .map(load_managed_paths_from_snapshot)
-            .transpose()?
-            .map(|m| super::super::util::filter_managed(m, &ctx.cli.target))
-    };
-    let plan = compute_plan(&desired, managed_paths.as_ref())?;
+    let crate::handlers::read_only::ReadOnlyContext {
+        targets,
+        desired,
+        plan,
+        warnings,
+        roots,
+    } = read_only_context_in(&engine, &ctx.cli.profile, &ctx.cli.target)?;
 
     let will_apply = apply && !ctx.cli.dry_run;
 

--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -1,36 +1,21 @@
-use crate::deploy::load_managed_paths_from_snapshot;
-use crate::deploy::plan as compute_plan;
-use crate::engine::Engine;
+use crate::handlers::read_only::read_only_context;
 use crate::output::{JsonEnvelope, print_json};
-use crate::state::latest_snapshot;
 
 use super::Ctx;
 
 pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
-    let engine = Engine::load(ctx.cli.repo.as_deref(), ctx.cli.machine.as_deref())?;
-    let targets = super::super::util::selected_targets(&engine.manifest, &ctx.cli.target)?;
-    let render = engine.desired_state(&ctx.cli.profile, &ctx.cli.target)?;
-    let desired = render.desired;
-    let mut warnings = render.warnings;
-    let roots = render.roots;
-    let managed_paths_from_manifest =
-        crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
-    warnings.extend(managed_paths_from_manifest.warnings);
-    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
-    let managed_paths = if !managed_paths_from_manifest.is_empty() {
-        Some(super::super::util::filter_managed(
-            managed_paths_from_manifest,
-            &ctx.cli.target,
-        ))
-    } else {
-        latest_snapshot(&engine.home, &["deploy", "rollback"])?
-            .as_ref()
-            .map(load_managed_paths_from_snapshot)
-            .transpose()?
-            .map(|m| super::super::util::filter_managed(m, &ctx.cli.target))
-    };
-
-    let plan = compute_plan(&desired, managed_paths.as_ref())?;
+    let crate::handlers::read_only::ReadOnlyContext {
+        targets,
+        desired,
+        plan,
+        warnings,
+        ..
+    } = read_only_context(
+        ctx.cli.repo.as_deref(),
+        ctx.cli.machine.as_deref(),
+        &ctx.cli.profile,
+        &ctx.cli.target,
+    )?;
 
     if ctx.cli.json {
         let mut envelope = JsonEnvelope::ok(

--- a/src/cli/commands/plan.rs
+++ b/src/cli/commands/plan.rs
@@ -1,36 +1,20 @@
-use crate::deploy::load_managed_paths_from_snapshot;
-use crate::deploy::plan as compute_plan;
-use crate::engine::Engine;
+use crate::handlers::read_only::read_only_context;
 use crate::output::{JsonEnvelope, print_json};
-use crate::state::latest_snapshot;
 
 use super::Ctx;
 
 pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
-    let engine = Engine::load(ctx.cli.repo.as_deref(), ctx.cli.machine.as_deref())?;
-    let targets = super::super::util::selected_targets(&engine.manifest, &ctx.cli.target)?;
-    let render = engine.desired_state(&ctx.cli.profile, &ctx.cli.target)?;
-    let desired = render.desired;
-    let mut warnings = render.warnings;
-    let roots = render.roots;
-    let managed_paths_from_manifest =
-        crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
-    warnings.extend(managed_paths_from_manifest.warnings);
-    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
-    let managed_paths = if !managed_paths_from_manifest.is_empty() {
-        Some(super::super::util::filter_managed(
-            managed_paths_from_manifest,
-            &ctx.cli.target,
-        ))
-    } else {
-        latest_snapshot(&engine.home, &["deploy", "rollback"])?
-            .as_ref()
-            .map(load_managed_paths_from_snapshot)
-            .transpose()?
-            .map(|m| super::super::util::filter_managed(m, &ctx.cli.target))
-    };
-
-    let plan = compute_plan(&desired, managed_paths.as_ref())?;
+    let crate::handlers::read_only::ReadOnlyContext {
+        targets,
+        plan,
+        warnings,
+        ..
+    } = read_only_context(
+        ctx.cli.repo.as_deref(),
+        ctx.cli.machine.as_deref(),
+        &ctx.cli.profile,
+        &ctx.cli.target,
+    )?;
 
     if ctx.cli.json {
         let mut envelope = JsonEnvelope::ok(

--- a/src/cli/commands/preview.rs
+++ b/src/cli/commands/preview.rs
@@ -1,10 +1,7 @@
 use crate::deploy::TargetPath;
-use crate::deploy::load_managed_paths_from_snapshot;
-use crate::deploy::plan as compute_plan;
 use crate::diff::unified_diff;
-use crate::engine::Engine;
+use crate::handlers::read_only::read_only_context;
 use crate::output::{JsonEnvelope, print_json};
-use crate::state::latest_snapshot;
 
 use super::Ctx;
 
@@ -25,30 +22,18 @@ struct PreviewDiffFile {
 }
 
 pub(crate) fn run(ctx: &Ctx<'_>, diff: bool) -> anyhow::Result<()> {
-    let engine = Engine::load(ctx.cli.repo.as_deref(), ctx.cli.machine.as_deref())?;
-    let targets = super::super::util::selected_targets(&engine.manifest, &ctx.cli.target)?;
-    let render = engine.desired_state(&ctx.cli.profile, &ctx.cli.target)?;
-    let desired = render.desired;
-    let mut warnings = render.warnings;
-    let roots = render.roots;
-    let managed_paths_from_manifest =
-        crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
-    warnings.extend(managed_paths_from_manifest.warnings);
-    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
-    let managed_paths = if !managed_paths_from_manifest.is_empty() {
-        Some(super::super::util::filter_managed(
-            managed_paths_from_manifest,
-            &ctx.cli.target,
-        ))
-    } else {
-        latest_snapshot(&engine.home, &["deploy", "rollback"])?
-            .as_ref()
-            .map(load_managed_paths_from_snapshot)
-            .transpose()?
-            .map(|m| super::super::util::filter_managed(m, &ctx.cli.target))
-    };
-
-    let plan = compute_plan(&desired, managed_paths.as_ref())?;
+    let crate::handlers::read_only::ReadOnlyContext {
+        targets,
+        desired,
+        plan,
+        mut warnings,
+        roots,
+    } = read_only_context(
+        ctx.cli.repo.as_deref(),
+        ctx.cli.machine.as_deref(),
+        &ctx.cli.profile,
+        &ctx.cli.target,
+    )?;
 
     if ctx.cli.json {
         let plan_changes = plan.changes.clone();

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod read_only;

--- a/src/handlers/read_only.rs
+++ b/src/handlers/read_only.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+
+use crate::deploy::ManagedPaths;
+use crate::deploy::load_managed_paths_from_snapshot;
+use crate::deploy::plan as compute_plan;
+use crate::engine::Engine;
+use crate::state::latest_snapshot;
+use crate::targets::TargetRoot;
+
+#[derive(Debug)]
+pub(crate) struct ReadOnlyContext {
+    pub(crate) targets: Vec<String>,
+    pub(crate) desired: crate::deploy::DesiredState,
+    pub(crate) plan: crate::deploy::PlanResult,
+    pub(crate) warnings: Vec<String>,
+    pub(crate) roots: Vec<TargetRoot>,
+}
+
+pub(crate) fn read_only_context(
+    repo_override: Option<&Path>,
+    machine_override: Option<&str>,
+    profile: &str,
+    target_filter: &str,
+) -> anyhow::Result<ReadOnlyContext> {
+    let engine = Engine::load(repo_override, machine_override)?;
+    read_only_context_in(&engine, profile, target_filter)
+}
+
+pub(crate) fn read_only_context_in(
+    engine: &Engine,
+    profile: &str,
+    target_filter: &str,
+) -> anyhow::Result<ReadOnlyContext> {
+    let targets = crate::target_selection::selected_targets(&engine.manifest, target_filter)?;
+    let render = engine.desired_state(profile, target_filter)?;
+    let desired = render.desired;
+    let mut warnings = render.warnings;
+    let roots = render.roots;
+
+    let managed_paths = managed_paths_for_plan(engine, &roots, target_filter, &mut warnings)?;
+    let plan = compute_plan(&desired, managed_paths.as_ref())?;
+
+    Ok(ReadOnlyContext {
+        targets,
+        desired,
+        plan,
+        warnings,
+        roots,
+    })
+}
+
+fn managed_paths_for_plan(
+    engine: &Engine,
+    roots: &[TargetRoot],
+    target_filter: &str,
+    warnings: &mut Vec<String>,
+) -> anyhow::Result<Option<ManagedPaths>> {
+    let managed_paths_from_manifest =
+        crate::target_manifest::load_managed_paths_from_manifests(roots)?;
+    warnings.extend(managed_paths_from_manifest.warnings);
+    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
+
+    if !managed_paths_from_manifest.is_empty() {
+        return Ok(Some(filter_managed(
+            managed_paths_from_manifest,
+            target_filter,
+        )));
+    }
+
+    let latest = latest_snapshot(&engine.home, &["deploy", "rollback"])?;
+    Ok(latest
+        .as_ref()
+        .map(load_managed_paths_from_snapshot)
+        .transpose()?
+        .map(|m| filter_managed(m, target_filter)))
+}
+
+fn filter_managed(managed: ManagedPaths, target_filter: &str) -> ManagedPaths {
+    managed
+        .into_iter()
+        .filter(|tp| target_filter == "all" || tp.target == target_filter)
+        .collect()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod engine;
 pub mod events;
 pub mod fs;
 pub mod git;
+pub(crate) mod handlers;
 pub mod hash;
 pub mod ids;
 pub mod lockfile;


### PR DESCRIPTION
## Why
Reduce duplicated read-only planning code across CLI and TUI as a stepping stone for M3-REF-004 (shared command handlers).

## What
- Add `src/handlers/read_only.rs` for the shared read-only pipeline: selected targets → desired state → managed paths → plan.
- Update CLI `plan`/`diff`/`preview`/`deploy` to use the handler.
- Update `tui_core` read-only views to use the handler.

## Spec
- OpenSpec change: `openspec/changes/refactor-command-handlers-readonly/`

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate refactor-command-handlers-readonly --strict --no-interactive`

Closes #524.
