### PR TITLE
refactor(mcp): run evolve_restore in-process

### DIFF
--- a/openspec/changes/refactor-mcp-tools-evolve-restore-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-evolve-restore-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-evolve-restore-handler
+
+Refactor MCP evolve_restore tool to run in-process (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-evolve-restore-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-evolve-restore-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP evolve_restore tool to call handler directly
+
+## Why
+
+The MCP server currently shells out to `agentpack --json` for the `evolve_restore` tool. This duplicates CLI argument/default handling and blocks progress toward M3-REF-004 (single-source business logic across CLI/MCP/TUI).
+
+## What Changes
+
+- Update MCP `evolve_restore` tool to execute in-process via the existing evolve restore handler (`src/handlers/evolve.rs`) rather than spawning an `agentpack --json` subprocess.
+- Preserve the exact Agentpack `--json` envelope shape and stable error code behavior by mapping `UserError` into the MCP tool envelope.
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-evolve-restore-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-evolve-restore-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP evolve_restore runs in-process
+The system SHALL compute MCP tool `evolve_restore` in-process (without spawning an `agentpack --json` subprocess) by invoking the same evolve restore handler logic used by the CLI.
+
+#### Scenario: evolve_restore uses handler and preserves stable envelopes
+- **WHEN** a client calls tool `evolve_restore`
+- **THEN** the server returns an Agentpack JSON envelope with the expected `command` value
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-evolve-restore-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-evolve-restore-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to compute the `evolve_restore` JSON envelope via `src/handlers/evolve.rs`.
+- [x] 1.2 Preserve CLI-style error envelope behavior (prefer `UserError` code/message/details when present).
+- [x] 1.3 Update MCP tool dispatch for `evolve_restore` to use the in-process path (no subprocess).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `evolve_restore` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-evolve-restore-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
## Summary
- Refactors MCP tool `evolve_restore` to run in-process via `src/handlers/evolve.rs` (no `agentpack --json` subprocess).
- Preserves the CLI `--json` envelope shape and stable `UserError` code/message/details mapping.

## Motivation
This reduces overhead/duplication in the MCP server and continues the M3-REF-004 path toward single-source command logic across CLI/MCP/TUI.

## Testing
- `openspec validate refactor-mcp-tools-evolve-restore-handler --strict --no-interactive`
- `cargo test --all --locked`

Closes #557.
