### PR TITLE
docs: add 5-minute demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Agentpack is an AI-first local “asset control plane” for managing and deploy
 
 - Docs entrypoint: `docs/index.md` (English), `docs/zh-CN/index.md` (Chinese)
 - Quickstart: `docs/tutorials/quickstart.md`
+- 5-minute demo (safe preview): `docs/tutorials/demo-5min.md`
 - Daily workflow: `docs/howto/workflows.md`
 - CLI reference: `docs/reference/cli.md`
 - Codex MCP wiring: `docs/howto/mcp.md`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,7 @@ Agentpack 是一个 AI-first 的本地“资产控制平面（asset control plan
 
 - 文档入口：`docs/index.md`（英文）、`docs/zh-CN/index.md`（中文）
 - 推荐从：`docs/tutorials/quickstart.md` 开始
+- 5 分钟 demo（安全预览）：`docs/zh-CN/tutorials/demo-5min.md`
 - 日常工作流：`docs/howto/workflows.md`
 - CLI 参考：`docs/reference/cli.md`
 - Codex MCP 集成：`docs/howto/mcp.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,11 @@ This page is the single “start here” entrypoint for Agentpack documentation.
   - CLI reference: `reference/cli.md#import`
   - Daily workflow context: `howto/workflows.md`
 
+### 3) 5-minute demo (safe preview)
+
+- Run a safe demo in a temporary HOME/AGENTPACK_HOME (no real writes):
+  - `tutorials/demo-5min.md`
+
 ## Common workflows
 
 - Local customization with overlays (including patch overlays):

--- a/docs/tutorials/demo-5min.md
+++ b/docs/tutorials/demo-5min.md
@@ -1,0 +1,39 @@
+# Demo: 5 minutes to value (safe, no real writes)
+
+> Language: English | [Chinese (Simplified)](../zh-CN/tutorials/demo-5min.md)
+
+Goal: run a safe demo that shows a real plan/diff without touching your real home directory.
+
+## Run
+
+From the repo root:
+
+```bash
+./scripts/demo_5min.sh
+```
+
+The script prefers (in order):
+- `AGENTPACK_BIN` (if you set it to a path)
+- `agentpack` on your PATH
+- `cargo run` from this repository (if Rust is installed)
+
+## What it does
+
+- Creates a temporary `HOME` and a temporary `AGENTPACK_HOME`
+- Copies `docs/examples/minimal_repo` into a temp workspace
+- Runs:
+  - `agentpack doctor --json`
+  - `agentpack preview --diff --json`
+
+It does **not** use `--apply`, so it should not write any target files. Even if a target path is resolved, it’s inside the temporary `HOME`.
+
+## Next steps
+
+- Create your own config repo:
+  - `agentpack init`
+  - `agentpack update`
+  - `agentpack preview --diff`
+- Apply for real (explicit confirmation):
+  - `agentpack deploy --apply --yes`
+- Roll back if needed:
+  - `agentpack rollback --to <snapshot_id>`

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -19,6 +19,11 @@
   - CLI 参考：`reference/cli.md#import`
   - 工作流背景：`howto/workflows.md`
 
+### 3) 5 分钟 demo（安全预览）
+
+- 在临时 HOME/AGENTPACK_HOME 下跑一个安全 demo（不写真实环境）：
+  - `tutorials/demo-5min.md`
+
 ## 常用工作流
 
 - 用 overlays 做本地定制（包括 patch overlays）：

--- a/docs/zh-CN/tutorials/demo-5min.md
+++ b/docs/zh-CN/tutorials/demo-5min.md
@@ -1,0 +1,39 @@
+# Demo：5 分钟看到价值（安全，不写真实环境）
+
+> Language: 简体中文 | [English](../../tutorials/demo-5min.md)
+
+目标：跑一个安全 demo，让你在不污染真实 HOME 的前提下，看到一次真实的 plan/diff。
+
+## 运行
+
+在仓库根目录执行：
+
+```bash
+./scripts/demo_5min.sh
+```
+
+脚本会按优先级选择运行方式：
+- 如果设置了 `AGENTPACK_BIN`（一个可执行文件路径），优先用它
+- 否则用 PATH 里的 `agentpack`
+- 否则（如果已安装 Rust）使用本仓库的 `cargo run`
+
+## 它做了什么
+
+- 创建临时 `HOME` 与临时 `AGENTPACK_HOME`
+- 把 `docs/examples/minimal_repo` 复制到临时 workspace
+- 运行：
+  - `agentpack doctor --json`
+  - `agentpack preview --diff --json`
+
+脚本不会使用 `--apply`，因此不会写入任何 target 文件；即便解析到了 target 路径，也是在临时 `HOME` 里。
+
+## 下一步
+
+- 建一个你自己的 config repo：
+  - `agentpack init`
+  - `agentpack update`
+  - `agentpack preview --diff`
+- 真正写入（显式确认）：
+  - `agentpack deploy --apply --yes`
+- 需要撤销时：
+  - `agentpack rollback --to <snapshot_id>`

--- a/openspec/changes/add-demo-5min-script/.openspec.yaml
+++ b/openspec/changes/add-demo-5min-script/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-21

--- a/openspec/changes/add-demo-5min-script/README.md
+++ b/openspec/changes/add-demo-5min-script/README.md
@@ -1,0 +1,3 @@
+# add-demo-5min-script
+
+Add 5-minute demo script and tutorial (no real writes)

--- a/openspec/changes/add-demo-5min-script/proposal.md
+++ b/openspec/changes/add-demo-5min-script/proposal.md
@@ -1,0 +1,14 @@
+# Change: Add 5-minute demo script + tutorial
+
+## Why
+Agentpack is easiest to understand when users can run a safe, non-destructive command and immediately see a plan/diff. A “5-minute demo” script that uses temporary HOME/AGENTPACK_HOME reduces onboarding friction and makes the value proposition tangible.
+
+## What Changes
+- Add `scripts/demo_5min.sh` that runs against a copied example repo in a temp workspace, with temp `HOME` and `AGENTPACK_HOME` (no writes to the user’s real environment).
+- Add a tutorial page (EN + zh-CN) that explains the demo, the safety properties, and the next steps (how to apply with explicit `--yes`).
+- Add an integration test that executes the script and asserts success.
+
+## Impact
+- Affected specs: `agentpack-cli` (docs/onboarding surface)
+- Affected code/docs: new script + docs + tests
+- Compatibility: no CLI/JSON behavior changes

--- a/openspec/changes/add-demo-5min-script/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-demo-5min-script/specs/agentpack-cli/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Repository provides a non-destructive 5-minute demo
+
+The repository SHALL provide a “5-minute demo” script and tutorial that runs Agentpack with temporary `HOME` and `AGENTPACK_HOME`, and demonstrates `doctor --json` plus `preview --diff --json` without writing to the user’s real environment.
+
+#### Scenario: New user can run a safe demo
+- **GIVEN** a user clones the repo
+- **WHEN** they run the demo script
+- **THEN** it exits successfully and prints a plan/diff in JSON mode
+- **AND** it does not write to the user’s real home directory

--- a/openspec/changes/add-demo-5min-script/tasks.md
+++ b/openspec/changes/add-demo-5min-script/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+- [x] 1.1 Add `scripts/demo_5min.sh` (temp HOME/AGENTPACK_HOME; runs doctor + preview --diff --json)
+- [x] 1.2 Add `docs/tutorials/demo-5min.md` and `docs/zh-CN/tutorials/demo-5min.md`
+- [x] 1.3 Link from `README.md`, `docs/index.md`, `docs/zh-CN/index.md`
+- [x] 1.4 Add `tests/cli_demo_5min_script.rs`
+- [x] 1.5 Run `cargo test --test cli_demo_5min_script` and `cargo test --test docs_markdown_links`

--- a/scripts/demo_5min.sh
+++ b/scripts/demo_5min.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+EXAMPLE_REPO_SRC="${PROJECT_ROOT}/docs/examples/minimal_repo"
+
+if [[ ! -d "${EXAMPLE_REPO_SRC}" ]]; then
+  echo "error: example repo not found: ${EXAMPLE_REPO_SRC}" >&2
+  exit 1
+fi
+
+run_agentpack() {
+  if [[ -n "${AGENTPACK_BIN:-}" ]]; then
+    "${AGENTPACK_BIN}" "$@"
+    return
+  fi
+
+  if command -v agentpack >/dev/null 2>&1; then
+    agentpack "$@"
+    return
+  fi
+
+  if command -v cargo >/dev/null 2>&1; then
+    cargo run --quiet --manifest-path "${PROJECT_ROOT}/Cargo.toml" -- "$@"
+    return
+  fi
+
+  echo "error: agentpack not found (set AGENTPACK_BIN, install agentpack, or run with Rust/cargo)" >&2
+  exit 1
+}
+
+TMP_ROOT="$(mktemp -d)"
+cleanup() { rm -rf "${TMP_ROOT}"; }
+trap cleanup EXIT
+
+DEMO_HOME="${TMP_ROOT}/home"
+DEMO_AGENTPACK_HOME="${TMP_ROOT}/agentpack_home"
+DEMO_WORKSPACE="${TMP_ROOT}/workspace"
+DEMO_REPO="${TMP_ROOT}/repo"
+
+mkdir -p "${DEMO_HOME}" "${DEMO_AGENTPACK_HOME}" "${DEMO_WORKSPACE}"
+cp -R "${EXAMPLE_REPO_SRC}" "${DEMO_REPO}"
+
+export HOME="${DEMO_HOME}"
+export AGENTPACK_HOME="${DEMO_AGENTPACK_HOME}"
+
+echo "[demo] HOME=${HOME}" >&2
+echo "[demo] AGENTPACK_HOME=${AGENTPACK_HOME}" >&2
+echo "[demo] repo=${DEMO_REPO}" >&2
+echo "[demo] workspace=${DEMO_WORKSPACE}" >&2
+
+cd "${DEMO_WORKSPACE}"
+
+echo "[demo] agentpack doctor --json" >&2
+run_agentpack --repo "${DEMO_REPO}" doctor --json
+
+echo "[demo] agentpack preview --diff --json" >&2
+run_agentpack --repo "${DEMO_REPO}" preview --diff --json

--- a/tests/cli_demo_5min_script.rs
+++ b/tests/cli_demo_5min_script.rs
@@ -1,0 +1,26 @@
+#[cfg(not(windows))]
+use std::path::Path;
+
+#[cfg(not(windows))]
+use std::process::Command;
+
+#[test]
+#[cfg(not(windows))]
+fn demo_5min_script_succeeds() {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/demo_5min.sh");
+    assert!(script.exists(), "missing script: {}", script.display());
+
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    let out = Command::new("bash")
+        .arg(script)
+        .env("AGENTPACK_BIN", bin)
+        .output()
+        .expect("run demo_5min.sh");
+
+    assert!(
+        out.status.success(),
+        "demo_5min.sh failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
Closes #596.

## What
- Adds `scripts/demo_5min.sh` (temp HOME/AGENTPACK_HOME + copied example repo; runs doctor + preview in `--json`)
- Adds tutorials: `docs/tutorials/demo-5min.md` + `docs/zh-CN/tutorials/demo-5min.md`
- Links the demo from `README.md` + docs index pages
- Adds `tests/cli_demo_5min_script.rs`
- Adds OpenSpec change `add-demo-5min-script`

## Tests
- `cargo test --test cli_demo_5min_script`
- `cargo test --test docs_markdown_links`
