### PR TITLE
docs: unify tagline and GitHub setup checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agentpack
 
+> A declarative, safe control plane for deploying coding-agent assets across tools.
+
 > Language: English | [Chinese (Simplified)](README.zh-CN.md)
 
 Agentpack is an AI-first local “asset control plane” for managing and deploying:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,7 @@
 # Agentpack
 
+> 面向 AI 编程代理的本地资产控制面：声明式管理与安全部署 AGENTS/Skills/Commands/Prompts。
+
 > Language: 简体中文 | [English](README.md)
 
 Agentpack 是一个 AI-first 的本地“资产控制平面（asset control plane）”，用于管理与部署：

--- a/docs/GITHUB_SETUP.md
+++ b/docs/GITHUB_SETUP.md
@@ -8,6 +8,12 @@ Recommended order: get CI green and stable first, then enable branch protection 
 
 GitHub repo page: Settings → General
 
+- About (repo homepage sidebar)
+  - Description (EN): A declarative, safe control plane for deploying coding-agent assets across tools.
+  - Description (ZH): 面向 AI 编程代理的本地资产控制面：声明式管理与安全部署 AGENTS/Skills/Commands/Prompts。
+  - Topics (suggested): ai, agent, codex, claude-code, mcp, cli, rust, developer-tools
+  - Website (optional): https://crates.io/crates/agentpack
+
 - Features
   - Issues: recommended
   - Discussions: optional (useful if you want to offload “usage questions/ideas” from Issues)

--- a/openspec/changes/update-tagline-and-github-setup/.openspec.yaml
+++ b/openspec/changes/update-tagline-and-github-setup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-21

--- a/openspec/changes/update-tagline-and-github-setup/README.md
+++ b/openspec/changes/update-tagline-and-github-setup/README.md
@@ -1,0 +1,3 @@
+# update-tagline-and-github-setup
+
+Unify README tagline and GitHub About checklist

--- a/openspec/changes/update-tagline-and-github-setup/proposal.md
+++ b/openspec/changes/update-tagline-and-github-setup/proposal.md
@@ -1,0 +1,13 @@
+# Change: Update tagline and GitHub setup checklist
+
+## Why
+New users often see the repo “About” blurb and README top section before anything else. If the tagline is missing or inconsistent across languages, the value proposition is harder to understand and the messaging drifts over time.
+
+## What Changes
+- Add a single, consistent EN/ZH tagline at the top of `README.md` and `README.zh-CN.md`.
+- Extend `docs/GITHUB_SETUP.md` with a copy-paste checklist for GitHub “About” fields (tagline/topics/website), matching the README tagline.
+
+## Impact
+- Affected specs: `agentpack-cli` (docs/discovery surface)
+- Affected code/docs: `README.md`, `README.zh-CN.md`, `docs/GITHUB_SETUP.md`
+- Compatibility: docs-only; no CLI/JSON behavior changes

--- a/openspec/changes/update-tagline-and-github-setup/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-tagline-and-github-setup/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Tagline and GitHub About fields stay consistent
+
+The repository SHALL document a single, copy-pasteable English and Chinese tagline in `README.md`, `README.zh-CN.md`, and `docs/GITHUB_SETUP.md` to keep GitHub “About” fields consistent over time.
+
+#### Scenario: Maintainer updates GitHub About without drift
+- **GIVEN** a maintainer wants to update the repository “About” tagline
+- **WHEN** they follow the checklist in `docs/GITHUB_SETUP.md`
+- **THEN** they can copy/paste the exact tagline that appears at the top of `README.md` and `README.zh-CN.md`

--- a/openspec/changes/update-tagline-and-github-setup/tasks.md
+++ b/openspec/changes/update-tagline-and-github-setup/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 Update `README.md` and `README.zh-CN.md` top tagline (EN/ZH)
+- [x] 1.2 Add GitHub About/Topics/Website checklist to `docs/GITHUB_SETUP.md`
+- [x] 1.3 Run `cargo test --test docs_markdown_links`


### PR DESCRIPTION
Closes #590.

## What
- Adds a single EN/ZH tagline at the top of `README.md` / `README.zh-CN.md`
- Extends `docs/GITHUB_SETUP.md` with copy/paste GitHub About fields
- Adds OpenSpec change `update-tagline-and-github-setup`

## Tests
- `cargo test --test docs_markdown_links`
