### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,21 @@ This project follows SemVer with the following clarifications (especially for au
 
 ### Security
 
+## [0.8.0] - 2026-01-20
+
+### Added
+- `agentpack help --markdown` for generating the CLI reference.
+
+### Changed
+- MCP tools now run in-process (no subprocess spawning) for improved reliability and performance.
+- Governance policy tooling enforces `supply_chain_policy.allowed_git_remotes` for `policy_pack` sources.
+
+### Fixed
+- Ignore `.agentpack/.git` directories during copy-tree filtering.
+
+### Security
+- Restrict policy packs to allowlisted git remotes to harden the trust chain.
+
 ## [0.7.0] - 2026-01-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentpack"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentpack"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["liqiongyu <li@libiao.co>"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cargo install agentpack --locked
 If crates.io install is not available yet, install from source:
 
 ```bash
-cargo install --git https://github.com/liqiongyu/agentpack --tag v0.7.0 --locked
+cargo install --git https://github.com/liqiongyu/agentpack --tag v0.8.0 --locked
 ```
 
 ### Prebuilt binaries

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@ cargo install agentpack --locked
 如果暂时无法从 crates.io 安装，可以从源码安装：
 
 ```bash
-cargo install --git https://github.com/liqiongyu/agentpack --tag v0.7.0 --locked
+cargo install --git https://github.com/liqiongyu/agentpack --tag v0.8.0 --locked
 ```
 
 ### 预编译二进制

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # Spec (implementation contract)
 
-> Current as of **v0.7.0** (2026-01-18). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
+> Current as of **v0.8.0** (2026-01-20). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
 
 ## 0. Conventions
 
@@ -16,7 +16,7 @@ Default data directory: `~/.agentpack` (override via `AGENTPACK_HOME`), with:
 
 Optional durability mode: set `AGENTPACK_FSYNC=1` to request `fsync` on atomic writes (slower, but more crash-consistent).
 
-Supported as of v0.7.0:
+Supported as of v0.8.0:
 - targets: `codex`, `claude_code`, `cursor`, `vscode`, `jetbrains`, `zed`
 - module types: `instructions`, `skill`, `prompt`, `command`
 - source types: `local_path`, `git` (`url` + `ref` + `subdir`)
@@ -379,7 +379,7 @@ Additional (v0.3+):
 - Patch overlay rebase conflicts may be written under `<overlay_dir>/.agentpack/conflicts/` (not deployed).
 - `.agentpack/` is a reserved metadata directory: it is never deployed to target roots and must not appear in module outputs.
 
-## 4. CLI commands (v0.7.0)
+## 4. CLI commands (v0.8.0)
 
 Global flags:
 - `--repo <path>`: config repo location

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -1,6 +1,6 @@
 # ERROR_CODES.md (stable error code registry)
 
-> Current as of **v0.7.0** (2026-01-18). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
+> Current as of **v0.8.0** (2026-01-20). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
 
 This file defines stable, externally-consumable error codes for `--json` mode (`errors[0].code`).
 

--- a/docs/reference/json-api.md
+++ b/docs/reference/json-api.md
@@ -1,6 +1,6 @@
 # JSON API (the `--json` output contract)
 
-> Current as of **v0.7.0** (2026-01-18). `SPEC.md` is the semantic source of truth; this file focuses on the stable `--json` contract.
+> Current as of **v0.8.0** (2026-01-20). `SPEC.md` is the semantic source of truth; this file focuses on the stable `--json` contract.
 
 ## 1) Stability guarantees (principles)
 
@@ -31,7 +31,7 @@ Failure example:
   "schema_version": 1,
   "ok": false,
   "command": "deploy",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "data": {},
   "warnings": [],
   "errors": [

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -36,7 +36,7 @@ Common “heavy user” setups (pick one to start):
   - From crates.io:
     - `cargo install agentpack --locked`
   - If you see `could not find \`agentpack\` in registry \`crates-io\``, install from source:
-    - Latest tagged release (recommended): `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.7.0 --locked`
+    - Latest tagged release (recommended): `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.8.0 --locked`
     - Bleeding edge (`main`): `cargo install --git https://github.com/liqiongyu/agentpack --branch main --locked`
 - Non-Rust users:
   - Download a prebuilt binary from GitHub Releases (see the repository README).

--- a/docs/zh-CN/tutorials/quickstart.md
+++ b/docs/zh-CN/tutorials/quickstart.md
@@ -36,7 +36,7 @@
   - 从 crates.io 安装：
     - `cargo install agentpack --locked`
   - 如果你遇到 `could not find \`agentpack\` in registry \`crates-io\``，可以从源码安装：
-    - 最新 tag（推荐）：`cargo install --git https://github.com/liqiongyu/agentpack --tag v0.7.0 --locked`
+    - 最新 tag（推荐）：`cargo install --git https://github.com/liqiongyu/agentpack --tag v0.8.0 --locked`
     - main 分支（尝鲜）：`cargo install --git https://github.com/liqiongyu/agentpack --branch main --locked`
 - 非 Rust 用户：
   - 从 GitHub Releases 下载对应平台二进制（见仓库 README）。


### PR DESCRIPTION
Closes #582.

## What
- Bump crate version to 0.8.0
- Update contract doc version stamps + install tag docs
- Add CHANGELOG entry for 0.8.0

## Test
- just check