### PR TITLE
refactor(mcp): run explain in-process

### DIFF
--- a/openspec/changes/refactor-mcp-tools-explain-handler/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tools-explain-handler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/refactor-mcp-tools-explain-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-explain-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-explain-handler
+
+Refactor MCP explain tool to call handlers directly (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-explain-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-explain-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP explain tool to call handlers directly
+
+## Why
+
+The MCP server still shells out to `agentpack explain ... --json` for the `explain` tool. This duplicates argument/default handling, adds overhead, and blocks progress toward M3-REF-004 (single-source business logic across CLI/MCP/TUI).
+
+## What Changes
+
+- Update MCP tool `explain` to compute results in-process using the same underlying logic as the CLI (`src/cli/commands/explain.rs` + shared utilities).
+- Preserve the exact Agentpack `--json` envelope shape and stable error code behavior by mapping `UserError` into the MCP tool envelope.
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-explain-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-explain-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP explain runs in-process
+The system SHALL compute MCP tool `explain` in-process (without spawning an `agentpack --json` subprocess) by invoking the same logic used by the CLI.
+
+#### Scenario: explain uses in-process logic and preserves stable envelopes
+- **WHEN** a client calls tool `explain` with `kind=plan|diff|status`
+- **THEN** the server returns an Agentpack JSON envelope with the expected `command` value
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-explain-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-explain-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to compute `explain` JSON envelopes for `kind=plan|diff|status`.
+- [x] 1.2 Preserve CLI-style `explain.* --json` fields and `command` values (including `explain.plan` and `explain.status`).
+- [x] 1.3 Update MCP tool dispatch for `explain` to use the in-process path (no subprocess).
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `explain` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-explain-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -960,6 +960,303 @@ async fn call_status_in_process(args: StatusArgs) -> anyhow::Result<(String, ser
     .context("mcp status handler task join")?
 }
 
+async fn call_explain_in_process(args: ExplainArgs) -> anyhow::Result<(String, serde_json::Value)> {
+    tokio::task::spawn_blocking(move || {
+        #[derive(serde::Serialize)]
+        struct ExplainedModule {
+            module_id: String,
+            module_type: Option<String>,
+            layer: Option<String>,
+            module_path: Option<String>,
+        }
+
+        #[derive(serde::Serialize)]
+        struct ExplainedChange {
+            op: String,
+            target: String,
+            path: String,
+            path_posix: String,
+            modules: Vec<ExplainedModule>,
+        }
+
+        #[derive(serde::Serialize)]
+        struct ExplainedDrift {
+            kind: String,
+            target: String,
+            path: String,
+            path_posix: String,
+            expected: Option<String>,
+            actual: Option<String>,
+            modules: Vec<String>,
+        }
+
+        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
+        let profile = args.common.profile.as_deref().unwrap_or("default");
+        let target = args.common.target.as_deref().unwrap_or("all");
+        let machine_override = args.common.machine.as_deref();
+
+        let command = match args.kind {
+            ExplainKindArg::Status => "explain.status",
+            ExplainKindArg::Plan | ExplainKindArg::Diff => "explain.plan",
+        };
+
+        let result = (|| -> anyhow::Result<(String, serde_json::Value)> {
+            let engine = crate::engine::Engine::load(repo_override.as_deref(), machine_override)?;
+
+            match args.kind {
+                ExplainKindArg::Plan | ExplainKindArg::Diff => {
+                    let targets = crate::cli::util::selected_targets(&engine.manifest, target)?;
+                    let render = engine.desired_state(profile, target)?;
+                    let desired = render.desired;
+                    let mut warnings = render.warnings;
+                    let roots = render.roots;
+
+                    let manifest_index = crate::cli::util::load_manifest_module_ids(&roots)?;
+                    warnings.extend(manifest_index.warnings);
+                    let manifest_index = manifest_index.index;
+
+                    let managed_paths_from_manifest =
+                        crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+                    warnings.extend(managed_paths_from_manifest.warnings);
+                    let managed_paths_from_manifest = managed_paths_from_manifest.managed_paths;
+                    let managed_paths = if !managed_paths_from_manifest.is_empty() {
+                        Some(crate::cli::util::filter_managed(
+                            managed_paths_from_manifest,
+                            target,
+                        ))
+                    } else {
+                        crate::state::latest_snapshot(&engine.home, &["deploy", "rollback"])?
+                            .as_ref()
+                            .map(crate::deploy::load_managed_paths_from_snapshot)
+                            .transpose()?
+                            .map(|m| crate::cli::util::filter_managed(m, target))
+                    };
+                    let plan = crate::deploy::plan(&desired, managed_paths.as_ref())?;
+
+                    let mut explained = Vec::new();
+                    for c in &plan.changes {
+                        let tp = crate::deploy::TargetPath {
+                            target: c.target.clone(),
+                            path: std::path::PathBuf::from(&c.path),
+                        };
+
+                        let module_ids = match c.op {
+                            crate::deploy::Op::Delete => {
+                                manifest_index.get(&tp).cloned().unwrap_or_default()
+                            }
+                            crate::deploy::Op::Create | crate::deploy::Op::Update => desired
+                                .get(&tp)
+                                .map(|f| f.module_ids.clone())
+                                .unwrap_or_default(),
+                        };
+
+                        let mut modules = Vec::new();
+                        for module_id in module_ids {
+                            let module = engine.manifest.modules.iter().find(|m| m.id == module_id);
+                            let module_type = module.map(|m| format!("{:?}", m.module_type));
+                            let module_path = module.and_then(|m| {
+                                crate::cli::util::module_rel_path_for_output(
+                                    m, &module_id, &tp, &roots,
+                                )
+                            });
+                            let layer = match (module, module_path.as_deref()) {
+                                (Some(m), Some(rel)) => Some(
+                                    crate::cli::util::source_layer_for_module_file(
+                                        &engine, m, rel,
+                                    )?,
+                                ),
+                                _ => None,
+                            };
+                            modules.push(ExplainedModule {
+                                module_id,
+                                module_type,
+                                layer,
+                                module_path,
+                            });
+                        }
+
+                        explained.push(ExplainedChange {
+                            op: format!("{:?}", c.op).to_lowercase(),
+                            target: c.target.clone(),
+                            path: c.path.clone(),
+                            path_posix: c.path_posix.clone(),
+                            modules,
+                        });
+                    }
+
+                    let mut envelope = crate::output::JsonEnvelope::ok(
+                        "explain.plan",
+                        serde_json::json!({
+                            "profile": profile,
+                            "targets": targets,
+                            "changes": explained,
+                        }),
+                    );
+                    envelope.warnings = warnings;
+                    let text = serde_json::to_string_pretty(&envelope)?;
+                    let envelope = serde_json::to_value(&envelope)?;
+                    Ok((text, envelope))
+                }
+                ExplainKindArg::Status => {
+                    let targets = crate::cli::util::selected_targets(&engine.manifest, target)?;
+                    let render = engine.desired_state(profile, target)?;
+                    let desired = render.desired;
+                    let mut warnings = render.warnings;
+                    let roots = render.roots;
+
+                    let manifest_index = crate::cli::util::load_manifest_module_ids(&roots)?;
+                    warnings.extend(manifest_index.warnings);
+                    let manifest_index = manifest_index.index;
+
+                    let managed_paths_from_manifest =
+                        crate::target_manifest::load_managed_paths_from_manifests(&roots)?;
+                    warnings.extend(managed_paths_from_manifest.warnings);
+                    let managed_paths_from_manifest = crate::cli::util::filter_managed(
+                        managed_paths_from_manifest.managed_paths,
+                        target,
+                    );
+
+                    let mut drift = Vec::new();
+                    if managed_paths_from_manifest.is_empty() {
+                        warnings.push(
+                            "no target manifests found; drift may be inaccurate (run deploy --apply to write manifests)".to_string(),
+                        );
+                        for (tp, desired_file) in &desired {
+                            let expected = format!(
+                                "sha256:{}",
+                                crate::hash::sha256_hex(&desired_file.bytes)
+                            );
+                            match std::fs::read(&tp.path) {
+                                Ok(actual_bytes) => {
+                                    let actual =
+                                        format!("sha256:{}", crate::hash::sha256_hex(&actual_bytes));
+                                    if actual != expected {
+                                        drift.push(ExplainedDrift {
+                                            kind: "modified".to_string(),
+                                            target: tp.target.clone(),
+                                            path: tp.path.to_string_lossy().to_string(),
+                                            path_posix: crate::paths::path_to_posix_string(&tp.path),
+                                            expected: Some(expected),
+                                            actual: Some(actual),
+                                            modules: desired_file.module_ids.clone(),
+                                        });
+                                    }
+                                }
+                                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                                    drift.push(ExplainedDrift {
+                                        kind: "missing".to_string(),
+                                        target: tp.target.clone(),
+                                        path: tp.path.to_string_lossy().to_string(),
+                                        path_posix: crate::paths::path_to_posix_string(&tp.path),
+                                        expected: Some(expected),
+                                        actual: None,
+                                        modules: desired_file.module_ids.clone(),
+                                    })
+                                }
+                                Err(err) => return Err(err).context("read deployed file"),
+                            }
+                        }
+                    } else {
+                        for tp in &managed_paths_from_manifest {
+                            let expected = desired
+                                .get(tp)
+                                .map(|f| format!("sha256:{}", crate::hash::sha256_hex(&f.bytes)));
+                            match std::fs::read(&tp.path) {
+                                Ok(actual_bytes) => {
+                                    let actual =
+                                        format!("sha256:{}", crate::hash::sha256_hex(&actual_bytes));
+                                    if let Some(exp) = &expected {
+                                        if &actual != exp {
+                                            drift.push(ExplainedDrift {
+                                                kind: "modified".to_string(),
+                                                target: tp.target.clone(),
+                                                path: tp.path.to_string_lossy().to_string(),
+                                                path_posix: crate::paths::path_to_posix_string(
+                                                    &tp.path,
+                                                ),
+                                                expected: Some(exp.clone()),
+                                                actual: Some(actual),
+                                                modules: manifest_index
+                                                    .get(tp)
+                                                    .cloned()
+                                                    .unwrap_or_default(),
+                                            });
+                                        }
+                                    } else {
+                                        drift.push(ExplainedDrift {
+                                            kind: "extra".to_string(),
+                                            target: tp.target.clone(),
+                                            path: tp.path.to_string_lossy().to_string(),
+                                            path_posix: crate::paths::path_to_posix_string(&tp.path),
+                                            expected: None,
+                                            actual: Some(actual),
+                                            modules: manifest_index
+                                                .get(tp)
+                                                .cloned()
+                                                .unwrap_or_default(),
+                                        });
+                                    }
+                                }
+                                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                                    if let Some(exp) = expected {
+                                        drift.push(ExplainedDrift {
+                                            kind: "missing".to_string(),
+                                            target: tp.target.clone(),
+                                            path: tp.path.to_string_lossy().to_string(),
+                                            path_posix: crate::paths::path_to_posix_string(
+                                                &tp.path,
+                                            ),
+                                            expected: Some(exp),
+                                            actual: None,
+                                            modules: manifest_index
+                                                .get(tp)
+                                                .cloned()
+                                                .unwrap_or_default(),
+                                        });
+                                    }
+                                }
+                                Err(err) => return Err(err).context("read deployed file"),
+                            }
+                        }
+                    }
+
+                    let mut envelope = crate::output::JsonEnvelope::ok(
+                        "explain.status",
+                        serde_json::json!({
+                            "profile": profile,
+                            "targets": targets,
+                            "drift": drift,
+                        }),
+                    );
+                    envelope.warnings = warnings;
+                    let text = serde_json::to_string_pretty(&envelope)?;
+                    let envelope = serde_json::to_value(&envelope)?;
+                    Ok((text, envelope))
+                }
+            }
+        })();
+
+        match result {
+            Ok(v) => Ok(v),
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = envelope_error(command, &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                Ok((text, envelope))
+            }
+        }
+    })
+    .await
+    .context("mcp explain handler task join")?
+}
+
 async fn call_rollback_in_process(
     args: RollbackArgs,
 ) -> anyhow::Result<(String, serde_json::Value)> {
@@ -1356,21 +1653,6 @@ fn cli_args_for_evolve_propose(evolve: &EvolveProposeArgs) -> Vec<String> {
         args.push(branch.clone());
     }
 
-    args
-}
-
-fn cli_args_for_explain(explain: &ExplainArgs) -> Vec<String> {
-    let mut args = vec!["--json".to_string()];
-    append_common_flags(&mut args, &explain.common);
-    args.push("explain".to_string());
-    args.push(
-        match explain.kind {
-            ExplainKindArg::Plan => "plan",
-            ExplainKindArg::Diff => "diff",
-            ExplainKindArg::Status => "status",
-        }
-        .to_string(),
-    );
     args
 }
 
@@ -1831,7 +2113,7 @@ pub(super) async fn call_tool(
         }
         "explain" => {
             let args = deserialize_args::<ExplainArgs>(request.arguments)?;
-            match call_agentpack_json(cli_args_for_explain(&args)).await {
+            match call_explain_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
                 Err(err) => Ok(CallToolResult::structured_error(envelope_error(
                     "explain",


### PR DESCRIPTION
Closes #567.

Moves MCP tool `explain` off the `agentpack --json` subprocess path and onto in-process logic while preserving the CLI JSON envelope (including `explain.plan` for `kind=plan|diff` and `explain.status` for `kind=status`).

## Tests
- `openspec validate refactor-mcp-tools-explain-handler --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
