### PR TITLE
test(cli): add policy JSON golden snapshots

### DIFF
--- a/openspec/changes/add-policy-json-golden-tests/.openspec.yaml
+++ b/openspec/changes/add-policy-json-golden-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/add-policy-json-golden-tests/README.md
+++ b/openspec/changes/add-policy-json-golden-tests/README.md
@@ -1,0 +1,3 @@
+# add-policy-json-golden-tests
+
+Add golden snapshots for policy lint/lock JSON output

--- a/openspec/changes/add-policy-json-golden-tests/proposal.md
+++ b/openspec/changes/add-policy-json-golden-tests/proposal.md
@@ -1,0 +1,19 @@
+# Change: Add golden snapshots for policy lint/lock JSON output
+
+## Why
+Automation relies on `--json` output as an API contract. `agentpack policy lint` / `agentpack policy lock`
+already exist, but we do not have golden snapshots that protect the stability of their JSON `data` payloads
+for downstream tooling.
+
+## What Changes
+- Add golden snapshot tests for:
+  - `agentpack policy lock --json --yes` (success `data`)
+  - `agentpack policy lint --json` (success `data`, after lock)
+- Normalize temp paths so snapshots are deterministic across OS.
+
+## Scope
+- Tests and snapshots only (no behavior changes).
+
+## Acceptance
+- Golden snapshots are deterministic (normalized temp paths, stable ordering).
+- No changes to the `--json` envelope contract (`schema_version=1`).

--- a/openspec/changes/add-policy-json-golden-tests/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-policy-json-golden-tests/specs/agentpack-cli/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: policy lint/lock JSON output is protected by golden snapshots
+
+The repository SHALL provide golden snapshot tests for the JSON `data` payloads of:
+- `agentpack policy lock --json --yes`
+- `agentpack policy lint --json`
+
+The snapshots SHALL normalize temporary paths to ensure deterministic results across OS.
+
+#### Scenario: policy lock/lint JSON data is stable for automation
+- **WHEN** the test suite runs in CI
+- **THEN** golden tests validate the normalized JSON `data` payloads for `policy lock` and `policy lint`
+- **AND** the snapshots remain deterministic across OS (normalized temp paths, stable ordering)

--- a/openspec/changes/add-policy-json-golden-tests/tasks.md
+++ b/openspec/changes/add-policy-json-golden-tests/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+### 1.1 Golden snapshots for policy commands
+- [x] Add a golden test for `policy lock` / `policy lint` JSON output.
+- [x] Add `tests/golden/policy_lock_json_data.json`.
+- [x] Add `tests/golden/policy_lint_json_data.json`.
+- [x] Normalize temp paths for cross-OS stability.
+
+### 1.2 Validation
+- [x] Run `cargo fmt --all -- --check`.
+- [x] Run `cargo clippy --all-targets --all-features -- -D warnings`.
+- [x] Run `cargo test --all --locked`.
+
+## 2. Spec deltas
+
+- [x] Add a delta requirement describing the policy JSON golden snapshots (archive with `--skip-specs` since this is tests-only).

--- a/tests/cli_json_golden_policy.rs
+++ b/tests/cli_json_golden_policy.rs
@@ -1,0 +1,174 @@
+use std::path::Path;
+use std::process::Command;
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .env("AGENTPACK_MACHINE_ID", "test-machine")
+        .env("HOME", home)
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn canonicalize_json(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut items: Vec<(String, serde_json::Value)> = map.into_iter().collect();
+            items.sort_by(|a, b| a.0.cmp(&b.0));
+
+            let mut out = serde_json::Map::new();
+            for (k, v) in items {
+                out.insert(k, canonicalize_json(v));
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(canonicalize_json).collect::<Vec<_>>())
+        }
+        other => other,
+    }
+}
+
+fn normalize_json(value: serde_json::Value, tmp_prefix: &str) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                out.insert(k, normalize_json(v, tmp_prefix));
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(
+            arr.into_iter()
+                .map(|v| normalize_json(v, tmp_prefix))
+                .collect::<Vec<_>>(),
+        ),
+        serde_json::Value::String(s) => {
+            let mut out = s.replace('\\', "/");
+            out = out.replace(tmp_prefix, "<TMP>");
+            serde_json::Value::String(out)
+        }
+        other => other,
+    }
+}
+
+fn pretty_json(value: serde_json::Value) -> String {
+    let canonical = canonicalize_json(value);
+    let mut out = serde_json::to_string_pretty(&canonical).expect("pretty json");
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+fn assert_envelope_shape(v: &serde_json::Value, expected_command: &str, ok: bool) {
+    assert_eq!(v["schema_version"], 1);
+    assert_eq!(v["ok"], ok);
+    assert_eq!(v["command"], expected_command);
+
+    assert_eq!(v["version"], env!("CARGO_PKG_VERSION"));
+    assert!(v["data"].is_object());
+    assert!(v["warnings"].is_array());
+    assert!(v["errors"].is_array());
+}
+
+fn assert_data_matches_golden(
+    v: &serde_json::Value,
+    golden_path: &str,
+    tmp_prefix: &str,
+) -> anyhow::Result<()> {
+    let normalized = normalize_json(v["data"].clone(), tmp_prefix);
+    let actual = pretty_json(normalized);
+
+    let expected_path = std::path::Path::new(golden_path);
+    if !expected_path.exists() {
+        anyhow::bail!("missing golden snapshot: {golden_path}\n\n{actual}");
+    }
+
+    let expected = std::fs::read_to_string(expected_path)
+        .map_err(|e| anyhow::anyhow!("read golden {golden_path}: {e}"))?;
+    assert_eq!(actual, expected);
+    Ok(())
+}
+
+fn write_file(path: &Path, contents: &str) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(path, contents).map_err(|e| anyhow::anyhow!("write {}: {e}", path.display()))?;
+    Ok(())
+}
+
+#[test]
+fn json_policy_command_data_matches_golden_snapshots() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path();
+    let cwd = home;
+
+    let repo = home.join("repo");
+    std::fs::create_dir_all(&repo)?;
+
+    write_file(
+        repo.join("policies/my-pack/rule.txt").as_path(),
+        "deny: example\n",
+    )?;
+    write_file(
+        repo.join("agentpack.org.yaml").as_path(),
+        r#"version: 1
+
+policy_pack:
+  source: "local:policies/my-pack"
+"#,
+    )?;
+
+    write_file(
+        repo.join("skills/example-skill/SKILL.md").as_path(),
+        r#"---
+name: example-skill
+description: Example skill for policy golden tests.
+---
+
+# Example
+"#,
+    )?;
+    write_file(
+        repo.join("modules/claude-commands/example.md").as_path(),
+        r#"# example
+
+This command does not use bash.
+"#,
+    )?;
+
+    let tmp_prefix = home.to_string_lossy().replace('\\', "/");
+
+    let lock = agentpack_in(home, cwd, &["policy", "lock", "--json", "--yes"]);
+    assert!(lock.status.success());
+    let lock_v = parse_stdout_json(&lock);
+    assert_envelope_shape(&lock_v, "policy.lock", true);
+    assert_data_matches_golden(
+        &lock_v,
+        "tests/golden/policy_lock_json_data.json",
+        &tmp_prefix,
+    )?;
+
+    let lint = agentpack_in(home, cwd, &["policy", "lint", "--json"]);
+    assert!(lint.status.success());
+    let lint_v = parse_stdout_json(&lint);
+    assert_envelope_shape(&lint_v, "policy.lint", true);
+    assert_data_matches_golden(
+        &lint_v,
+        "tests/golden/policy_lint_json_data.json",
+        &tmp_prefix,
+    )?;
+
+    Ok(())
+}

--- a/tests/golden/policy_lint_json_data.json
+++ b/tests/golden/policy_lint_json_data.json
@@ -1,0 +1,12 @@
+{
+  "issues": [],
+  "root": "<TMP>/repo",
+  "root_posix": "<TMP>/repo",
+  "summary": {
+    "claude_command_files": 1,
+    "files_scanned": 2,
+    "rules": {},
+    "skill_files": 1,
+    "violations": 0
+  }
+}

--- a/tests/golden/policy_lock_json_data.json
+++ b/tests/golden/policy_lock_json_data.json
@@ -1,0 +1,7 @@
+{
+  "files": 1,
+  "lockfile_path": "<TMP>/repo/agentpack.org.lock.json",
+  "lockfile_path_posix": "<TMP>/repo/agentpack.org.lock.json",
+  "resolved_version": "local",
+  "sha256": "db1789261d917b6b01fc77f8b2414fc2c00579c5d272180ae03dbb57cafec7bd"
+}


### PR DESCRIPTION
Refs #576
OpenSpec: add-policy-json-golden-tests

## Summary
- Add golden snapshot coverage for `agentpack policy lock --json --yes` and `agentpack policy lint --json` (`data` payload only).
- Normalize temp paths so snapshots are stable across OS.

## Testing
- `openspec validate add-policy-json-golden-tests --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`

## Notes
- Tests/snapshots only; no runtime behavior changes.