### PR TITLE
refactor(mcp): run deploy_apply apply in-process

### DIFF
--- a/openspec/changes/refactor-mcp-tools-deploy-apply-handler/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tools-deploy-apply-handler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/refactor-mcp-tools-deploy-apply-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-deploy-apply-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-deploy-apply-handler
+
+Refactor MCP deploy_apply tool to apply in-process (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-deploy-apply-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-deploy-apply-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP deploy_apply tool to apply in-process
+
+## Why
+
+The MCP server still shells out to `agentpack deploy --apply --json` for the mutating `deploy_apply` tool. This adds overhead and blocks progress toward M3-REF-004 (single-source business logic across CLI/MCP/TUI), especially for the confirm-token apply path.
+
+## What Changes
+
+- Update MCP tool `deploy_apply` to execute the apply path in-process (using the existing deploy handler logic under `src/handlers/deploy.rs`).
+- Preserve the exact Agentpack `--json` envelope shape (`command = "deploy"`) and stable error codes (including confirm-token mismatch/expired/required).
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-deploy-apply-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-deploy-apply-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: MCP deploy_apply applies in-process
+The system SHALL compute and apply MCP tool `deploy_apply` in-process (without spawning an `agentpack --json` subprocess) while preserving confirm-token semantics.
+
+#### Scenario: deploy_apply reuses handlers and preserves stable envelopes
+- **WHEN** a client calls tool `deploy_apply` with `yes=true` and a valid `confirm_token`
+- **THEN** the server applies the deploy plan without spawning an `agentpack --json` subprocess
+- **AND** the server returns an Agentpack JSON envelope with `command = "deploy"`
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-deploy-apply-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-deploy-apply-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process MCP path to execute `deploy --apply` logic for `deploy_apply` (no subprocess) while keeping confirm-token validation.
+- [x] 1.2 Preserve CLI-style `deploy --apply --json` envelope fields (`applied`, `snapshot_id`, `reason`, `changes`, `summary`) and stable error codes.
+- [x] 1.3 Update MCP tool dispatch for `deploy_apply` to use the in-process apply path.
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `deploy_apply` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-deploy-apply-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`


### PR DESCRIPTION
Closes #570.

## What
- Run MCP tool `deploy_apply` in-process (no `agentpack --json` subprocess) while preserving confirm-token validation.

## Why
- Finish the last remaining MCP mutating tool that still spawned a subprocess, progressing M3-REF-004.

## Testing
- `openspec validate refactor-mcp-tools-deploy-apply-handler --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
