### PR TITLE
M3-REF-004: MCP deploy call handlers (no subprocess)

### DIFF
--- a/openspec/changes/refactor-mcp-tools-deploy-handler/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tools-deploy-handler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/refactor-mcp-tools-deploy-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-deploy-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-deploy-handler
+
+Refactor MCP deploy tool to compute plan in-process (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-deploy-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-deploy-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP deploy tool to compute plan in-process
+
+## Why
+
+The MCP server currently shells out to `agentpack --json deploy` for the deploy planning stage. This adds overhead and makes it harder to ensure MCP reuses the same in-process business logic as the CLI/TUI (M3-REF-004).
+
+## What Changes
+
+- Update MCP tool `deploy` to compute the deploy plan envelope in-process via existing handler logic (no `agentpack --json` subprocess).
+- Preserve the confirm-token flow by continuing to derive `confirm_plan_hash` from the stable envelope `data` and attaching `confirm_token` fields to the returned envelope.
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-deploy-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-deploy-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP deploy runs in-process for planning
+The system SHALL compute MCP tool `deploy` (planning stage) in-process (without spawning an `agentpack --json` subprocess) by invoking the same read-only handler logic used by the CLI.
+
+#### Scenario: deploy uses handlers and preserves stable envelopes
+- **WHEN** a client calls tool `deploy`
+- **THEN** the server returns an Agentpack JSON envelope with `command = "deploy"`
+- **AND** the server returns a confirm token bound to the computed plan (`confirm_token` + `confirm_plan_hash`)

--- a/openspec/changes/refactor-mcp-tools-deploy-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-deploy-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to compute the `deploy` plan JSON envelope (like `agentpack deploy --json` without `--apply`).
+- [x] 1.2 Preserve confirm token behavior (`confirm_plan_hash` computed from binding + envelope data; token + expiry injected into the envelope).
+- [x] 1.3 Update MCP tool dispatch for `deploy` to use the in-process path (no subprocess).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `deploy` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-deploy-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
Closes #551

OpenSpec: `openspec/changes/refactor-mcp-tools-deploy-handler/`

What
- MCP `deploy` tool computes the deploy plan envelope in-process (no `agentpack --json deploy` subprocess).
- Confirm token flow stays the same (plan hash computed from binding + envelope data; token fields injected into response).

Validation
- `openspec validate refactor-mcp-tools-deploy-handler --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
