### PR TITLE
refactor(handlers): centralize rollback logic

### DIFF
--- a/openspec/changes/refactor-command-handlers-rollback/proposal.md
+++ b/openspec/changes/refactor-command-handlers-rollback/proposal.md
@@ -1,0 +1,19 @@
+# Change: Refactor rollback command logic into handlers
+
+## Why
+
+As part of M3-REF-004 (shared command handlers), mutating command guardrails should be enforced in the handlers layer so CLI/MCP/TUI callers share a single source of truth.
+
+Rollback is a core mutating command and is a small, contained step toward that goal.
+
+## What Changes
+
+- Add a rollback handler that centralizes rollback execution and `--json` guardrails.
+- Refactor CLI `rollback` to delegate to the handler.
+- Keep user-facing behavior and `--json` contracts unchanged.
+
+## Impact
+
+- Affected specs: none (refactor-only; no user-facing behavior change expected)
+- Affected code: `src/handlers/*`, `src/cli/commands/rollback.rs`
+- Affected runtime behavior: none expected (covered by existing CLI/MCP/journey tests)

--- a/openspec/changes/refactor-command-handlers-rollback/specs/agentpack/spec.md
+++ b/openspec/changes/refactor-command-handlers-rollback/specs/agentpack/spec.md
@@ -1,0 +1,11 @@
+# agentpack Delta
+
+## ADDED Requirements
+
+### Requirement: Rollback logic is centralized
+
+The repository SHALL centralize rollback business logic and `--json` guardrails in a handlers module so callers reuse a single implementation, without changing user-facing behavior.
+
+#### Scenario: rollback handler refactor preserves behavior
+- **WHEN** rollback logic is reorganized
+- **THEN** existing CLI, MCP, and journey tests continue to pass

--- a/openspec/changes/refactor-command-handlers-rollback/tasks.md
+++ b/openspec/changes/refactor-command-handlers-rollback/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Add `src/handlers/rollback.rs` for rollback execution + guardrails.
+- [x] 1.2 Refactor CLI `rollback` to use the handler.
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing rollback handler modularization (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-command-handlers-rollback --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`

--- a/src/cli/commands/rollback.rs
+++ b/src/cli/commands/rollback.rs
@@ -1,13 +1,10 @@
-use anyhow::Context as _;
-
+use crate::handlers::rollback::rollback;
 use crate::output::{JsonEnvelope, print_json};
 
 use super::Ctx;
 
 pub(crate) fn run(ctx: &Ctx<'_>, snapshot_id: &str) -> anyhow::Result<()> {
-    super::super::util::require_yes_for_json_mutation(ctx.cli, "rollback")?;
-
-    let event = crate::apply::rollback(ctx.home, snapshot_id).context("rollback")?;
+    let event = rollback(ctx.home, snapshot_id, ctx.cli.json, ctx.cli.yes)?;
     if ctx.cli.json {
         let envelope = JsonEnvelope::ok(
             "rollback",

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod deploy;
 pub(crate) mod read_only;
+pub(crate) mod rollback;

--- a/src/handlers/rollback.rs
+++ b/src/handlers/rollback.rs
@@ -1,0 +1,17 @@
+use anyhow::Context as _;
+
+use crate::paths::AgentpackHome;
+use crate::user_error::UserError;
+
+pub(crate) fn rollback(
+    home: &AgentpackHome,
+    snapshot_id: &str,
+    json: bool,
+    yes: bool,
+) -> anyhow::Result<crate::state::DeploymentSnapshot> {
+    if json && !yes {
+        return Err(UserError::confirm_required("rollback"));
+    }
+
+    crate::apply::rollback(home, snapshot_id).context("rollback")
+}


### PR DESCRIPTION
## Why
As part of M3-REF-004 (shared handlers), mutating guardrails should be enforced in the handlers layer to reduce drift between callers.

## What
- Add `src/handlers/rollback.rs` to centralize rollback execution and `--json` confirmation guardrail.
- Refactor CLI `rollback` to delegate to the handler.

## Spec
- OpenSpec change: `openspec/changes/refactor-command-handlers-rollback/`

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
- `openspec validate refactor-command-handlers-rollback --strict --no-interactive`

Closes #530.
