### PR TITLE
docs: refresh high-level docs for v0.8.0

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,15 +1,16 @@
 # BACKLOG.md
 
-> Current as of **v0.7.0** (2026-01-18). Historical content is tracked in git history.
+> Current as of **v0.8.0** (2026-01-20). Historical content is tracked in git history.
 
 ## Status
 
 - v0.5 milestone: a round of “daily-usable + AI-first loop” convergence (composite commands, overlay rebase, adopt protection, evolve restore, etc.).
 - v0.6 milestone: governance policy tooling, MCP server integration (`agentpack mcp serve`), and optional TUI.
 - v0.7 milestone: target platformization hardening (per-target manifests) + new built-in targets (`jetbrains`, `zed`).
+- v0.8 milestone: MCP tooling refactors (in-process tools) + governance hardening for policy packs.
 - For concrete shipped changes, see `CHANGELOG.md`.
 
-## Next (candidates for v0.8+)
+## Next (candidates for v0.9+)
 
 ### Targets & ecosystem
 - Add more targets behind strict feature gates + conformance tests, with clear mapping docs (`docs/TARGET_MAPPING_TEMPLATE.md`).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,6 +1,6 @@
 # PRD.md
 
-> Current as of **v0.7.0** (2026-01-18). Historical content is tracked in git history.
+> Current as of **v0.8.0** (2026-01-20). Historical content is tracked in git history.
 
 ## 1. Background
 
@@ -42,6 +42,8 @@ UX and AI-first:
 - `doctor --fix`: reduce accidental commits of manifests
 - bootstrap: install operator assets (Codex operator skill + Claude `/ap-*` commands)
 - evolve: `propose` (turn drift into overlay proposal branches) + `restore` (create-only restore missing files)
+- Governance policy tooling: `policy lint` / `policy lock` / `policy audit` (org distribution + supply-chain guardrails)
+- MCP server integration: `agentpack mcp serve` exposes structured read-only tools plus approval-gated mutations
 
 ## 4. Non-goals (short term)
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE.md
 
-> Current as of **v0.7.0** (2026-01-18). Historical content is tracked in git history.
+> Current as of **v0.8.0** (2026-01-20). Historical content is tracked in git history.
 
 ## 1. One-line summary
 


### PR DESCRIPTION
Closes #584.

## What
- Update version stamps to v0.8.0 in PRD/BACKLOG/Architecture
- Update BACKLOG milestone notes (v0.8 milestone; next = v0.9+)
- Minor PRD additions for governance + MCP

## Test
- cargo test --test docs_markdown_links