### PR TITLE
refactor(mcp): run status in-process

### DIFF
--- a/openspec/changes/refactor-mcp-tools-status-handler/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tools-status-handler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/refactor-mcp-tools-status-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-status-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-status-handler
+
+Refactor MCP status tool to call handlers directly (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-status-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-status-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP status tool to call handlers directly
+
+## Why
+
+The MCP server still shells out to `agentpack status --json` for the `status` tool. This duplicates argument/default handling, adds overhead, and blocks progress toward M3-REF-004 (single-source business logic across CLI/MCP/TUI).
+
+## What Changes
+
+- Update MCP tool `status` to compute results in-process via the same handler logic used by the CLI (`src/handlers/status.rs` + existing engine/planning utilities).
+- Preserve the exact Agentpack `--json` envelope shape (including `data.next_actions` and `data.next_actions_detailed`) and stable error code behavior by mapping `UserError` into the MCP tool envelope.
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-status-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-status-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP status runs in-process
+The system SHALL compute MCP tool `status` in-process (without spawning an `agentpack --json` subprocess) by invoking the same handler logic used by the CLI.
+
+#### Scenario: status uses handlers and preserves stable envelopes
+- **WHEN** a client calls tool `status`
+- **THEN** the server returns an Agentpack JSON envelope with the expected `command` value
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-status-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-status-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to compute `status` JSON envelopes via `src/handlers/status.rs`.
+- [x] 1.2 Preserve CLI-style `status --json` fields (including `data.next_actions` and `data.next_actions_detailed`) and ordering.
+- [x] 1.3 Update MCP tool dispatch for `status` to use the in-process path (no subprocess).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `status` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-status-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
Closes #564.

Moves MCP tool `status` off the `agentpack --json` subprocess path and onto in-process handler logic while preserving the CLI JSON envelope (including `data.next_actions` + `data.next_actions_detailed` and operator-asset warnings).

## Tests
- `openspec validate refactor-mcp-tools-status-handler --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
