### PR TITLE
ci: enforce docs/README markdown link checks (E1-DOC-006)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,23 @@ jobs:
 
           echo "rust=$rust" >> "$GITHUB_OUTPUT"
 
+  docs_links:
+    name: Docs links
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.88.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo test docs_markdown_links
+        run: cargo test --locked --test docs_markdown_links
+
   test:
     name: Rust (${{ matrix.os }})
     needs: changed

--- a/openspec/changes/enforce-docs-links-in-ci/.openspec.yaml
+++ b/openspec/changes/enforce-docs-links-in-ci/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-21

--- a/openspec/changes/enforce-docs-links-in-ci/README.md
+++ b/openspec/changes/enforce-docs-links-in-ci/README.md
@@ -1,0 +1,3 @@
+# enforce-docs-links-in-ci
+
+Fail CI on broken docs/README links

--- a/openspec/changes/enforce-docs-links-in-ci/proposal.md
+++ b/openspec/changes/enforce-docs-links-in-ci/proposal.md
@@ -1,0 +1,13 @@
+# Change: Enforce markdown link checks in CI
+
+## Why
+Broken internal links in docs/README directly hurt onboarding. Today, docs-only changes may skip Rust checks in CI, so link regressions can slip through.
+
+## What Changes
+- Expand `tests/docs_markdown_links.rs` to validate links in `docs/` **and** top-level `README.md` / `README.zh-CN.md`.
+- Add a CI job to run the link-check test so broken links fail PR checks even for docs-only changes.
+
+## Impact
+- Affected specs: `agentpack-cli` (docs-as-code / onboarding surface)
+- Affected code/docs: tests + CI workflow
+- Compatibility: no CLI/JSON behavior changes

--- a/openspec/changes/enforce-docs-links-in-ci/specs/agentpack-cli/spec.md
+++ b/openspec/changes/enforce-docs-links-in-ci/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: CI fails on broken markdown links
+
+The repository SHALL validate internal markdown links in `docs/` and top-level README files in CI, and SHALL fail CI when a link target resolves to a missing file.
+
+#### Scenario: Docs-only PR with a broken link is blocked
+- **GIVEN** a PR changes markdown content under `docs/` or `README*.md`
+- **WHEN** it introduces a link to a missing file
+- **THEN** CI fails due to the markdown link check

--- a/openspec/changes/enforce-docs-links-in-ci/tasks.md
+++ b/openspec/changes/enforce-docs-links-in-ci/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 Update `tests/docs_markdown_links.rs` to also scan `README.md` and `README.zh-CN.md`
+- [x] 1.2 Update `.github/workflows/ci.yml` to run `cargo test --test docs_markdown_links` in CI
+- [x] 1.3 Run `cargo test --test docs_markdown_links`


### PR DESCRIPTION
Closes #604

Implements backlog item E1-DOC-006 from `docs/dev/agentpack_unified_iteration_plan.md`.

Changes
- Expand `tests/docs_markdown_links.rs` to scan `docs/` and top-level `README.md` / `README.zh-CN.md`.
- Add a dedicated CI job to run `cargo test --test docs_markdown_links` so broken links fail PR checks even for docs-only changes.

OpenSpec
- `openspec/changes/enforce-docs-links-in-ci/`

Tests
- `cargo test --test docs_markdown_links`
