### PR TITLE
refactor(mcp): run evolve_propose in-process

### DIFF
--- a/openspec/changes/refactor-mcp-tools-evolve-propose-handler/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tools-evolve-propose-handler/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/refactor-mcp-tools-evolve-propose-handler/README.md
+++ b/openspec/changes/refactor-mcp-tools-evolve-propose-handler/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tools-evolve-propose-handler
+
+Refactor MCP evolve_propose tool to run in-process (remove CLI subprocess).

--- a/openspec/changes/refactor-mcp-tools-evolve-propose-handler/proposal.md
+++ b/openspec/changes/refactor-mcp-tools-evolve-propose-handler/proposal.md
@@ -1,0 +1,15 @@
+# Change: Refactor MCP evolve_propose tool to run in-process
+
+## Why
+
+The MCP server still shells out to `agentpack evolve propose --json` for the mutating `evolve_propose` tool. This adds overhead and is the last remaining MCP tool that spawns an `agentpack --json` subprocess, blocking progress toward M3-REF-004 (single-source business logic across CLI/MCP/TUI).
+
+## What Changes
+
+- Add an in-process handler for `evolve propose` and route MCP tool `evolve_propose` through it (no subprocess).
+- Preserve the exact Agentpack `--json` envelope shape (`command = "evolve.propose"`) and stable error codes.
+
+## Impact
+
+- Affected specs: none (refactor-only; expected no user-facing behavior change)
+- Affected code: `src/handlers/evolve.rs`, `src/cli/commands/evolve.rs`, `src/mcp/tools.rs`

--- a/openspec/changes/refactor-mcp-tools-evolve-propose-handler/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tools-evolve-propose-handler/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: MCP evolve_propose runs in-process
+The system SHALL compute and apply MCP tool `evolve_propose` in-process (without spawning an `agentpack --json` subprocess).
+
+#### Scenario: evolve_propose reuses handlers and preserves stable envelopes
+- **WHEN** a client calls tool `evolve_propose` in `--json` mode
+- **THEN** the server executes evolve propose without spawning an `agentpack --json` subprocess
+- **AND** the server returns an Agentpack JSON envelope with `command = "evolve.propose"`
+- **AND** on errors, the server returns an envelope with stable `UserError` codes when applicable

--- a/openspec/changes/refactor-mcp-tools-evolve-propose-handler/tasks.md
+++ b/openspec/changes/refactor-mcp-tools-evolve-propose-handler/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Add an in-process handler path for `evolve propose` that returns CLI-compatible `--json` envelopes without printing to stdout.
+- [x] 1.2 Update MCP tool dispatch for `evolve_propose` to use the in-process handler (no subprocess).
+- [x] 1.3 Preserve CLI-style `evolve.propose --json` envelope fields and stable error codes.
+
+## 2. Spec deltas
+
+- [x] 2.1 Add a delta requirement describing MCP `evolve_propose` in-process execution (archive with `--skip-specs` since this is refactor-only).
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate refactor-mcp-tools-evolve-propose-handler --strict --no-interactive`
+- [x] 3.2 `cargo fmt --all -- --check`
+- [x] 3.3 `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] 3.4 `cargo test --all --locked`

--- a/src/cli/commands/evolve.rs
+++ b/src/cli/commands/evolve.rs
@@ -1,13 +1,7 @@
-use anyhow::Context as _;
-
-use crate::deploy::TargetPath;
 use crate::engine::Engine;
-use crate::fs::write_atomic;
 use crate::output::{JsonEnvelope, print_json};
-use crate::user_error::UserError;
-use time::macros::format_description;
 
-use super::super::args::{EvolveCommands, EvolveScope, OverlayScope};
+use super::super::args::{EvolveCommands, EvolveScope};
 use super::Ctx;
 
 pub(crate) fn run(ctx: &Ctx<'_>, command: &EvolveCommands) -> anyhow::Result<()> {
@@ -37,331 +31,133 @@ fn evolve_propose(
     scope: EvolveScope,
     branch_override: Option<&str>,
 ) -> anyhow::Result<()> {
-    #[derive(serde::Serialize)]
-    struct ProposalItem {
-        module_id: String,
-        target: String,
-        path: String,
-        path_posix: String,
-    }
-
-    #[derive(serde::Serialize)]
-    struct Suggestion {
-        action: String,
-        reason: String,
-    }
-
-    #[derive(serde::Serialize)]
-    struct SkippedItem {
-        target: String,
-        path: String,
-        path_posix: String,
-        reason: String,
-        reason_code: String,
-        reason_message: String,
-        next_actions: Vec<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        module_id: Option<String>,
-        #[serde(skip_serializing_if = "Vec::is_empty", default)]
-        module_ids: Vec<String>,
-        #[serde(skip_serializing_if = "Vec::is_empty", default)]
-        suggestions: Vec<Suggestion>,
-    }
-
-    #[derive(Default, serde::Serialize)]
-    struct ProposalSummary {
-        drifted_proposeable: u64,
-        drifted_skipped: u64,
-        skipped_missing: u64,
-        skipped_multi_module: u64,
-        skipped_read_error: u64,
-    }
-
-    type MarkedSectionCandidates = Vec<(String, Vec<u8>)>;
-
-    fn try_propose_marked_instructions_sections(
-        desired_bytes: &[u8],
-        actual_bytes: &[u8],
-        module_ids: &[String],
-    ) -> anyhow::Result<Option<MarkedSectionCandidates>> {
-        if !desired_bytes
-            .windows(crate::markers::MODULE_SECTION_START_PREFIX.len())
-            .any(|w| w == crate::markers::MODULE_SECTION_START_PREFIX.as_bytes())
-        {
-            return Ok(None);
-        }
-        if !actual_bytes
-            .windows(crate::markers::MODULE_SECTION_START_PREFIX.len())
-            .any(|w| w == crate::markers::MODULE_SECTION_START_PREFIX.as_bytes())
-        {
-            return Ok(None);
-        }
-
-        let desired = match crate::markers::parse_module_sections_from_bytes(desired_bytes) {
-            Ok(v) => v,
-            Err(_) => return Ok(None),
-        };
-        let actual = match crate::markers::parse_module_sections_from_bytes(actual_bytes) {
-            Ok(v) => v,
-            Err(_) => return Ok(None),
-        };
-
-        if module_ids
-            .iter()
-            .any(|id| !desired.contains_key(id) || !actual.contains_key(id))
-        {
-            return Ok(None);
-        }
-
-        let mut out = Vec::new();
-        for module_id in module_ids {
-            let Some(desired_text) = desired.get(module_id) else {
-                continue;
-            };
-            let Some(actual_text) = actual.get(module_id) else {
-                continue;
-            };
-            if desired_text != actual_text {
-                out.push((module_id.clone(), actual_text.as_bytes().to_vec()));
-            }
-        }
-
-        if out.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(out))
-        }
-    }
-
-    let render = engine.desired_state(&cli.profile, &cli.target)?;
-    let desired = render.desired;
-    let roots = render.roots;
-
-    let mut summary = ProposalSummary::default();
-    let mut candidates: Vec<(String, TargetPath, Vec<u8>)> = Vec::new();
-    let mut instructions_sections: std::collections::BTreeMap<String, Vec<u8>> =
-        std::collections::BTreeMap::new();
-    let mut skipped: Vec<SkippedItem> = Vec::new();
-    let mut warnings: Vec<String> = Vec::new();
-
     let prefix = action_prefix(cli);
-    let suggestions_for_skipped_reason = |reason: &str| -> Vec<Suggestion> {
-        match reason {
-            "missing" => vec![
-                Suggestion {
-                    action: "agentpack evolve restore".to_string(),
-                    reason: "restore missing desired outputs (create-only)".to_string(),
-                },
-                Suggestion {
-                    action: "agentpack deploy --apply".to_string(),
-                    reason: "re-deploy desired state and write/update manifests".to_string(),
-                },
-            ],
-            "multi_module_output" => vec![
-                Suggestion {
-                    action: "Add per-module markers to aggregated instructions outputs".to_string(),
-                    reason: "allow evolve.propose to map drift back to a single module".to_string(),
-                },
-                Suggestion {
-                    action: "Split aggregated outputs so each file maps to one module".to_string(),
-                    reason: "avoid multi-module outputs that cannot be proposed safely".to_string(),
-                },
-            ],
-            _ => Vec::new(),
-        }
-    };
-    let reason_message_for_skipped_reason = |reason: &str| -> String {
-        match reason {
-            "missing" => "expected managed output is missing on disk (use evolve.restore or deploy to recreate)".to_string(),
-            "multi_module_output" => "output is produced by multiple modules and cannot be proposed safely (add markers or split outputs)".to_string(),
-            _ => reason.to_string(),
-        }
-    };
-    let next_actions_for_missing = |module_id: Option<&str>| -> Vec<String> {
-        let mut actions = Vec::new();
-        let mut restore = format!("{prefix} evolve restore");
-        if let Some(module_id) = module_id {
-            restore.push_str(&format!(" --module-id {module_id}"));
-        }
-        restore.push_str(" --yes --json");
-        actions.push(restore);
-        actions.push(format!("{prefix} deploy --apply --yes --json"));
-        actions
+    let handler_scope = match scope {
+        EvolveScope::Global => crate::handlers::evolve::EvolveScope::Global,
+        EvolveScope::Machine => crate::handlers::evolve::EvolveScope::Machine,
+        EvolveScope::Project => crate::handlers::evolve::EvolveScope::Project,
     };
 
-    for (tp, desired_file) in &desired {
-        if let Some(filter) = module_filter {
-            if !desired_file.module_ids.iter().any(|id| id == filter) {
-                continue;
-            }
+    let mut outcome = crate::handlers::evolve::evolve_propose_in(
+        engine,
+        crate::handlers::evolve::EvolveProposeInput {
+            profile: &cli.profile,
+            target_filter: &cli.target,
+            action_prefix: &prefix,
+            module_filter,
+            scope: handler_scope,
+            branch_override,
+            dry_run: cli.dry_run,
+            confirmed: cli.yes,
+            json: cli.json,
+        },
+    )?;
+
+    if matches!(
+        outcome,
+        crate::handlers::evolve::EvolveProposeOutcome::NeedsConfirmation
+    ) {
+        if !super::super::util::confirm("Create evolve proposal branch?")? {
+            println!("Aborted");
+            return Ok(());
         }
-
-        let actual = match std::fs::read(&tp.path) {
-            Ok(bytes) => Some(bytes),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
-            Err(err) => {
-                summary.skipped_read_error += 1;
-                warnings.push(format!(
-                    "evolve.propose: skipped {} {}: failed to read deployed file: {err}",
-                    tp.target,
-                    tp.path.display()
-                ));
-                continue;
-            }
-        };
-
-        let is_drifted = match &actual {
-            Some(bytes) => bytes != &desired_file.bytes,
-            None => true,
-        };
-        if !is_drifted {
-            continue;
-        }
-
-        if desired_file.module_ids.len() != 1 {
-            match &actual {
-                None => {
-                    summary.drifted_skipped += 1;
-                    summary.skipped_missing += 1;
-                    let reason = "missing".to_string();
-                    skipped.push(SkippedItem {
-                        target: tp.target.clone(),
-                        path: tp.path.to_string_lossy().to_string(),
-                        path_posix: crate::paths::path_to_posix_string(&tp.path),
-                        reason_code: reason.clone(),
-                        reason_message: reason_message_for_skipped_reason(&reason),
-                        next_actions: next_actions_for_missing(None),
-                        reason,
-                        module_id: None,
-                        module_ids: desired_file.module_ids.clone(),
-                        suggestions: suggestions_for_skipped_reason("missing"),
-                    });
-                }
-                Some(actual) => {
-                    if let Some(section_candidates) = try_propose_marked_instructions_sections(
-                        &desired_file.bytes,
-                        actual,
-                        &desired_file.module_ids,
-                    )? {
-                        for (module_id, bytes) in section_candidates {
-                            if let Some(prev) = instructions_sections.get(&module_id) {
-                                if prev != &bytes {
-                                    warnings.push(format!(
-                                        "evolve.propose: skipped {} {} section for {}: conflicting edits across aggregated outputs",
-                                        tp.target,
-                                        tp.path.display(),
-                                        module_id
-                                    ));
-                                    continue;
-                                }
-                                continue;
-                            }
-
-                            instructions_sections.insert(module_id.clone(), bytes.clone());
-                            summary.drifted_proposeable += 1;
-                            candidates.push((module_id, tp.clone(), bytes));
-                        }
-                        continue;
-                    }
-
-                    summary.drifted_skipped += 1;
-                    summary.skipped_multi_module += 1;
-                    let reason = "multi_module_output".to_string();
-                    skipped.push(SkippedItem {
-                        target: tp.target.clone(),
-                        path: tp.path.to_string_lossy().to_string(),
-                        path_posix: crate::paths::path_to_posix_string(&tp.path),
-                        reason_code: reason.clone(),
-                        reason_message: reason_message_for_skipped_reason(&reason),
-                        next_actions: Vec::new(),
-                        reason,
-                        module_id: None,
-                        module_ids: desired_file.module_ids.clone(),
-                        suggestions: suggestions_for_skipped_reason("multi_module_output"),
-                    });
-                }
-            }
-            continue;
-        }
-
-        let module_id = desired_file.module_ids[0].clone();
-        match actual {
-            Some(actual) => {
-                summary.drifted_proposeable += 1;
-                candidates.push((module_id, tp.clone(), actual));
-            }
-            None => {
-                summary.drifted_skipped += 1;
-                summary.skipped_missing += 1;
-                let reason = "missing".to_string();
-                skipped.push(SkippedItem {
-                    target: tp.target.clone(),
-                    path: tp.path.to_string_lossy().to_string(),
-                    path_posix: crate::paths::path_to_posix_string(&tp.path),
-                    reason_code: reason.clone(),
-                    reason_message: reason_message_for_skipped_reason(&reason),
-                    next_actions: next_actions_for_missing(Some(module_id.as_str())),
-                    reason,
-                    module_id: Some(module_id),
-                    module_ids: Vec::new(),
-                    suggestions: suggestions_for_skipped_reason("missing"),
-                });
-            }
-        }
+        outcome = crate::handlers::evolve::evolve_propose_in(
+            engine,
+            crate::handlers::evolve::EvolveProposeInput {
+                profile: &cli.profile,
+                target_filter: &cli.target,
+                action_prefix: &prefix,
+                module_filter,
+                scope: handler_scope,
+                branch_override,
+                dry_run: cli.dry_run,
+                confirmed: true,
+                json: false,
+            },
+        )?;
     }
 
-    let mut items: Vec<ProposalItem> = candidates
-        .iter()
-        .map(|(module_id, tp, _)| ProposalItem {
-            module_id: module_id.clone(),
-            target: tp.target.clone(),
-            path: tp.path.to_string_lossy().to_string(),
-            path_posix: crate::paths::path_to_posix_string(&tp.path),
-        })
-        .collect();
-    items.sort_by(|a, b| {
-        (a.module_id.as_str(), a.path.as_str()).cmp(&(b.module_id.as_str(), b.path.as_str()))
-    });
-
-    skipped.sort_by(|a, b| {
-        (a.reason.as_str(), a.target.as_str(), a.path.as_str()).cmp(&(
-            b.reason.as_str(),
-            b.target.as_str(),
-            b.path.as_str(),
-        ))
-    });
-
-    if items.is_empty() {
-        let reason = if skipped.is_empty() {
-            "no_drift"
-        } else {
-            "no_proposeable_drift"
-        };
-
-        if cli.json {
-            let envelope = JsonEnvelope::ok(
-                "evolve.propose",
-                serde_json::json!({
-                    "created": false,
-                    "reason": reason,
-                    "summary": summary,
-                    "skipped": skipped,
-                }),
-            );
-            let mut envelope = envelope;
-            envelope.warnings = warnings;
-            print_json(&envelope)?;
-        } else {
-            for w in warnings {
-                eprintln!("Warning: {w}");
-            }
-            if reason == "no_drift" {
-                println!("No drifted managed files to propose");
+    match outcome {
+        crate::handlers::evolve::EvolveProposeOutcome::Noop(report) => {
+            if cli.json {
+                let mut envelope = JsonEnvelope::ok(
+                    "evolve.propose",
+                    serde_json::json!({
+                        "created": false,
+                        "reason": report.reason,
+                        "summary": report.summary,
+                        "skipped": report.skipped,
+                    }),
+                );
+                envelope.warnings = report.warnings;
+                print_json(&envelope)?;
             } else {
-                println!("No proposeable drifted files to propose");
-                if !skipped.is_empty() {
+                for w in report.warnings {
+                    eprintln!("Warning: {w}");
+                }
+                if report.reason == "no_drift" {
+                    println!("No drifted managed files to propose");
+                } else {
+                    println!("No proposeable drifted files to propose");
+                    if !report.skipped.is_empty() {
+                        println!("Skipped drift (not proposeable):");
+                        for s in report.skipped {
+                            let who = s
+                                .module_id
+                                .as_deref()
+                                .map(|m| m.to_string())
+                                .unwrap_or_else(|| {
+                                    if s.module_ids.is_empty() {
+                                        "-".to_string()
+                                    } else {
+                                        s.module_ids.join(",")
+                                    }
+                                });
+                            println!("- {} {} {} modules={who}", s.reason, s.target, s.path);
+                            match s.reason.as_str() {
+                                "missing" => {
+                                    println!(
+                                        "  hint: run agentpack evolve restore (create-only) or agentpack deploy --apply"
+                                    );
+                                }
+                                "multi_module_output" => {
+                                    println!(
+                                        "  hint: add per-module markers to aggregated outputs or split outputs so each file maps to one module"
+                                    );
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+        crate::handlers::evolve::EvolveProposeOutcome::DryRun(report) => {
+            if cli.json {
+                let mut envelope = JsonEnvelope::ok(
+                    "evolve.propose",
+                    serde_json::json!({
+                        "created": false,
+                        "reason": "dry_run",
+                        "candidates": report.candidates,
+                        "skipped": report.skipped,
+                        "summary": report.summary,
+                    }),
+                );
+                envelope.warnings = report.warnings;
+                print_json(&envelope)?;
+            } else {
+                for w in report.warnings {
+                    eprintln!("Warning: {w}");
+                }
+                println!("Candidates (dry-run):");
+                for i in report.candidates {
+                    println!("- {} {} {}", i.module_id, i.target, i.path);
+                }
+                if !report.skipped.is_empty() {
                     println!("Skipped drift (not proposeable):");
-                    for s in skipped {
+                    for s in report.skipped {
                         let who = s
                             .module_id
                             .as_deref()
@@ -390,215 +186,41 @@ fn evolve_propose(
                     }
                 }
             }
+            Ok(())
         }
-        return Ok(());
-    }
+        crate::handlers::evolve::EvolveProposeOutcome::Created(report) => {
+            if let Some(warning) = report.commit_warning.as_deref() {
+                eprintln!("Warning: {warning}");
+            }
 
-    if cli.dry_run {
-        if cli.json {
-            let envelope = JsonEnvelope::ok(
-                "evolve.propose",
-                serde_json::json!({
-                    "created": false,
-                    "reason": "dry_run",
-                    "candidates": items,
-                    "skipped": skipped,
-                    "summary": summary,
-                }),
-            );
-            let mut envelope = envelope;
-            envelope.warnings = warnings;
-            print_json(&envelope)?;
-        } else {
-            for w in warnings {
-                eprintln!("Warning: {w}");
-            }
-            println!("Candidates (dry-run):");
-            for i in items {
-                println!("- {} {} {}", i.module_id, i.target, i.path);
-            }
-            if !skipped.is_empty() {
-                println!("Skipped drift (not proposeable):");
-                for s in skipped {
-                    let who = s
-                        .module_id
-                        .as_deref()
-                        .map(|m| m.to_string())
-                        .unwrap_or_else(|| {
-                            if s.module_ids.is_empty() {
-                                "-".to_string()
-                            } else {
-                                s.module_ids.join(",")
-                            }
-                        });
-                    println!("- {} {} {} modules={who}", s.reason, s.target, s.path);
-                    match s.reason.as_str() {
-                        "missing" => {
-                            println!(
-                                "  hint: run agentpack evolve restore (create-only) or agentpack deploy --apply"
-                            );
-                        }
-                        "multi_module_output" => {
-                            println!(
-                                "  hint: add per-module markers to aggregated outputs or split outputs so each file maps to one module"
-                            );
-                        }
-                        _ => {}
-                    }
+            if cli.json {
+                let envelope = JsonEnvelope::ok(
+                    "evolve.propose",
+                    serde_json::json!({
+                        "created": true,
+                        "branch": report.branch,
+                        "scope": report.scope,
+                        "files": report.files,
+                        "files_posix": report.files_posix,
+                        "committed": report.committed,
+                    }),
+                );
+                print_json(&envelope)?;
+            } else {
+                println!("Created proposal branch: {}", report.branch);
+                for f in &report.files {
+                    println!("- {f}");
+                }
+                if !report.committed {
+                    println!("Note: commit failed; changes are left on the proposal branch.");
                 }
             }
+            Ok(())
         }
-        return Ok(());
-    }
-
-    if cli.json && !cli.yes {
-        return Err(UserError::confirm_required("evolve propose"));
-    }
-    if !cli.json && !cli.yes && !super::super::util::confirm("Create evolve proposal branch?")? {
-        println!("Aborted");
-        return Ok(());
-    }
-
-    let repo_dir = engine.repo.repo_dir.as_path();
-    if !repo_dir.join(".git").exists() {
-        anyhow::bail!(
-            "config repo is not a git repository: {}",
-            repo_dir.display()
-        );
-    }
-
-    let status = crate::git::git_in(repo_dir, &["status", "--porcelain"])?;
-    if !status.trim().is_empty() {
-        anyhow::bail!("refusing to propose with a dirty working tree (commit or stash first)");
-    }
-
-    let original = crate::git::git_in(repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;
-    let original = original.trim().to_string();
-
-    let branch = branch_override.map(|s| s.to_string()).unwrap_or_else(|| {
-        let scope = match scope {
-            EvolveScope::Global => "global",
-            EvolveScope::Machine => "machine",
-            EvolveScope::Project => "project",
-        };
-        let module = if let Some(filter) = module_filter {
-            crate::store::sanitize_module_id(filter)
-        } else {
-            let mut uniq: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
-            for i in &items {
-                uniq.insert(i.module_id.as_str());
-            }
-            if uniq.len() == 1 {
-                crate::store::sanitize_module_id(uniq.iter().next().copied().unwrap_or("multi"))
-            } else {
-                "multi".to_string()
-            }
-        };
-        let now = time::OffsetDateTime::now_utc();
-        let timestamp = now
-            .format(format_description!(
-                "[year][month][day]T[hour][minute][second]Z"
-            ))
-            .unwrap_or_else(|_| "unknown".to_string());
-        let nanos = now.nanosecond();
-        format!("evolve/propose-{scope}-{module}-{timestamp}-{nanos:09}")
-    });
-
-    crate::git::git_in(repo_dir, &["checkout", "-b", branch.as_str()])?;
-
-    let mut touched = Vec::new();
-    for (module_id, output, actual) in &candidates {
-        let Some(module) = engine.manifest.modules.iter().find(|m| m.id == *module_id) else {
-            continue;
-        };
-        let Some(module_rel) =
-            super::super::util::module_rel_path_for_output(module, module_id, output, &roots)
-        else {
-            continue;
-        };
-
-        let overlay_dir = match scope {
-            EvolveScope::Global => {
-                super::super::util::overlay_dir_for_scope(engine, module_id, OverlayScope::Global)
-            }
-            EvolveScope::Machine => {
-                super::super::util::overlay_dir_for_scope(engine, module_id, OverlayScope::Machine)
-            }
-            EvolveScope::Project => {
-                super::super::util::overlay_dir_for_scope(engine, module_id, OverlayScope::Project)
-            }
-        };
-
-        let dst = overlay_dir.join(&module_rel);
-        if let Some(parent) = dst.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("create {}", parent.display()))?;
-        }
-        write_atomic(&dst, actual).with_context(|| format!("write {}", dst.display()))?;
-        touched.push(
-            dst.strip_prefix(&engine.repo.repo_dir)
-                .unwrap_or(&dst)
-                .to_string_lossy()
-                .to_string(),
-        );
-    }
-
-    if touched.is_empty() {
-        crate::git::git_in(repo_dir, &["checkout", original.as_str()]).ok();
-        anyhow::bail!("no proposeable files (only multi-module outputs or unknown modules)");
-    }
-
-    crate::git::git_in(repo_dir, &["add", "-A"])?;
-
-    let commit = std::process::Command::new("git")
-        .current_dir(repo_dir)
-        .args(["commit", "-m", "chore(evolve): propose overlay updates"])
-        .output();
-
-    let committed = match commit {
-        Ok(out) if out.status.success() => true,
-        Ok(out) => {
-            eprintln!(
-                "Warning: git commit failed: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-            false
-        }
-        Err(err) => {
-            eprintln!("Warning: failed to run git commit: {err}");
-            false
-        }
-    };
-
-    if committed {
-        crate::git::git_in(repo_dir, &["checkout", original.as_str()]).ok();
-    }
-
-    if cli.json {
-        let files_posix: Vec<String> = touched.iter().map(|p| p.replace('\\', "/")).collect();
-        let envelope = JsonEnvelope::ok(
-            "evolve.propose",
-            serde_json::json!({
-                "created": true,
-                "branch": branch,
-                "scope": scope,
-                "files": touched,
-                "files_posix": files_posix,
-                "committed": committed,
-            }),
-        );
-        print_json(&envelope)?;
-    } else {
-        println!("Created proposal branch: {branch}");
-        for f in &touched {
-            println!("- {f}");
-        }
-        if !committed {
-            println!("Note: commit failed; changes are left on the proposal branch.");
+        crate::handlers::evolve::EvolveProposeOutcome::NeedsConfirmation => {
+            anyhow::bail!("evolve propose requires confirmation, but confirmation was not provided")
         }
     }
-
-    Ok(())
 }
 
 fn evolve_restore(

--- a/src/handlers/evolve.rs
+++ b/src/handlers/evolve.rs
@@ -1,8 +1,10 @@
 use anyhow::Context as _;
 
+use crate::config::{Module, ModuleType};
 use crate::deploy::TargetPath;
 use crate::engine::Engine;
 use crate::user_error::UserError;
+use time::macros::format_description;
 
 #[derive(Debug)]
 pub(crate) enum EvolveRestoreOutcome {
@@ -124,5 +126,633 @@ pub(crate) fn evolve_restore_in(
         summary,
         warnings,
         reason,
+    }))
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum EvolveScope {
+    Global,
+    Machine,
+    Project,
+}
+
+#[derive(Debug)]
+pub(crate) enum EvolveProposeOutcome {
+    NeedsConfirmation,
+    Noop(EvolveProposeNoopReport),
+    DryRun(EvolveProposeDryRunReport),
+    Created(EvolveProposeCreatedReport),
+}
+
+#[derive(Debug)]
+pub(crate) struct EvolveProposeNoopReport {
+    pub(crate) reason: &'static str,
+    pub(crate) summary: EvolveProposeSummary,
+    pub(crate) skipped: Vec<EvolveProposeSkippedItem>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct EvolveProposeDryRunReport {
+    pub(crate) summary: EvolveProposeSummary,
+    pub(crate) candidates: Vec<EvolveProposeItem>,
+    pub(crate) skipped: Vec<EvolveProposeSkippedItem>,
+    pub(crate) warnings: Vec<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct EvolveProposeCreatedReport {
+    pub(crate) branch: String,
+    pub(crate) scope: EvolveScope,
+    pub(crate) files: Vec<String>,
+    pub(crate) files_posix: Vec<String>,
+    pub(crate) committed: bool,
+    pub(crate) commit_warning: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct EvolveProposeItem {
+    pub(crate) module_id: String,
+    pub(crate) target: String,
+    pub(crate) path: String,
+    pub(crate) path_posix: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct EvolveProposeSuggestion {
+    pub(crate) action: String,
+    pub(crate) reason: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct EvolveProposeSkippedItem {
+    pub(crate) target: String,
+    pub(crate) path: String,
+    pub(crate) path_posix: String,
+    pub(crate) reason: String,
+    pub(crate) reason_code: String,
+    pub(crate) reason_message: String,
+    pub(crate) next_actions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) module_id: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub(crate) module_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub(crate) suggestions: Vec<EvolveProposeSuggestion>,
+}
+
+#[derive(Default, Debug, Clone, serde::Serialize)]
+pub(crate) struct EvolveProposeSummary {
+    pub(crate) drifted_proposeable: u64,
+    pub(crate) drifted_skipped: u64,
+    pub(crate) skipped_missing: u64,
+    pub(crate) skipped_multi_module: u64,
+    pub(crate) skipped_read_error: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EvolveProposeInput<'a> {
+    pub(crate) profile: &'a str,
+    pub(crate) target_filter: &'a str,
+    pub(crate) action_prefix: &'a str,
+    pub(crate) module_filter: Option<&'a str>,
+    pub(crate) scope: EvolveScope,
+    pub(crate) branch_override: Option<&'a str>,
+    pub(crate) dry_run: bool,
+    pub(crate) confirmed: bool,
+    pub(crate) json: bool,
+}
+
+type MarkedSectionCandidates = Vec<(String, Vec<u8>)>;
+
+fn try_propose_marked_instructions_sections(
+    desired_bytes: &[u8],
+    actual_bytes: &[u8],
+    module_ids: &[String],
+) -> anyhow::Result<Option<MarkedSectionCandidates>> {
+    if !desired_bytes
+        .windows(crate::markers::MODULE_SECTION_START_PREFIX.len())
+        .any(|w| w == crate::markers::MODULE_SECTION_START_PREFIX.as_bytes())
+    {
+        return Ok(None);
+    }
+    if !actual_bytes
+        .windows(crate::markers::MODULE_SECTION_START_PREFIX.len())
+        .any(|w| w == crate::markers::MODULE_SECTION_START_PREFIX.as_bytes())
+    {
+        return Ok(None);
+    }
+
+    let desired = match crate::markers::parse_module_sections_from_bytes(desired_bytes) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let actual = match crate::markers::parse_module_sections_from_bytes(actual_bytes) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+
+    if module_ids
+        .iter()
+        .any(|id| !desired.contains_key(id) || !actual.contains_key(id))
+    {
+        return Ok(None);
+    }
+
+    let mut out = Vec::new();
+    for module_id in module_ids {
+        let Some(desired_text) = desired.get(module_id) else {
+            continue;
+        };
+        let Some(actual_text) = actual.get(module_id) else {
+            continue;
+        };
+        if desired_text != actual_text {
+            out.push((module_id.clone(), actual_text.as_bytes().to_vec()));
+        }
+    }
+
+    if out.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(out))
+    }
+}
+
+fn evolve_propose_reason_message(reason: &str) -> String {
+    match reason {
+        "missing" => "expected managed output is missing on disk (use evolve.restore or deploy to recreate)".to_string(),
+        "multi_module_output" => "output is produced by multiple modules and cannot be proposed safely (add markers or split outputs)".to_string(),
+        _ => reason.to_string(),
+    }
+}
+
+fn evolve_propose_suggestions(reason: &str) -> Vec<EvolveProposeSuggestion> {
+    match reason {
+        "missing" => vec![
+            EvolveProposeSuggestion {
+                action: "agentpack evolve restore".to_string(),
+                reason: "restore missing desired outputs (create-only)".to_string(),
+            },
+            EvolveProposeSuggestion {
+                action: "agentpack deploy --apply".to_string(),
+                reason: "re-deploy desired state and write/update manifests".to_string(),
+            },
+        ],
+        "multi_module_output" => vec![
+            EvolveProposeSuggestion {
+                action: "Add per-module markers to aggregated instructions outputs".to_string(),
+                reason: "allow evolve.propose to map drift back to a single module".to_string(),
+            },
+            EvolveProposeSuggestion {
+                action: "Split aggregated outputs so each file maps to one module".to_string(),
+                reason: "avoid multi-module outputs that cannot be proposed safely".to_string(),
+            },
+        ],
+        _ => Vec::new(),
+    }
+}
+
+fn evolve_propose_next_actions_for_missing(
+    action_prefix: &str,
+    module_id: Option<&str>,
+) -> Vec<String> {
+    let mut actions = Vec::new();
+
+    let mut restore = format!("{action_prefix} evolve restore");
+    if let Some(module_id) = module_id {
+        restore.push_str(&format!(" --module-id {module_id}"));
+    }
+    restore.push_str(" --yes --json");
+    actions.push(restore);
+
+    actions.push(format!("{action_prefix} deploy --apply --yes --json"));
+
+    actions
+}
+
+#[derive(Debug, Clone, Copy)]
+enum OverlayScope {
+    Global,
+    Machine,
+    Project,
+}
+
+fn overlay_dir_for_scope(
+    engine: &Engine,
+    module_id: &str,
+    scope: OverlayScope,
+) -> std::path::PathBuf {
+    let fs_key = crate::ids::module_fs_key(module_id);
+    let canonical = match scope {
+        OverlayScope::Global => engine.repo.repo_dir.join("overlays").join(&fs_key),
+        OverlayScope::Machine => engine
+            .repo
+            .repo_dir
+            .join("overlays/machines")
+            .join(&engine.machine_id)
+            .join(&fs_key),
+        OverlayScope::Project => engine
+            .repo
+            .repo_dir
+            .join("projects")
+            .join(&engine.project.project_id)
+            .join("overlays")
+            .join(&fs_key),
+    };
+
+    let legacy_fs_key = crate::ids::module_fs_key_unbounded(module_id);
+    let legacy_fs_key = (legacy_fs_key != fs_key).then(|| match scope {
+        OverlayScope::Global => engine.repo.repo_dir.join("overlays").join(&legacy_fs_key),
+        OverlayScope::Machine => engine
+            .repo
+            .repo_dir
+            .join("overlays/machines")
+            .join(&engine.machine_id)
+            .join(&legacy_fs_key),
+        OverlayScope::Project => engine
+            .repo
+            .repo_dir
+            .join("projects")
+            .join(&engine.project.project_id)
+            .join("overlays")
+            .join(&legacy_fs_key),
+    });
+
+    let legacy = crate::ids::is_safe_legacy_path_component(module_id).then(|| match scope {
+        OverlayScope::Global => engine.repo.repo_dir.join("overlays").join(module_id),
+        OverlayScope::Machine => engine
+            .repo
+            .repo_dir
+            .join("overlays/machines")
+            .join(&engine.machine_id)
+            .join(module_id),
+        OverlayScope::Project => engine
+            .repo
+            .repo_dir
+            .join("projects")
+            .join(&engine.project.project_id)
+            .join("overlays")
+            .join(module_id),
+    });
+
+    if canonical.exists() {
+        canonical
+    } else if legacy_fs_key.as_ref().is_some_and(|p| p.exists()) {
+        legacy_fs_key.expect("legacy fs_key exists")
+    } else if legacy.as_ref().is_some_and(|p| p.exists()) {
+        legacy.expect("legacy exists")
+    } else {
+        canonical
+    }
+}
+
+fn module_rel_path_for_output(
+    module: &Module,
+    module_id: &str,
+    output: &TargetPath,
+    roots: &[crate::targets::TargetRoot],
+) -> Option<String> {
+    match module.module_type {
+        ModuleType::Instructions => Some("AGENTS.md".to_string()),
+        ModuleType::Prompt | ModuleType::Command => output
+            .path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string()),
+        ModuleType::Skill => {
+            let best = crate::targets::best_root_for(roots, &output.target, &output.path)?;
+            let rel = output.path.strip_prefix(&best.root).ok()?;
+            let rel_str = rel.to_string_lossy().replace('\\', "/");
+            let skill_name = crate::cli::util::module_name_from_id(module_id);
+            let Some((first, rest)) = rel_str.split_once('/') else {
+                return Some(rel_str);
+            };
+            if first == skill_name && !rest.is_empty() {
+                Some(rest.to_string())
+            } else {
+                Some(rel_str)
+            }
+        }
+    }
+}
+
+pub(crate) fn evolve_propose_in(
+    engine: &Engine,
+    input: EvolveProposeInput<'_>,
+) -> anyhow::Result<EvolveProposeOutcome> {
+    let EvolveProposeInput {
+        profile,
+        target_filter,
+        action_prefix,
+        module_filter,
+        scope,
+        branch_override,
+        dry_run,
+        confirmed,
+        json,
+    } = input;
+
+    let render = engine.desired_state(profile, target_filter)?;
+    let desired = render.desired;
+    let roots = render.roots;
+
+    let mut summary = EvolveProposeSummary::default();
+    let mut candidates: Vec<(String, TargetPath, Vec<u8>)> = Vec::new();
+    let mut instructions_sections: std::collections::BTreeMap<String, Vec<u8>> =
+        std::collections::BTreeMap::new();
+    let mut skipped: Vec<EvolveProposeSkippedItem> = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
+
+    for (tp, desired_file) in &desired {
+        if let Some(filter) = module_filter {
+            if !desired_file.module_ids.iter().any(|id| id == filter) {
+                continue;
+            }
+        }
+
+        let actual = match std::fs::read(&tp.path) {
+            Ok(bytes) => Some(bytes),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+            Err(err) => {
+                summary.skipped_read_error += 1;
+                warnings.push(format!(
+                    "evolve.propose: skipped {} {}: failed to read deployed file: {err}",
+                    tp.target,
+                    tp.path.display()
+                ));
+                continue;
+            }
+        };
+
+        let is_drifted = match &actual {
+            Some(bytes) => bytes != &desired_file.bytes,
+            None => true,
+        };
+        if !is_drifted {
+            continue;
+        }
+
+        if desired_file.module_ids.len() != 1 {
+            match &actual {
+                None => {
+                    summary.drifted_skipped += 1;
+                    summary.skipped_missing += 1;
+                    let reason = "missing".to_string();
+                    skipped.push(EvolveProposeSkippedItem {
+                        target: tp.target.clone(),
+                        path: tp.path.to_string_lossy().to_string(),
+                        path_posix: crate::paths::path_to_posix_string(&tp.path),
+                        reason_code: reason.clone(),
+                        reason_message: evolve_propose_reason_message(&reason),
+                        next_actions: evolve_propose_next_actions_for_missing(action_prefix, None),
+                        reason,
+                        module_id: None,
+                        module_ids: desired_file.module_ids.clone(),
+                        suggestions: evolve_propose_suggestions("missing"),
+                    });
+                }
+                Some(actual) => {
+                    if let Some(section_candidates) = try_propose_marked_instructions_sections(
+                        &desired_file.bytes,
+                        actual,
+                        &desired_file.module_ids,
+                    )? {
+                        for (module_id, bytes) in section_candidates {
+                            if let Some(prev) = instructions_sections.get(&module_id) {
+                                if prev != &bytes {
+                                    warnings.push(format!(
+                                        "evolve.propose: skipped {} {} section for {}: conflicting edits across aggregated outputs",
+                                        tp.target,
+                                        tp.path.display(),
+                                        module_id
+                                    ));
+                                    continue;
+                                }
+                                continue;
+                            }
+
+                            instructions_sections.insert(module_id.clone(), bytes.clone());
+                            summary.drifted_proposeable += 1;
+                            candidates.push((module_id, tp.clone(), bytes));
+                        }
+                        continue;
+                    }
+
+                    summary.drifted_skipped += 1;
+                    summary.skipped_multi_module += 1;
+                    let reason = "multi_module_output".to_string();
+                    skipped.push(EvolveProposeSkippedItem {
+                        target: tp.target.clone(),
+                        path: tp.path.to_string_lossy().to_string(),
+                        path_posix: crate::paths::path_to_posix_string(&tp.path),
+                        reason_code: reason.clone(),
+                        reason_message: evolve_propose_reason_message(&reason),
+                        next_actions: Vec::new(),
+                        reason,
+                        module_id: None,
+                        module_ids: desired_file.module_ids.clone(),
+                        suggestions: evolve_propose_suggestions("multi_module_output"),
+                    });
+                }
+            }
+            continue;
+        }
+
+        let module_id = desired_file.module_ids[0].clone();
+        match actual {
+            Some(actual) => {
+                summary.drifted_proposeable += 1;
+                candidates.push((module_id, tp.clone(), actual));
+            }
+            None => {
+                summary.drifted_skipped += 1;
+                summary.skipped_missing += 1;
+                let reason = "missing".to_string();
+                skipped.push(EvolveProposeSkippedItem {
+                    target: tp.target.clone(),
+                    path: tp.path.to_string_lossy().to_string(),
+                    path_posix: crate::paths::path_to_posix_string(&tp.path),
+                    reason_code: reason.clone(),
+                    reason_message: evolve_propose_reason_message(&reason),
+                    next_actions: evolve_propose_next_actions_for_missing(
+                        action_prefix,
+                        Some(module_id.as_str()),
+                    ),
+                    reason,
+                    module_id: Some(module_id),
+                    module_ids: Vec::new(),
+                    suggestions: evolve_propose_suggestions("missing"),
+                });
+            }
+        }
+    }
+
+    let mut items: Vec<EvolveProposeItem> = candidates
+        .iter()
+        .map(|(module_id, tp, _)| EvolveProposeItem {
+            module_id: module_id.clone(),
+            target: tp.target.clone(),
+            path: tp.path.to_string_lossy().to_string(),
+            path_posix: crate::paths::path_to_posix_string(&tp.path),
+        })
+        .collect();
+    items.sort_by(|a, b| {
+        (a.module_id.as_str(), a.path.as_str()).cmp(&(b.module_id.as_str(), b.path.as_str()))
+    });
+
+    skipped.sort_by(|a, b| {
+        (a.reason.as_str(), a.target.as_str(), a.path.as_str()).cmp(&(
+            b.reason.as_str(),
+            b.target.as_str(),
+            b.path.as_str(),
+        ))
+    });
+
+    if items.is_empty() {
+        let reason = if skipped.is_empty() {
+            "no_drift"
+        } else {
+            "no_proposeable_drift"
+        };
+
+        return Ok(EvolveProposeOutcome::Noop(EvolveProposeNoopReport {
+            reason,
+            summary,
+            skipped,
+            warnings,
+        }));
+    }
+
+    if dry_run {
+        return Ok(EvolveProposeOutcome::DryRun(EvolveProposeDryRunReport {
+            candidates: items,
+            skipped,
+            summary,
+            warnings,
+        }));
+    }
+
+    if !confirmed {
+        if json {
+            return Err(UserError::confirm_required("evolve propose"));
+        }
+        return Ok(EvolveProposeOutcome::NeedsConfirmation);
+    }
+
+    let repo_dir = engine.repo.repo_dir.as_path();
+    if !repo_dir.join(".git").exists() {
+        anyhow::bail!(
+            "config repo is not a git repository: {}",
+            repo_dir.display()
+        );
+    }
+
+    let status = crate::git::git_in(repo_dir, &["status", "--porcelain"])?;
+    if !status.trim().is_empty() {
+        anyhow::bail!("refusing to propose with a dirty working tree (commit or stash first)");
+    }
+
+    let original = crate::git::git_in(repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    let original = original.trim().to_string();
+
+    let branch = branch_override.map(|s| s.to_string()).unwrap_or_else(|| {
+        let scope_str = match scope {
+            EvolveScope::Global => "global",
+            EvolveScope::Machine => "machine",
+            EvolveScope::Project => "project",
+        };
+        let module = if let Some(filter) = module_filter {
+            crate::store::sanitize_module_id(filter)
+        } else {
+            let mut uniq: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+            for i in &items {
+                uniq.insert(i.module_id.as_str());
+            }
+            if uniq.len() == 1 {
+                crate::store::sanitize_module_id(uniq.iter().next().copied().unwrap_or("multi"))
+            } else {
+                "multi".to_string()
+            }
+        };
+        let now = time::OffsetDateTime::now_utc();
+        let timestamp = now
+            .format(format_description!(
+                "[year][month][day]T[hour][minute][second]Z"
+            ))
+            .unwrap_or_else(|_| "unknown".to_string());
+        let nanos = now.nanosecond();
+        format!("evolve/propose-{scope_str}-{module}-{timestamp}-{nanos:09}")
+    });
+
+    crate::git::git_in(repo_dir, &["checkout", "-b", branch.as_str()])?;
+
+    let mut touched = Vec::new();
+    for (module_id, output, actual) in &candidates {
+        let Some(module) = engine.manifest.modules.iter().find(|m| m.id == *module_id) else {
+            continue;
+        };
+        let Some(module_rel) = module_rel_path_for_output(module, module_id, output, &roots) else {
+            continue;
+        };
+
+        let overlay_dir = match scope {
+            EvolveScope::Global => overlay_dir_for_scope(engine, module_id, OverlayScope::Global),
+            EvolveScope::Machine => overlay_dir_for_scope(engine, module_id, OverlayScope::Machine),
+            EvolveScope::Project => overlay_dir_for_scope(engine, module_id, OverlayScope::Project),
+        };
+
+        let dst = overlay_dir.join(&module_rel);
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        crate::fs::write_atomic(&dst, actual)
+            .with_context(|| format!("write {}", dst.display()))?;
+        touched.push(
+            dst.strip_prefix(&engine.repo.repo_dir)
+                .unwrap_or(&dst)
+                .to_string_lossy()
+                .to_string(),
+        );
+    }
+
+    if touched.is_empty() {
+        crate::git::git_in(repo_dir, &["checkout", original.as_str()]).ok();
+        anyhow::bail!("no proposeable files (only multi-module outputs or unknown modules)");
+    }
+
+    crate::git::git_in(repo_dir, &["add", "-A"])?;
+
+    let commit = std::process::Command::new("git")
+        .current_dir(repo_dir)
+        .args(["commit", "-m", "chore(evolve): propose overlay updates"])
+        .output();
+
+    let (committed, commit_warning) = match commit {
+        Ok(out) if out.status.success() => (true, None),
+        Ok(out) => (
+            false,
+            Some(format!(
+                "git commit failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            )),
+        ),
+        Err(err) => (false, Some(format!("failed to run git commit: {err}"))),
+    };
+
+    if committed {
+        crate::git::git_in(repo_dir, &["checkout", original.as_str()]).ok();
+    }
+
+    let files_posix: Vec<String> = touched.iter().map(|p| p.replace('\\', "/")).collect();
+    Ok(EvolveProposeOutcome::Created(EvolveProposeCreatedReport {
+        branch,
+        scope,
+        files: touched,
+        files_posix,
+        committed,
+        commit_warning,
     }))
 }


### PR DESCRIPTION
Closes #573.

## What
- Adds an in-process handler for `evolve propose` and routes MCP tool `evolve_propose` through it (no `agentpack --json` subprocess).
- Keeps CLI `evolve propose` behavior intact by reusing the same handler.

## Why
- This is the last MCP tool that still spawned a CLI subprocess; completing M3-REF-004 (single-source CLI/MCP handlers).

## Testing
- `openspec validate refactor-mcp-tools-evolve-propose-handler --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`
