### PR TITLE
refactor(handlers): centralize deploy apply logic

### DIFF
--- a/openspec/changes/refactor-command-handlers-deploy-apply/proposal.md
+++ b/openspec/changes/refactor-command-handlers-deploy-apply/proposal.md
@@ -1,0 +1,21 @@
+# Change: Refactor deploy apply logic into handlers
+
+## Why
+
+Deploy apply logic is currently duplicated across:
+- CLI `deploy --apply`
+- TUI apply (`tui_apply`)
+
+This duplication increases maintenance cost and makes it easier for behavior/guardrails to drift over time.
+
+## What Changes
+
+- Add a deploy handler that centralizes the deploy apply pipeline (adopt guardrails, manifest-write behavior, apply execution).
+- Refactor CLI `deploy --apply` and `tui_apply` to reuse the handler.
+- Keep user-facing behavior and `--json` contracts unchanged.
+
+## Impact
+
+- Affected specs: none (refactor-only; no user-facing behavior change expected)
+- Affected code: `src/handlers/*`, `src/cli/commands/deploy.rs`, `src/tui_apply.rs`, `src/target_manifest.rs`
+- Affected runtime behavior: none expected (covered by existing CLI/TUI/journey tests)

--- a/openspec/changes/refactor-command-handlers-deploy-apply/specs/agentpack/spec.md
+++ b/openspec/changes/refactor-command-handlers-deploy-apply/specs/agentpack/spec.md
@@ -1,0 +1,11 @@
+# agentpack Delta
+
+## ADDED Requirements
+
+### Requirement: Deploy apply logic is centralized
+
+The repository SHALL centralize deploy apply business logic (adopt guardrails, manifest-write behavior, and apply execution) in a handlers module so CLI and TUI callers reuse a single implementation, without changing user-facing behavior.
+
+#### Scenario: deploy apply handler refactor preserves behavior
+- **WHEN** deploy apply logic is reorganized
+- **THEN** existing CLI, TUI, and journey tests continue to pass

--- a/openspec/changes/refactor-command-handlers-deploy-apply/tasks.md
+++ b/openspec/changes/refactor-command-handlers-deploy-apply/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [x] 1.1 Add `src/handlers/deploy.rs` for shared deploy apply logic and guardrails.
+- [x] 1.2 Move `manifests_missing_for_desired` logic into a non-CLI module (used by CLI/TUI/handlers).
+- [x] 1.3 Refactor CLI `deploy --apply` to use the handler (preserve `--json` behavior).
+- [x] 1.4 Refactor `tui_apply` to use the handler.
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing deploy apply handler modularization (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-command-handlers-deploy-apply --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`

--- a/src/handlers/deploy.rs
+++ b/src/handlers/deploy.rs
@@ -1,0 +1,97 @@
+use crate::engine::Engine;
+use crate::targets::TargetRoot;
+use crate::user_error::UserError;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ConfirmationStyle {
+    /// `--json` mode: mutating operations require `--yes`.
+    JsonYes { command_id: &'static str },
+    /// Interactive callers can prompt the user when changes exist.
+    Interactive,
+    /// Non-interactive callers require an explicit `confirmed=true` input.
+    Explicit,
+}
+
+#[derive(Debug)]
+pub(crate) enum DeployApplyOutcome {
+    NoChanges,
+    NeedsConfirmation,
+    Applied { snapshot_id: String },
+}
+
+pub(crate) fn deploy_apply_in(
+    engine: &Engine,
+    plan: &crate::deploy::PlanResult,
+    desired: &crate::deploy::DesiredState,
+    roots: &[TargetRoot],
+    adopt: bool,
+    confirmed: bool,
+    confirmation_style: ConfirmationStyle,
+) -> anyhow::Result<DeployApplyOutcome> {
+    match confirmation_style {
+        ConfirmationStyle::JsonYes { command_id } => {
+            if !confirmed {
+                return Err(UserError::confirm_required(command_id));
+            }
+        }
+        ConfirmationStyle::Explicit => {
+            if !confirmed {
+                return Err(anyhow::Error::new(UserError::new(
+                    "E_CONFIRM_REQUIRED",
+                    "refusing to apply without explicit confirmation",
+                )));
+            }
+        }
+        ConfirmationStyle::Interactive => {}
+    }
+
+    ensure_adopt_ok(plan, adopt)?;
+
+    let needs_manifests = crate::target_manifest::manifests_missing_for_desired(roots, desired);
+    if plan.changes.is_empty() && !needs_manifests {
+        return Ok(DeployApplyOutcome::NoChanges);
+    }
+
+    if !confirmed {
+        return Ok(DeployApplyOutcome::NeedsConfirmation);
+    }
+
+    let lockfile_path = engine
+        .repo
+        .lockfile_path
+        .exists()
+        .then_some(engine.repo.lockfile_path.as_path());
+    let snapshot =
+        crate::apply::apply_plan(&engine.home, "deploy", plan, desired, lockfile_path, roots)?;
+
+    Ok(DeployApplyOutcome::Applied {
+        snapshot_id: snapshot.id,
+    })
+}
+
+fn ensure_adopt_ok(plan: &crate::deploy::PlanResult, adopt: bool) -> anyhow::Result<()> {
+    let adopt_updates: Vec<&crate::deploy::PlanChange> = plan
+        .changes
+        .iter()
+        .filter(|c| matches!(c.update_kind, Some(crate::deploy::UpdateKind::AdoptUpdate)))
+        .collect();
+    if adopt_updates.is_empty() || adopt {
+        return Ok(());
+    }
+
+    let mut sample_paths: Vec<String> = adopt_updates.iter().map(|c| c.path.clone()).collect();
+    sample_paths.sort();
+    sample_paths.truncate(20);
+
+    Err(anyhow::Error::new(
+        UserError::new(
+            "E_ADOPT_CONFIRM_REQUIRED",
+            "refusing to overwrite unmanaged existing files without --adopt",
+        )
+        .with_details(serde_json::json!({
+            "flag": "--adopt",
+            "adopt_updates": adopt_updates.len(),
+            "sample_paths": sample_paths,
+        })),
+    ))
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod deploy;
 pub(crate) mod read_only;

--- a/src/target_manifest.rs
+++ b/src/target_manifest.rs
@@ -227,3 +227,54 @@ fn ensure_safe_relative_path(p: &str) -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+fn best_root_idx(roots: &[TargetRoot], target: &str, path: &Path) -> Option<usize> {
+    roots
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.target == target)
+        .filter(|(_, r)| path.strip_prefix(&r.root).is_ok())
+        .max_by_key(|(_, r)| r.root.components().count())
+        .map(|(idx, _)| idx)
+}
+
+pub(crate) fn manifests_missing_for_desired(
+    roots: &[TargetRoot],
+    desired: &crate::deploy::DesiredState,
+) -> bool {
+    if roots.is_empty() {
+        return false;
+    }
+
+    let mut used: Vec<bool> = vec![false; roots.len()];
+    for tp in desired.keys() {
+        if let Some(idx) = best_root_idx(roots, &tp.target, &tp.path) {
+            used[idx] = true;
+        }
+    }
+
+    for (idx, root) in roots.iter().enumerate() {
+        if !used[idx] {
+            continue;
+        }
+
+        let preferred = manifest_path_for_target(&root.root, &root.target);
+        if preferred.exists() {
+            continue;
+        }
+
+        let legacy = legacy_manifest_path(&root.root);
+        if !legacy.exists() {
+            return true;
+        }
+
+        // Avoid cross-target collisions: only treat legacy manifests as present when they belong
+        // to the expected target.
+        let (manifest, _warnings) = read_target_manifest_soft(&legacy, &root.target);
+        if manifest.is_none() {
+            return true;
+        }
+    }
+
+    false
+}

--- a/src/tui_apply.rs
+++ b/src/tui_apply.rs
@@ -1,10 +1,8 @@
 use std::path::Path;
 
-use crate::deploy::load_managed_paths_from_snapshot;
-use crate::deploy::plan as compute_plan;
 use crate::engine::Engine;
-use crate::state::latest_snapshot;
-use crate::targets::TargetRoot;
+use crate::handlers::deploy::{ConfirmationStyle, DeployApplyOutcome, deploy_apply_in};
+use crate::handlers::read_only::read_only_context_in;
 use crate::user_error::UserError;
 
 #[derive(Debug)]
@@ -39,137 +37,20 @@ pub fn apply_from_tui_in(
     adopt: bool,
     confirmed: bool,
 ) -> anyhow::Result<ApplyOutcome> {
-    if !confirmed {
-        return Err(anyhow::Error::new(UserError::new(
-            "E_CONFIRM_REQUIRED",
-            "refusing to apply without explicit confirmation",
-        )));
+    let ctx = read_only_context_in(engine, profile, target_filter)?;
+    match deploy_apply_in(
+        engine,
+        &ctx.plan,
+        &ctx.desired,
+        &ctx.roots,
+        adopt,
+        confirmed,
+        ConfirmationStyle::Explicit,
+    )? {
+        DeployApplyOutcome::NoChanges => Ok(ApplyOutcome::NoChanges),
+        DeployApplyOutcome::Applied { snapshot_id } => Ok(ApplyOutcome::Applied { snapshot_id }),
+        DeployApplyOutcome::NeedsConfirmation => anyhow::bail!(
+            "tui apply requires explicit confirmation, but confirmation was not provided"
+        ),
     }
-
-    let _targets = crate::target_selection::selected_targets(&engine.manifest, target_filter)?;
-    let render = engine.desired_state(profile, target_filter)?;
-    let desired = render.desired;
-    let mut warnings = render.warnings;
-    let roots = render.roots;
-    let managed_paths_from_manifest =
-        crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
-    warnings.extend(managed_paths_from_manifest.warnings);
-    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
-    let managed_paths = if !managed_paths_from_manifest.is_empty() {
-        Some(filter_managed(managed_paths_from_manifest, target_filter))
-    } else {
-        latest_snapshot(&engine.home, &["deploy", "rollback"])?
-            .as_ref()
-            .map(load_managed_paths_from_snapshot)
-            .transpose()?
-            .map(|m| filter_managed(m, target_filter))
-    };
-    let plan = compute_plan(&desired, managed_paths.as_ref())?;
-
-    let adopt_updates: Vec<&crate::deploy::PlanChange> = plan
-        .changes
-        .iter()
-        .filter(|c| matches!(c.update_kind, Some(crate::deploy::UpdateKind::AdoptUpdate)))
-        .collect();
-    if !adopt_updates.is_empty() && !adopt {
-        let mut sample_paths: Vec<String> = adopt_updates.iter().map(|c| c.path.clone()).collect();
-        sample_paths.sort();
-        sample_paths.truncate(20);
-
-        return Err(anyhow::Error::new(
-            UserError::new(
-                "E_ADOPT_CONFIRM_REQUIRED",
-                "refusing to overwrite unmanaged existing files without --adopt",
-            )
-            .with_details(serde_json::json!({
-                "flag": "--adopt",
-                "adopt_updates": adopt_updates.len(),
-                "sample_paths": sample_paths,
-            })),
-        ));
-    }
-
-    let needs_manifests = manifests_missing_for_desired(&roots, &desired);
-
-    if plan.changes.is_empty() && !needs_manifests {
-        return Ok(ApplyOutcome::NoChanges);
-    }
-
-    let lockfile_path = if engine.repo.lockfile_path.exists() {
-        Some(engine.repo.lockfile_path.as_path())
-    } else {
-        None
-    };
-    let snapshot = crate::apply::apply_plan(
-        &engine.home,
-        "deploy",
-        &plan,
-        &desired,
-        lockfile_path,
-        &roots,
-    )?;
-
-    Ok(ApplyOutcome::Applied {
-        snapshot_id: snapshot.id,
-    })
-}
-
-fn filter_managed(
-    managed: crate::deploy::ManagedPaths,
-    target_filter: &str,
-) -> crate::deploy::ManagedPaths {
-    managed
-        .into_iter()
-        .filter(|tp| target_filter == "all" || tp.target == target_filter)
-        .collect()
-}
-
-fn best_root_idx(roots: &[TargetRoot], target: &str, path: &Path) -> Option<usize> {
-    roots
-        .iter()
-        .enumerate()
-        .filter(|(_, r)| r.target == target)
-        .filter(|(_, r)| path.strip_prefix(&r.root).is_ok())
-        .max_by_key(|(_, r)| r.root.components().count())
-        .map(|(idx, _)| idx)
-}
-
-fn manifests_missing_for_desired(
-    roots: &[TargetRoot],
-    desired: &crate::deploy::DesiredState,
-) -> bool {
-    if roots.is_empty() {
-        return false;
-    }
-
-    let mut used: Vec<bool> = vec![false; roots.len()];
-    for tp in desired.keys() {
-        if let Some(idx) = best_root_idx(roots, &tp.target, &tp.path) {
-            used[idx] = true;
-        }
-    }
-
-    for (idx, root) in roots.iter().enumerate() {
-        if !used[idx] {
-            continue;
-        }
-
-        let preferred = crate::target_manifest::manifest_path_for_target(&root.root, &root.target);
-        if preferred.exists() {
-            continue;
-        }
-
-        let legacy = crate::target_manifest::legacy_manifest_path(&root.root);
-        if !legacy.exists() {
-            return true;
-        }
-
-        let (manifest, _warnings) =
-            crate::target_manifest::read_target_manifest_soft(&legacy, &root.target);
-        if manifest.is_none() {
-            return true;
-        }
-    }
-
-    false
 }


### PR DESCRIPTION
## Why
Deploy apply logic is duplicated between CLI `deploy --apply` and `tui_apply`, increasing drift risk for mutating guardrails and manifest-writing behavior.

## What
- Add `src/handlers/deploy.rs` to centralize deploy apply behavior (confirmation style, adopt guardrail, manifest-write behavior).
- Move `manifests_missing_for_desired` into `src/target_manifest.rs`.
- Refactor CLI `deploy --apply` and `src/tui_apply.rs` to reuse the handler.

## Spec
- OpenSpec change: `openspec/changes/refactor-command-handlers-deploy-apply/`

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate refactor-command-handlers-deploy-apply --strict --no-interactive`

Closes #527.
