### PR TITLE
feat(governance): enforce allowlist for policy packs

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -92,6 +92,8 @@ agentpack --repo . policy lock
 
 When `policy_pack` is configured, `policy lint` expects the lockfile to exist and match the configured source. This keeps `policy lint` CI-friendly (no network access required).
 
+When `supply_chain_policy.allowed_git_remotes` is configured and `policy_pack.source` is a git source, `policy lint` (and `policy lock`) additionally enforce that the policy pack remote matches the allowlist.
+
 ## Org distribution policy (minimal v1)
 
 Organizations can optionally define a minimal “distribution policy” in `repo/agentpack.org.yaml` to enforce what a repo **must** configure.
@@ -130,6 +132,7 @@ supply_chain_policy:
 
 Enforcement:
 - `agentpack policy lint` validates that every git-sourced module in `repo/agentpack.yaml` uses a remote that matches at least one allowlist entry.
+- When `policy_pack.source` is a git source, `agentpack policy lint` also validates that the policy pack remote matches the allowlist.
 - Matching is case-insensitive and normalizes common git URL forms (e.g. `https://github.com/your-org/repo.git` and `git@github.com:your-org/repo.git`).
 - When `require_lockfile=true` and enabled git modules exist, `agentpack policy lint` requires `repo/agentpack.lock.json` to exist and include entries for those modules.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -681,7 +681,9 @@ Behavior:
   - Dangerous defaults: command markdown that uses the bash tool MUST invoke mutating agentpack commands with `--json` and `--yes`.
   - Policy pack pinning (when configured): if `repo/agentpack.org.yaml` configures `policy_pack`, then `repo/agentpack.org.lock.json` MUST exist and MUST match the configured source (no network access).
   - Org distribution policy (when configured): if `repo/agentpack.org.yaml` configures `distribution_policy`, then `policy lint` MUST validate the required targets/modules in `repo/agentpack.yaml`.
-  - Supply chain allowlist (when configured): if `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes`, then `policy lint` MUST validate that git module sources in `repo/agentpack.yaml` match at least one allowlist entry.
+  - Supply chain allowlist (when configured): if `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes`, then `policy lint` MUST validate that:
+    - git module sources in `repo/agentpack.yaml` match at least one allowlist entry, and
+    - git `policy_pack.source` remotes match at least one allowlist entry.
   - Supply chain lockfile pinning (when configured): if `repo/agentpack.org.yaml` configures `supply_chain_policy.require_lockfile=true`, then `policy lint` MUST require `repo/agentpack.lock.json` to exist and contain entries for enabled git modules.
 
 Exit codes:
@@ -699,10 +701,11 @@ JSON mode:
 Behavior:
 - Reads `repo/agentpack.org.yaml` and resolves the configured `policy_pack.source`.
 - Writes/updates `repo/agentpack.org.lock.json` to pin the policy pack (diff-friendly, deterministic ordering).
+- When `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes` and `policy_pack.source` is a git source, `policy lock` MUST refuse non-allowlisted remotes.
 
 JSON mode:
 - `policy lock --json` requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
-- On success: `command="policy.lock"`, `ok=true`, and `data` includes `lockfile_path`, `resolved_version`, and `sha256`.
+- On success: `command="policy.lock"`, `ok=true`, and `data` includes `lockfile_path`, `lockfile_path_posix`, `resolved_version`, `sha256`, and `files`.
 
 ### 4.21 `policy audit` (governance, read-only)
 

--- a/openspec/changes/update-policy-pack-allowlist-remotes/.openspec.yaml
+++ b/openspec/changes/update-policy-pack-allowlist-remotes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-20

--- a/openspec/changes/update-policy-pack-allowlist-remotes/README.md
+++ b/openspec/changes/update-policy-pack-allowlist-remotes/README.md
@@ -1,0 +1,3 @@
+# update-policy-pack-allowlist-remotes
+
+Enforce allowed git remotes for policy packs

--- a/openspec/changes/update-policy-pack-allowlist-remotes/proposal.md
+++ b/openspec/changes/update-policy-pack-allowlist-remotes/proposal.md
@@ -1,0 +1,24 @@
+# Change: Enforce allowed git remotes for policy packs
+
+## Why
+Policy packs are an opt-in governance surface, and should have a minimal trust chain to prevent accidental or unsafe adoption of policy pack sources.
+
+Agentpack already pins policy packs via `repo/agentpack.org.lock.json`, but it does not currently enforce a git remote allowlist for `policy_pack.source`. This makes it too easy for a repo to point at an unexpected/untrusted remote without CI catching it.
+
+## What Changes
+- Extend `supply_chain_policy.allowed_git_remotes` enforcement to `policy_pack.source` when it is a git source:
+  - `agentpack policy lint --json` reports `E_POLICY_VIOLATIONS` when the policy pack remote is not allowlisted.
+  - `agentpack policy lock` refuses to lock a policy pack from a non-allowlisted git remote (stable config error).
+- Document the behavior and keep governance opt-in (core commands unchanged).
+
+## Impact
+- Affected code: `src/policy.rs`, `src/policy_pack.rs` (and shared allowlist helpers).
+- Affected docs: `docs/SPEC.md`, `docs/GOVERNANCE.md`.
+- External contract: additive / opt-in only; no changes to `--json` envelope (`schema_version=1`).
+
+## Acceptance
+- With `supply_chain_policy.allowed_git_remotes` configured:
+  - `policy lint --json` fails with `E_POLICY_VIOLATIONS` and includes a machine-readable issue for a non-allowlisted policy pack remote.
+  - `policy lock --json --yes` fails with a stable policy config error and includes `{remote, allowed_git_remotes}` details.
+- When the allowlist is not configured, existing `policy lint` / `policy lock` behavior remains unchanged.
+- Covered by tests (integration).

--- a/openspec/changes/update-policy-pack-allowlist-remotes/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-policy-pack-allowlist-remotes/specs/agentpack-cli/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Provide a policy pack lock command
+
+The system SHALL provide a governance lock command:
+
+`agentpack policy lock`
+
+The command MUST read `repo/agentpack.org.yaml` and MUST write/update `repo/agentpack.org.lock.json`.
+
+When `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes` and `policy_pack.source` is a git source, `policy lock` MUST refuse to lock a policy pack from a non-allowlisted remote.
+
+In `--json` mode, the command MUST require `--yes` for safety (otherwise return `E_CONFIRM_REQUIRED`).
+
+#### Scenario: policy lock fails when policy pack remote is not allowlisted
+- **GIVEN** `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes=["github.com/your-org/"]`
+- **AND** `repo/agentpack.org.yaml` configures `policy_pack.source` from a different git remote
+- **WHEN** the user runs `agentpack policy lock --json --yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_POLICY_CONFIG_INVALID`
+- **AND** `errors[0].details` includes the policy pack `remote` and the configured `allowed_git_remotes`

--- a/openspec/changes/update-policy-pack-allowlist-remotes/specs/agentpack/spec.md
+++ b/openspec/changes/update-policy-pack-allowlist-remotes/specs/agentpack/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Governance supply_chain_policy can allowlist git remotes
+
+The governance config (`repo/agentpack.org.yaml`) SHALL support an optional supply chain policy section:
+
+- `supply_chain_policy.allowed_git_remotes: string[]`
+
+When `allowed_git_remotes` is configured and non-empty, `agentpack policy lint` MUST validate that:
+- every git-sourced module in `repo/agentpack.yaml` uses a git remote that matches at least one allowlist entry, and
+- if `policy_pack.source` is a git source, its remote matches at least one allowlist entry.
+
+The allowlist match MUST be case-insensitive and SHOULD treat common git URL forms as equivalent (e.g. `https://github.com/org/repo.git` and `git@github.com:org/repo.git`).
+
+Violations MUST be reported as standard `policy lint` issues and fail with `E_POLICY_VIOLATIONS`.
+
+#### Scenario: policy lint fails when a policy pack uses a non-allowlisted remote
+- **GIVEN** `repo/agentpack.org.yaml` configures `supply_chain_policy.allowed_git_remotes`
+- **AND** `repo/agentpack.org.yaml` configures a git `policy_pack.source` whose remote does not match the allowlist
+- **WHEN** the user runs `agentpack policy lint --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_POLICY_VIOLATIONS`
+- **AND** `errors[0].details.issues[]` includes an issue for the non-allowlisted policy pack remote

--- a/openspec/changes/update-policy-pack-allowlist-remotes/tasks.md
+++ b/openspec/changes/update-policy-pack-allowlist-remotes/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] Enforce `supply_chain_policy.allowed_git_remotes` for `policy_pack.source` (git) in `policy lint`.
+- [x] Enforce `supply_chain_policy.allowed_git_remotes` for `policy_pack.source` (git) in `policy lock`.
+- [x] Update docs to clarify the allowlist also applies to policy pack git sources.
+- [x] Add integration tests for:
+  - `policy lint` failing when policy pack remote is not allowlisted
+  - `policy lock` failing when policy pack remote is not allowlisted
+
+## 2. Validation
+
+- [x] `openspec validate update-policy-pack-allowlist-remotes --strict --no-interactive`
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all-targets --all-features -- -D warnings`
+- [x] `cargo test --all --locked`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod output;
 pub mod overlay;
 pub mod paths;
 pub mod policy;
+pub(crate) mod policy_allowlist;
 pub(crate) mod policy_pack;
 pub mod project;
 pub mod source;

--- a/src/policy_allowlist.rs
+++ b/src/policy_allowlist.rs
@@ -1,0 +1,37 @@
+pub(crate) fn normalize_git_remote_for_policy(url: &str) -> String {
+    let mut u = url.trim().trim_end_matches(".git").to_string();
+    if let Some(rest) = u.strip_prefix("git@") {
+        u = rest.replace(':', "/");
+    } else if let Some(rest) = u.strip_prefix("https://") {
+        u = rest.to_string();
+    } else if let Some(rest) = u.strip_prefix("http://") {
+        u = rest.to_string();
+    } else if let Some(rest) = u.strip_prefix("ssh://") {
+        u = rest.to_string();
+        if let Some((_, rest)) = u.split_once('@') {
+            u = rest.to_string();
+        }
+        u = u.replace(':', "/");
+    }
+    u.trim_start_matches('/').to_lowercase()
+}
+
+pub(crate) fn remote_matches_allowlist(normalized_remote: &str, normalized_allow: &str) -> bool {
+    if normalized_allow.is_empty() {
+        return false;
+    }
+    if normalized_remote == normalized_allow {
+        return true;
+    }
+    if !normalized_remote.starts_with(normalized_allow) {
+        return false;
+    }
+    if normalized_allow.ends_with('/') {
+        return true;
+    }
+    normalized_remote
+        .as_bytes()
+        .get(normalized_allow.len())
+        .copied()
+        == Some(b'/')
+}


### PR DESCRIPTION
Refs #579
OpenSpec: update-policy-pack-allowlist-remotes

## Summary
- Extend `supply_chain_policy.allowed_git_remotes` enforcement to `policy_pack.source` (git) in both `policy lint` and `policy lock`.
- Refuse locking a non-allowlisted policy pack remote with `E_POLICY_CONFIG_INVALID` (rejects before any git/network work).
- Add integration tests and update governance/spec docs.

## Testing
- `openspec validate update-policy-pack-allowlist-remotes --strict --no-interactive`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all --locked`