### PR TITLE
docs: strengthen docs index entrypoints (E1-DOC-001)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,13 +24,21 @@ This page is the single “start here” entrypoint for Agentpack documentation.
 - Run a safe demo in a temporary HOME/AGENTPACK_HOME (no real writes):
   - `tutorials/demo-5min.md`
 
+### 4) Compare (boundaries vs dotfiles managers)
+
+- If you're evaluating Agentpack vs Stow/chezmoi/yadm:
+  - `explanation/compare-dotfiles-managers.md`
+
+### 5) Architecture (how it works)
+
+- Learn how Agentpack composes overlays, renders targets, and applies safely:
+  - `explanation/architecture.md`
+
 ## Common workflows
 
 - Local customization with overlays (including patch overlays):
   - `explanation/overlays.md` (see `overlay edit --kind patch`)
   - `howto/overlays-create-sparse-materialize-rebase.md`
-- Why Agentpack is not a dotfiles manager (Stow/chezmoi/yadm):
-  - `explanation/compare-dotfiles-managers.md`
 - Drift → proposal → review → merge:
   - `howto/workflows.md`
   - `howto/evolve.md`

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -24,13 +24,21 @@
 - 在临时 HOME/AGENTPACK_HOME 下跑一个安全 demo（不写真实环境）：
   - `tutorials/demo-5min.md`
 
+### 4) 对比（与 dotfiles managers 的边界）
+
+- 如果你正在对比 Agentpack 与 Stow/chezmoi/yadm：
+  - `explanation/compare-dotfiles-managers.md`
+
+### 5) 架构（它如何工作）
+
+- 了解 overlays 组合、targets 渲染、plan/diff 与安全 apply 的整体链路：
+  - `explanation/architecture.md`
+
 ## 常用工作流
 
 - 用 overlays 做本地定制（包括 patch overlays）：
   - `explanation/overlays.md`（见 `overlay edit --kind patch`）
   - `howto/overlays-create-sparse-materialize-rebase.md`
-- “为什么不用 stow/chezmoi/yadm”（边界与适用场景）：
-  - `explanation/compare-dotfiles-managers.md`
 - 漂移 → 提案 → review → 合入：
   - `howto/workflows.md`
   - `howto/evolve.md`

--- a/openspec/changes/update-docs-index-entrypoints/.openspec.yaml
+++ b/openspec/changes/update-docs-index-entrypoints/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-21

--- a/openspec/changes/update-docs-index-entrypoints/README.md
+++ b/openspec/changes/update-docs-index-entrypoints/README.md
@@ -1,0 +1,3 @@
+# update-docs-index-entrypoints
+
+Strengthen docs index entrypoints

--- a/openspec/changes/update-docs-index-entrypoints/proposal.md
+++ b/openspec/changes/update-docs-index-entrypoints/proposal.md
@@ -1,0 +1,12 @@
+# Change: Strengthen docs/index entrypoints
+
+## Why
+New users should be able to choose the right documentation path quickly (quickstart vs import vs demo vs comparison vs architecture) without hunting through multiple pages.
+
+## What Changes
+- Update `docs/index.md` and `docs/zh-CN/index.md` to surface clear entrypoints for: Quickstart, Import, Demo-5min, Compare, and Architecture.
+
+## Impact
+- Affected specs: `agentpack-cli` (docs/discoverability surface)
+- Affected code/docs: docs index pages only
+- Compatibility: no CLI/JSON behavior changes

--- a/openspec/changes/update-docs-index-entrypoints/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-docs-index-entrypoints/specs/agentpack-cli/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Docs index provides fast onboarding entrypoints
+
+The documentation index pages (`docs/index.md` and `docs/zh-CN/index.md`) SHALL provide prominent entrypoints so a new user can quickly choose between:
+Quickstart, Import, Demo-5min, Compare, and Architecture.
+
+#### Scenario: New user chooses a path within 30 seconds
+- **GIVEN** a user opens the docs index page
+- **WHEN** they scan the “start here” entrypoint section
+- **THEN** they can find links to Quickstart, Import, Demo-5min, Compare, and Architecture without scrolling through unrelated sections

--- a/openspec/changes/update-docs-index-entrypoints/tasks.md
+++ b/openspec/changes/update-docs-index-entrypoints/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 Update `docs/index.md` to add prominent entrypoints (Quickstart / Import / Demo-5min / Compare / Architecture)
+- [x] 1.2 Update `docs/zh-CN/index.md` to match the entrypoints
+- [x] 1.3 Run `cargo test --test docs_markdown_links`


### PR DESCRIPTION
Closes #602

Implements backlog item E1-DOC-001 from `docs/dev/agentpack_unified_iteration_plan.md`.

Changes
- Add prominent entrypoints in `docs/index.md` and `docs/zh-CN/index.md` for: Quickstart / Import / Demo-5min / Compare / Architecture.

OpenSpec
- `openspec/changes/update-docs-index-entrypoints/`

Tests
- `cargo test --test docs_markdown_links`
