### PR TITLE
M3-REF-004: MCP plan/diff call handlers (no subprocess)

### DIFF
--- a/openspec/changes/refactor-mcp-tools-plan-diff-handlers/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tools-plan-diff-handlers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/refactor-mcp-tools-plan-diff-handlers/README.md
+++ b/openspec/changes/refactor-mcp-tools-plan-diff-handlers/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-plan-diff-handlers
+
+Refactor MCP plan/diff tools to call handlers directly (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-plan-diff-handlers/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-plan-diff-handlers/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP plan/diff tools to call handlers directly
+
+## Why
+
+The MCP server currently shells out to `agentpack --json` for read-only tools like `plan` and `diff`. This duplicates argument/default handling, adds overhead, and blocks progress toward M3-REF-004 (single-source business logic across CLI/MCP/TUI).
+
+## What Changes
+
+- Update MCP `plan` and `diff` tools to compute results in-process via existing read-only handlers (`src/handlers/read_only.rs`).
+- Preserve the exact Agentpack `--json` envelope shape and stable error code behavior by mapping `UserError` into the MCP tool envelope (instead of treating failures as unexpected errors).
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-plan-diff-handlers/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-plan-diff-handlers/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP plan/diff run in-process
+The system SHALL compute MCP tools `plan` and `diff` in-process (without spawning an `agentpack --json` subprocess) by invoking the same read-only handler logic used by the CLI.
+
+#### Scenario: plan/diff use handlers and preserve stable envelopes
+- **WHEN** a client calls tool `plan` or `diff`
+- **THEN** the server returns an Agentpack JSON envelope with the expected `command` value
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-plan-diff-handlers/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-plan-diff-handlers/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to compute `plan`/`diff` JSON envelopes via `src/handlers/read_only.rs`.
+- [x] 1.2 Preserve CLI-style error envelope behavior (prefer `UserError` code/message/details when present).
+- [x] 1.3 Update MCP tool dispatch for `plan` and `diff` to use the in-process path (no subprocess).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `plan`/`diff` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-plan-diff-handlers --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
Closes #545

OpenSpec: `openspec/changes/refactor-mcp-tools-plan-diff-handlers/`

What
- MCP `plan` and `diff` tools compute results in-process via `src/handlers/read_only.rs` (no `agentpack --json` subprocess).
- Error envelopes preserve CLI-style `UserError` mapping when available.

Validation
- `openspec validate refactor-mcp-tools-plan-diff-handlers --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
