### PR TITLE
M3-REF-004: MCP doctor call handlers (no subprocess)

### DIFF
--- a/openspec/changes/refactor-mcp-tools-doctor-handler/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tools-doctor-handler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/refactor-mcp-tools-doctor-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-doctor-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-doctor-handler
+
+Refactor MCP doctor tool to call handlers directly (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-doctor-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-doctor-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP doctor tool to call handlers directly
+
+## Why
+
+The MCP server currently shells out to `agentpack --json` for `doctor`. This adds overhead and prevents MCP from directly reusing the same in-process business logic as the CLI/TUI, which is a core goal of M3-REF-004.
+
+## What Changes
+
+- Update MCP tool `doctor` to compute results in-process via `src/handlers/doctor.rs` (no `agentpack --json` subprocess).
+- Preserve the stable Agentpack JSON envelope and CLI-style error code mapping via `UserError`.
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-doctor-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-doctor-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP doctor runs in-process
+The system SHALL compute MCP tool `doctor` in-process (without spawning an `agentpack --json` subprocess) by invoking the same handler logic used by the CLI.
+
+#### Scenario: doctor uses handlers and preserves stable envelopes
+- **WHEN** a client calls tool `doctor`
+- **THEN** the server returns an Agentpack JSON envelope with `command = "doctor"`
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-doctor-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-doctor-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to compute `doctor` JSON envelopes via `src/handlers/doctor.rs`.
+- [x] 1.2 Preserve CLI-style `doctor --json` fields (including `data.next_actions`) and ordering.
+- [x] 1.3 Update MCP tool dispatch for `doctor` to use the in-process path (no subprocess).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `doctor` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-doctor-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
Closes #548

OpenSpec: `openspec/changes/refactor-mcp-tools-doctor-handler/`

What
- MCP `doctor` tool computes results in-process via `src/handlers/doctor.rs` (no `agentpack --json` subprocess).
- Preserves CLI-style `doctor --json` output shape, including `data.next_actions` ordering.

Validation
- `openspec validate refactor-mcp-tools-doctor-handler --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
