### PR TITLE
docs: add targets capability matrix (E4-DOC-002)

### DIFF
--- a/docs/reference/targets.md
+++ b/docs/reference/targets.md
@@ -12,6 +12,21 @@ Built-in targets:
 - `jetbrains`
 - `zed`
 
+## Capability matrix (at a glance)
+
+| Target | Maturity | Scopes | Module types | Key outputs (typical) |
+| --- | --- | --- | --- | --- |
+| `codex` | stable | user / project / both | `instructions`, `skill`, `prompt` | `~/.codex/AGENTS.md`<br>`~/.codex/skills/<name>/...`<br>`~/.codex/prompts/<file>.md`<br>`<project_root>/AGENTS.md`<br>`<project_root>/.codex/skills/<name>/...` |
+| `claude_code` | stable | user / project / both | `command`, `skill` | `~/.claude/commands/<name>.md`<br>`<project_root>/.claude/commands/<name>.md`<br>`~/.claude/skills/<name>/...` (opt-in)<br>`<project_root>/.claude/skills/<name>/...` (opt-in) |
+| `cursor` | stable | project | `instructions` | `<project_root>/.cursor/rules/<module>.mdc` |
+| `vscode` | stable | project | `instructions`, `prompt` | `<project_root>/.github/copilot-instructions.md`<br>`<project_root>/.github/prompts/<name>.prompt.md` |
+| `jetbrains` | stable | project | `instructions` | `<project_root>/.junie/guidelines.md` |
+| `zed` | stable | project | `instructions` | `<project_root>/.rules` |
+
+Notes:
+- Exact roots/paths can vary based on target options (especially `codex`); see the per-target sections below.
+- `cursor`, `vscode`, `jetbrains`, and `zed` are project-scope targets.
+
 For shared target fields, see `CONFIG.md`.
 
 ## 1) codex

--- a/docs/zh-CN/reference/targets.md
+++ b/docs/zh-CN/reference/targets.md
@@ -12,6 +12,21 @@ Target 决定 agentpack 要把“编译后的资产”写到哪里，以及哪�
 - `jetbrains`
 - `zed`
 
+## 能力矩阵（速览）
+
+| Target | 成熟度 | Scope | Module types | 主要输出（常见默认） |
+| --- | --- | --- | --- | --- |
+| `codex` | stable | user / project / both | `instructions`, `skill`, `prompt` | `~/.codex/AGENTS.md`<br>`~/.codex/skills/<name>/...`<br>`~/.codex/prompts/<file>.md`<br>`<project_root>/AGENTS.md`<br>`<project_root>/.codex/skills/<name>/...` |
+| `claude_code` | stable | user / project / both | `command`, `skill` | `~/.claude/commands/<name>.md`<br>`<project_root>/.claude/commands/<name>.md`<br>`~/.claude/skills/<name>/...`（可选）<br>`<project_root>/.claude/skills/<name>/...`（可选） |
+| `cursor` | stable | project | `instructions` | `<project_root>/.cursor/rules/<module>.mdc` |
+| `vscode` | stable | project | `instructions`, `prompt` | `<project_root>/.github/copilot-instructions.md`<br>`<project_root>/.github/prompts/<name>.prompt.md` |
+| `jetbrains` | stable | project | `instructions` | `<project_root>/.junie/guidelines.md` |
+| `zed` | stable | project | `instructions` | `<project_root>/.rules` |
+
+说明：
+- 实际 roots/paths 可能会因为 target options 而变化（尤其是 `codex`）；详见下方各 target 的详细说明。
+- `cursor` / `vscode` / `jetbrains` / `zed` 目前都是 project-scope targets。
+
 Target 的通用字段见 `CONFIG.md`。
 
 ## 1) codex

--- a/openspec/changes/add-targets-capability-matrix/.openspec.yaml
+++ b/openspec/changes/add-targets-capability-matrix/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-21

--- a/openspec/changes/add-targets-capability-matrix/README.md
+++ b/openspec/changes/add-targets-capability-matrix/README.md
@@ -1,0 +1,3 @@
+# add-targets-capability-matrix
+
+Add targets capability matrix docs

--- a/openspec/changes/add-targets-capability-matrix/proposal.md
+++ b/openspec/changes/add-targets-capability-matrix/proposal.md
@@ -1,0 +1,12 @@
+# Change: Add targets capability matrix to docs
+
+## Why
+The per-target sections in `docs/reference/targets.md` are detailed, but new users often need a quick “at a glance” view to understand which targets support which module types and scopes.
+
+## What Changes
+- Add a concise capability matrix table to `docs/reference/targets.md` and `docs/zh-CN/reference/targets.md`.
+
+## Impact
+- Affected specs: `agentpack-cli` (docs/reference discoverability)
+- Affected code/docs: docs only
+- Compatibility: no CLI/JSON behavior changes

--- a/openspec/changes/add-targets-capability-matrix/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-targets-capability-matrix/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Targets reference includes a capability matrix
+
+The repository SHALL include a concise capability matrix in the targets reference docs so users can quickly see, per target, supported module types and supported scopes.
+
+#### Scenario: User can compare targets at a glance
+- **GIVEN** a user opens the targets reference page
+- **WHEN** they scan the top section
+- **THEN** they can see a table that compares targets by supported module types and scopes

--- a/openspec/changes/add-targets-capability-matrix/tasks.md
+++ b/openspec/changes/add-targets-capability-matrix/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 Add a targets capability matrix to `docs/reference/targets.md`
+- [x] 1.2 Add a matching matrix to `docs/zh-CN/reference/targets.md`
+- [x] 1.3 Run `cargo test --test docs_markdown_links`


### PR DESCRIPTION
Closes #608

Implements backlog item E4-DOC-002 from `docs/dev/agentpack_unified_iteration_plan.md`.

Changes
- Add an at-a-glance capability matrix to `docs/reference/targets.md` and `docs/zh-CN/reference/targets.md` (targets × scopes × module types × key outputs).

OpenSpec
- `openspec/changes/add-targets-capability-matrix/`

Tests
- `cargo test --test docs_markdown_links`
