### PR TITLE
docs: expand README with scenarios and full loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,48 @@ Agentpack is an AI-first local “asset control plane” for managing and deploy
 - Claude Code slash commands (`.claude/commands`)
 - Codex custom prompts (`~/.codex/prompts`)
 
+## Why you might want Agentpack
+
+1) **Cross-tool consistency**
+- Deploy the same agent assets to multiple tools (Codex, Claude Code, Cursor, VSCode, …) via explicit target adapters and mappings.
+
+2) **Reusable + rollbackable deployments**
+- Preview/diff-first, then apply with snapshots + rollback; manifest-based safe deletes protect user-owned files.
+
+3) **Multi-machine sync + auditability**
+- Treat the config repo as a single source of truth, sync with git (`sync --rebase`), and rely on stable automation contracts (`--json` / MCP) when orchestrating.
+
+## One full loop (end-to-end)
+
+```bash
+agentpack update
+agentpack preview --diff
+agentpack deploy --apply
+agentpack status
+agentpack rollback --to <snapshot_id>
+```
+
+Notes:
+- `deploy --apply` and `rollback` are mutating commands; in automation prefer `--json --yes` and always run `preview` first.
+- In `--json`, `deploy --apply` returns `data.snapshot_id` which you can pass to `rollback --to`.
+
 ## Documentation
 
 - Docs entrypoint: `docs/index.md` (English), `docs/zh-CN/index.md` (Chinese)
-- Quickstart: `docs/tutorials/quickstart.md`
-- 5-minute demo (safe preview): `docs/tutorials/demo-5min.md`
-- Daily workflow: `docs/howto/workflows.md`
-- CLI reference: `docs/reference/cli.md`
-- Codex MCP wiring: `docs/howto/mcp.md`
+  - English: [docs/index.md](docs/index.md)
+  - Chinese: [docs/zh-CN/index.md](docs/zh-CN/index.md)
+- Quickstart: [docs/tutorials/quickstart.md](docs/tutorials/quickstart.md)
+- 5-minute demo (safe preview): [docs/tutorials/demo-5min.md](docs/tutorials/demo-5min.md)
+- Why not a dotfiles manager (Stow/chezmoi/yadm): [docs/explanation/compare-dotfiles-managers.md](docs/explanation/compare-dotfiles-managers.md)
+- Daily workflow: [docs/howto/workflows.md](docs/howto/workflows.md)
+- CLI reference: [docs/reference/cli.md](docs/reference/cli.md)
+- Codex MCP wiring: [docs/howto/mcp.md](docs/howto/mcp.md)
+
+## Why not a dotfiles manager?
+
+Agentpack is focused on deploying agent assets into tool-specific discovery locations, not managing your entire `$HOME`.
+
+See: [docs/explanation/compare-dotfiles-managers.md](docs/explanation/compare-dotfiles-managers.md).
 
 ## Architecture (high level)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,14 +10,48 @@ Agentpack 是一个 AI-first 的本地“资产控制平面（asset control plan
 - Claude Code slash commands（`.claude/commands`）
 - Codex custom prompts（`~/.codex/prompts`）
 
+## 为什么你可能需要 Agentpack
+
+1) **跨工具一致性**
+- 把同一套 agent 资产部署到多个工具（Codex、Claude Code、Cursor、VSCode…），通过显式 targets/mapping 保持一致。
+
+2) **可复用 + 可回滚**
+- 先 preview/diff，再 apply；通过 snapshots + rollback 与 manifest 安全删除，尽量避免误删/误覆盖用户文件。
+
+3) **多机同步 + 可审计**
+- 把 config repo 当成单一真相源，用 git 同步（`sync --rebase`），并在自动化场景依赖稳定契约（`--json` / MCP）。
+
+## 一次完整闭环（从 update 到 rollback）
+
+```bash
+agentpack update
+agentpack preview --diff
+agentpack deploy --apply
+agentpack status
+agentpack rollback --to <snapshot_id>
+```
+
+说明：
+- `deploy --apply` 与 `rollback` 都是写入类命令；自动化推荐用 `--json --yes`，并始终先跑 `preview`。
+- `--json` 模式下，`deploy --apply` 会返回 `data.snapshot_id`，可直接传给 `rollback --to`。
+
 ## 文档
 
 - 文档入口：`docs/index.md`（英文）、`docs/zh-CN/index.md`（中文）
-- 推荐从：`docs/tutorials/quickstart.md` 开始
-- 5 分钟 demo（安全预览）：`docs/zh-CN/tutorials/demo-5min.md`
-- 日常工作流：`docs/howto/workflows.md`
-- CLI 参考：`docs/reference/cli.md`
-- Codex MCP 集成：`docs/howto/mcp.md`
+  - 英文： [docs/index.md](docs/index.md)
+  - 中文： [docs/zh-CN/index.md](docs/zh-CN/index.md)
+- 推荐从： [docs/tutorials/quickstart.md](docs/tutorials/quickstart.md)
+- 5 分钟 demo（安全预览）： [docs/zh-CN/tutorials/demo-5min.md](docs/zh-CN/tutorials/demo-5min.md)
+- “为什么不用 stow/chezmoi/yadm”： [docs/zh-CN/explanation/compare-dotfiles-managers.md](docs/zh-CN/explanation/compare-dotfiles-managers.md)
+- 日常工作流： [docs/howto/workflows.md](docs/howto/workflows.md)
+- CLI 参考： [docs/reference/cli.md](docs/reference/cli.md)
+- Codex MCP 集成： [docs/howto/mcp.md](docs/howto/mcp.md)
+
+## 为什么不用 dotfiles manager？
+
+Agentpack 聚焦把 agent 资产部署到工具的可发现位置，并不试图管理你的整个 `$HOME`。
+
+参考： [docs/zh-CN/explanation/compare-dotfiles-managers.md](docs/zh-CN/explanation/compare-dotfiles-managers.md)。
 
 ## 安装
 

--- a/openspec/changes/update-readme-story-and-demo/.openspec.yaml
+++ b/openspec/changes/update-readme-story-and-demo/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-21

--- a/openspec/changes/update-readme-story-and-demo/README.md
+++ b/openspec/changes/update-readme-story-and-demo/README.md
@@ -1,0 +1,3 @@
+# update-readme-story-and-demo
+
+Add README scenarios + full loop demo + compare entry

--- a/openspec/changes/update-readme-story-and-demo/proposal.md
+++ b/openspec/changes/update-readme-story-and-demo/proposal.md
@@ -1,0 +1,14 @@
+# Change: Update README with scenarios + full loop demo
+
+## Why
+The README is the first-touch surface for most users. Adding concrete scenarios, a real end-to-end loop, and an explicit “why not X” entry reduces confusion, improves onboarding, and makes Agentpack’s boundaries clearer.
+
+## What Changes
+- Add 3 real-world scenarios to `README.md` and `README.zh-CN.md`.
+- Add a single “full loop” demo (update → preview --diff → deploy --apply → status → rollback).
+- Link to the dotfiles-manager comparison page and the 5-minute demo.
+
+## Impact
+- Affected specs: `agentpack-cli` (docs/onboarding surface)
+- Affected code/docs: `README.md`, `README.zh-CN.md`
+- Compatibility: docs-only; no CLI/JSON behavior changes

--- a/openspec/changes/update-readme-story-and-demo/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-readme-story-and-demo/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: README explains why/when/how to use Agentpack
+
+The repository SHALL include in its README (EN + zh-CN) three concrete usage scenarios, one end-to-end command loop demonstration, and an explicit link to the dotfiles-manager comparison page to clarify boundaries.
+
+#### Scenario: New user can understand value and boundaries from README alone
+- **GIVEN** a new user reads the README
+- **WHEN** they scan the “Why” scenarios and the full-loop demo
+- **THEN** they can understand what Agentpack is for, the typical workflow, and where to read more for dotfiles-manager comparisons

--- a/openspec/changes/update-readme-story-and-demo/tasks.md
+++ b/openspec/changes/update-readme-story-and-demo/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 Update `README.md` with: 3 scenarios + full loop demo + links
+- [x] 1.2 Update `README.zh-CN.md` with the same content (localized)
+- [x] 1.3 Run `cargo test --test docs_markdown_links`


### PR DESCRIPTION
Closes #598.

## What
- Adds 3 scenarios + one end-to-end loop demo to `README.md` and `README.zh-CN.md`
- Adds explicit links to the 5-minute demo + dotfiles-manager comparison page
- Adds OpenSpec change `update-readme-story-and-demo`

## Tests
- `cargo test --test docs_markdown_links`
