### PR TITLE
refactor(mcp): run preview in-process

### DIFF
--- a/openspec/changes/refactor-mcp-tools-preview-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-preview-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-preview-handler
+
+Refactor MCP preview tool to run in-process (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-preview-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-preview-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP preview tool to call handlers directly
+
+## Why
+
+The MCP server currently shells out to `agentpack --json` for the `preview` tool. This duplicates CLI argument/default handling and blocks progress toward M3-REF-004 (single-source business logic across CLI/MCP/TUI).
+
+## What Changes
+
+- Update MCP `preview` tool to execute in-process via existing handler logic (`src/handlers/read_only.rs`), computing the same JSON envelope as `agentpack preview --json` (including `--diff` support).
+- Preserve the exact Agentpack `--json` envelope shape and stable error code behavior by mapping `UserError` into the MCP tool envelope.
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-preview-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-preview-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP preview runs in-process
+The system SHALL compute MCP tool `preview` in-process (without spawning an `agentpack --json` subprocess) by invoking the same handler logic used by the CLI.
+
+#### Scenario: preview uses handlers and preserves stable envelopes
+- **WHEN** a client calls tool `preview` (with `diff=true` or `diff=false`)
+- **THEN** the server returns an Agentpack JSON envelope with the expected `command` value
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-preview-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-preview-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to compute the `preview` JSON envelope (including `diff=true`) via `src/handlers/read_only.rs`.
+- [x] 1.2 Preserve CLI-style error envelope behavior (prefer `UserError` code/message/details when present).
+- [x] 1.3 Update MCP tool dispatch for `preview` to use the in-process path (no subprocess).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `preview` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-preview-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
## Summary
- Refactors MCP tool `preview` to run in-process (no `agentpack --json` subprocess).
- Preserves the CLI `--json` envelope shape, including `diff=true` unified diff generation and warning behavior.

## Motivation
This reduces overhead/duplication in the MCP server and continues the M3-REF-004 path toward single-source command logic across CLI/MCP/TUI.

## Testing
- `openspec validate refactor-mcp-tools-preview-handler --strict --no-interactive`
- `cargo test --all --locked`

Closes #560.
