### PR TITLE
refactor(mcp): run rollback in-process

### DIFF
--- a/openspec/changes/refactor-mcp-tools-rollback-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-rollback-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-rollback-handler
+
+Refactor MCP rollback tool to run in-process (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-rollback-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-rollback-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP rollback tool to call handler directly
+
+## Why
+
+The MCP server currently shells out to `agentpack --json` for the `rollback` tool. This duplicates CLI argument/default handling and blocks progress toward M3-REF-004 (single-source business logic across CLI/MCP/TUI).
+
+## What Changes
+
+- Update MCP `rollback` tool to execute in-process via the existing rollback handler (`src/handlers/rollback.rs`) rather than spawning an `agentpack --json` subprocess.
+- Preserve the exact Agentpack `--json` envelope shape and stable error code behavior by mapping `UserError` into the MCP tool envelope.
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-rollback-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-rollback-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP rollback runs in-process
+The system SHALL compute MCP tool `rollback` in-process (without spawning an `agentpack --json` subprocess) by invoking the same rollback handler logic used by the CLI.
+
+#### Scenario: rollback uses handler and preserves stable envelopes
+- **WHEN** a client calls tool `rollback`
+- **THEN** the server returns an Agentpack JSON envelope with the expected `command` value
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-rollback-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-rollback-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to compute the `rollback` JSON envelope via `src/handlers/rollback.rs`.
+- [x] 1.2 Preserve CLI-style error envelope behavior (prefer `UserError` code/message/details when present).
+- [x] 1.3 Update MCP tool dispatch for `rollback` to use the in-process path (no subprocess).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `rollback` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-rollback-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
## Summary
- Refactors MCP tool `rollback` to run in-process via `src/handlers/rollback.rs` (no `agentpack --json` subprocess).
- Preserves the CLI `--json` envelope shape and stable `UserError` code/message/details mapping.

## Motivation
This reduces overhead/duplication in the MCP server and continues the M3-REF-004 path toward single-source command logic across CLI/MCP/TUI.

## Testing
- `openspec validate refactor-mcp-tools-rollback-handler --strict --no-interactive`
- `cargo test --all --locked`

Closes #554.
