### PR TITLE
refactor(app): share preview diff generation

### DIFF
--- a/openspec/changes/refactor-app-preview-diff/.openspec.yaml
+++ b/openspec/changes/refactor-app-preview-diff/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-preview-diff/README.md
+++ b/openspec/changes/refactor-app-preview-diff/README.md
@@ -1,0 +1,3 @@
+# refactor-app-preview-diff
+
+Refactor: extract shared preview diff logic into app layer

--- a/openspec/changes/refactor-app-preview-diff/proposal.md
+++ b/openspec/changes/refactor-app-preview-diff/proposal.md
@@ -1,0 +1,19 @@
+# Change: Refactor preview diff generation into app layer
+
+## Why
+The preview per-file diff payload (`preview --json --diff` / MCP `preview {diff:true}`) is generated in multiple places today (CLI and MCP), which increases the risk of output drift and makes maintenance harder.
+
+This change centralizes the shared “preview diff files” generation logic to keep the contract consistent across interfaces.
+
+## What Changes
+- Add a small internal “app” module that owns shared logic for preview diff file generation.
+- Deduplicate common root-selection logic (`best_root_idx`) used by preview/status/manifest codepaths.
+
+## Impact
+- Affected specs: `agentpack-cli` (preview diff contract), `agentpack-mcp` (preview tool reuses the same envelope).
+- Affected code:
+  - `src/app/*` (new)
+  - `src/cli/commands/preview.rs` (use shared helper)
+  - `src/mcp/tools.rs` (use shared helper)
+  - `src/handlers/status.rs`, `src/target_manifest.rs`, `src/cli/util.rs` (root selection dedupe)
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-preview-diff/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-preview-diff/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Preview diff file generation is shared across interfaces
+The system SHALL centralize preview per-file diff payload generation so that `agentpack preview --json --diff` and the MCP `preview` tool (`diff=true`) remain consistent over time.
+
+#### Scenario: CLI preview and MCP preview remain consistent
+- **GIVEN** the same repo/profile/target inputs
+- **WHEN** the user runs `agentpack preview --json --diff`
+- **AND** an MCP client calls the `preview` tool with `diff=true`
+- **THEN** both responses include `data.diff.files` with the same schema and equivalent entries

--- a/openspec/changes/refactor-app-preview-diff/tasks.md
+++ b/openspec/changes/refactor-app-preview-diff/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared preview diff generation
+- [x] Run `openspec validate refactor-app-preview-diff --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared `best_root_idx` helper (dedupe duplicates)
+- [x] Add `src/app/preview_diff.rs` and wire it into CLI + MCP preview implementations
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod preview_diff;

--- a/src/app/preview_diff.rs
+++ b/src/app/preview_diff.rs
@@ -1,0 +1,99 @@
+use crate::targets::TargetRoot;
+
+const UNIFIED_DIFF_MAX_BYTES: usize = 100 * 1024;
+
+#[derive(serde::Serialize)]
+pub(crate) struct PreviewDiffFile {
+    pub(crate) target: String,
+    pub(crate) root: String,
+    pub(crate) root_posix: String,
+    pub(crate) path: String,
+    pub(crate) path_posix: String,
+    pub(crate) op: crate::deploy::Op,
+    pub(crate) before_hash: Option<String>,
+    pub(crate) after_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) unified: Option<String>,
+}
+
+pub(crate) fn preview_diff_files(
+    plan: &crate::deploy::PlanResult,
+    desired: &crate::deploy::DesiredState,
+    roots: &[TargetRoot],
+    warnings: &mut Vec<String>,
+) -> anyhow::Result<Vec<PreviewDiffFile>> {
+    let mut out = Vec::new();
+
+    for c in &plan.changes {
+        let abs_path = std::path::PathBuf::from(&c.path);
+        let root_idx = crate::roots::best_root_idx(roots, &c.target, &abs_path);
+        let root_path = root_idx
+            .and_then(|idx| roots.get(idx))
+            .map(|r| r.root.as_path());
+        let root = root_path
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let root_posix = root_path
+            .map(crate::paths::path_to_posix_string)
+            .unwrap_or_else(|| "<unknown>".to_string());
+
+        let rel_path = root_idx
+            .and_then(|idx| roots.get(idx))
+            .and_then(|r| abs_path.strip_prefix(&r.root).ok())
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| c.path.clone());
+        let rel_path_posix = rel_path.replace('\\', "/");
+
+        let before_hash = c.before_sha256.as_ref().map(|h| format!("sha256:{h}"));
+        let after_hash = c.after_sha256.as_ref().map(|h| format!("sha256:{h}"));
+
+        let mut unified: Option<String> = None;
+        if matches!(c.op, crate::deploy::Op::Create | crate::deploy::Op::Update) {
+            let before_bytes = std::fs::read(&abs_path).unwrap_or_default();
+            let tp = crate::deploy::TargetPath {
+                target: c.target.clone(),
+                path: abs_path.clone(),
+            };
+            if let Some(df) = desired.get(&tp) {
+                match (
+                    std::str::from_utf8(&before_bytes).ok(),
+                    std::str::from_utf8(&df.bytes).ok(),
+                ) {
+                    (Some(from), Some(to)) => {
+                        let from_name = format!("a/{rel_path}");
+                        let to_name = format!("b/{rel_path}");
+                        let diff = crate::diff::unified_diff(from, to, &from_name, &to_name);
+                        if diff.len() > UNIFIED_DIFF_MAX_BYTES {
+                            warnings.push(format!(
+                                "preview diff omitted for {} {} (over {} bytes)",
+                                c.target, rel_path, UNIFIED_DIFF_MAX_BYTES
+                            ));
+                        } else {
+                            unified = Some(diff);
+                        }
+                    }
+                    _ => {
+                        warnings.push(format!(
+                            "preview diff omitted for {} {} (binary or non-utf8)",
+                            c.target, rel_path
+                        ));
+                    }
+                }
+            }
+        }
+
+        out.push(PreviewDiffFile {
+            target: c.target.clone(),
+            root,
+            root_posix,
+            path: rel_path,
+            path_posix: rel_path_posix,
+            op: c.op.clone(),
+            before_hash,
+            after_hash,
+            unified,
+        });
+    }
+
+    Ok(out)
+}

--- a/src/cli/commands/preview.rs
+++ b/src/cli/commands/preview.rs
@@ -1,25 +1,8 @@
-use crate::deploy::TargetPath;
-use crate::diff::unified_diff;
+use crate::app::preview_diff::preview_diff_files;
 use crate::handlers::read_only::read_only_context;
 use crate::output::{JsonEnvelope, print_json};
 
 use super::Ctx;
-
-const UNIFIED_DIFF_MAX_BYTES: usize = 100 * 1024;
-
-#[derive(serde::Serialize)]
-struct PreviewDiffFile {
-    target: String,
-    root: String,
-    root_posix: String,
-    path: String,
-    path_posix: String,
-    op: crate::deploy::Op,
-    before_hash: Option<String>,
-    after_hash: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    unified: Option<String>,
-}
 
 pub(crate) fn run(ctx: &Ctx<'_>, diff: bool) -> anyhow::Result<()> {
     let crate::handlers::read_only::ReadOnlyContext {
@@ -76,86 +59,4 @@ pub(crate) fn run(ctx: &Ctx<'_>, diff: bool) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-fn preview_diff_files(
-    plan: &crate::deploy::PlanResult,
-    desired: &crate::deploy::DesiredState,
-    roots: &[crate::targets::TargetRoot],
-    warnings: &mut Vec<String>,
-) -> anyhow::Result<Vec<PreviewDiffFile>> {
-    let mut out = Vec::new();
-
-    for c in &plan.changes {
-        let abs_path = std::path::PathBuf::from(&c.path);
-        let root_idx = super::super::util::best_root_idx(roots, &c.target, &abs_path);
-        let root_path = root_idx
-            .and_then(|idx| roots.get(idx))
-            .map(|r| r.root.as_path());
-        let root = root_path
-            .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "<unknown>".to_string());
-        let root_posix = root_path
-            .map(crate::paths::path_to_posix_string)
-            .unwrap_or_else(|| "<unknown>".to_string());
-
-        let rel_path = root_idx
-            .and_then(|idx| roots.get(idx))
-            .and_then(|r| abs_path.strip_prefix(&r.root).ok())
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|| c.path.clone());
-        let rel_path_posix = rel_path.replace('\\', "/");
-
-        let before_hash = c.before_sha256.as_ref().map(|h| format!("sha256:{h}"));
-        let after_hash = c.after_sha256.as_ref().map(|h| format!("sha256:{h}"));
-
-        let mut unified: Option<String> = None;
-        if matches!(c.op, crate::deploy::Op::Create | crate::deploy::Op::Update) {
-            let before_bytes = std::fs::read(&abs_path).unwrap_or_default();
-            let tp = TargetPath {
-                target: c.target.clone(),
-                path: abs_path.clone(),
-            };
-            if let Some(df) = desired.get(&tp) {
-                match (
-                    std::str::from_utf8(&before_bytes).ok(),
-                    std::str::from_utf8(&df.bytes).ok(),
-                ) {
-                    (Some(from), Some(to)) => {
-                        let from_name = format!("a/{rel_path}");
-                        let to_name = format!("b/{rel_path}");
-                        let diff = unified_diff(from, to, &from_name, &to_name);
-                        if diff.len() > UNIFIED_DIFF_MAX_BYTES {
-                            warnings.push(format!(
-                                "preview diff omitted for {} {} (over {} bytes)",
-                                c.target, rel_path, UNIFIED_DIFF_MAX_BYTES
-                            ));
-                        } else {
-                            unified = Some(diff);
-                        }
-                    }
-                    _ => {
-                        warnings.push(format!(
-                            "preview diff omitted for {} {} (binary or non-utf8)",
-                            c.target, rel_path
-                        ));
-                    }
-                }
-            }
-        }
-
-        out.push(PreviewDiffFile {
-            target: c.target.clone(),
-            root,
-            root_posix,
-            path: rel_path,
-            path_posix: rel_path_posix,
-            op: c.op.clone(),
-            before_hash,
-            after_hash,
-            unified,
-        });
-    }
-
-    Ok(out)
 }

--- a/src/cli/util.rs
+++ b/src/cli/util.rs
@@ -64,20 +64,6 @@ pub(crate) fn filter_managed(
         .collect()
 }
 
-pub(crate) fn best_root_idx(
-    roots: &[TargetRoot],
-    target: &str,
-    path: &std::path::Path,
-) -> Option<usize> {
-    roots
-        .iter()
-        .enumerate()
-        .filter(|(_, r)| r.target == target)
-        .filter(|(_, r)| path.strip_prefix(&r.root).is_ok())
-        .max_by_key(|(_, r)| r.root.components().count())
-        .map(|(idx, _)| idx)
-}
-
 pub(crate) fn overlay_dir_for_scope(
     engine: &Engine,
     module_id: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod app;
 pub mod apply;
 pub mod cli;
 pub mod config;
@@ -22,6 +23,7 @@ pub mod policy;
 pub(crate) mod policy_allowlist;
 pub(crate) mod policy_pack;
 pub mod project;
+pub(crate) mod roots;
 pub mod source;
 pub mod state;
 pub mod store;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1519,105 +1519,6 @@ async fn call_evolve_propose_in_process(
 
 async fn call_preview_in_process(args: PreviewArgs) -> anyhow::Result<(String, serde_json::Value)> {
     tokio::task::spawn_blocking(move || {
-        const UNIFIED_DIFF_MAX_BYTES: usize = 100 * 1024;
-
-        #[derive(serde::Serialize)]
-        struct PreviewDiffFile {
-            target: String,
-            root: String,
-            root_posix: String,
-            path: String,
-            path_posix: String,
-            op: crate::deploy::Op,
-            before_hash: Option<String>,
-            after_hash: Option<String>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            unified: Option<String>,
-        }
-
-        fn preview_diff_files(
-            plan: &crate::deploy::PlanResult,
-            desired: &crate::deploy::DesiredState,
-            roots: &[crate::targets::TargetRoot],
-            warnings: &mut Vec<String>,
-        ) -> anyhow::Result<Vec<PreviewDiffFile>> {
-            let mut out = Vec::new();
-
-            for c in &plan.changes {
-                let abs_path = std::path::PathBuf::from(&c.path);
-                let root_idx = crate::cli::util::best_root_idx(roots, &c.target, &abs_path);
-                let root_path = root_idx
-                    .and_then(|idx| roots.get(idx))
-                    .map(|r| r.root.as_path());
-                let root = root_path
-                    .map(|p| p.display().to_string())
-                    .unwrap_or_else(|| "<unknown>".to_string());
-                let root_posix = root_path
-                    .map(crate::paths::path_to_posix_string)
-                    .unwrap_or_else(|| "<unknown>".to_string());
-
-                let rel_path = root_idx
-                    .and_then(|idx| roots.get(idx))
-                    .and_then(|r| abs_path.strip_prefix(&r.root).ok())
-                    .map(|p| p.to_string_lossy().to_string())
-                    .unwrap_or_else(|| c.path.clone());
-                let rel_path_posix = rel_path.replace('\\', "/");
-
-                let before_hash = c.before_sha256.as_ref().map(|h| format!("sha256:{h}"));
-                let after_hash = c.after_sha256.as_ref().map(|h| format!("sha256:{h}"));
-
-                let mut unified: Option<String> = None;
-                if matches!(c.op, crate::deploy::Op::Create | crate::deploy::Op::Update) {
-                    let before_bytes = std::fs::read(&abs_path).unwrap_or_default();
-                    let tp = crate::deploy::TargetPath {
-                        target: c.target.clone(),
-                        path: abs_path.clone(),
-                    };
-                    if let Some(df) = desired.get(&tp) {
-                        match (
-                            std::str::from_utf8(&before_bytes).ok(),
-                            std::str::from_utf8(&df.bytes).ok(),
-                        ) {
-                            (Some(from), Some(to)) => {
-                                let from_name = format!("a/{rel_path}");
-                                let to_name = format!("b/{rel_path}");
-                                let diff =
-                                    crate::diff::unified_diff(from, to, &from_name, &to_name);
-                                if diff.len() > UNIFIED_DIFF_MAX_BYTES {
-                                    warnings.push(format!(
-                                        "preview diff omitted for {} {} (over {} bytes)",
-                                        c.target, rel_path, UNIFIED_DIFF_MAX_BYTES
-                                    ));
-                                } else {
-                                    unified = Some(diff);
-                                }
-                            }
-                            _ => {
-                                warnings.push(format!(
-                                    "preview diff omitted for {} {} (binary or non-utf8)",
-                                    c.target, rel_path
-                                ));
-                            }
-                        }
-                    }
-                }
-
-                out.push(PreviewDiffFile {
-                    target: c.target.clone(),
-                    root,
-                    root_posix,
-                    path: rel_path,
-                    path_posix: rel_path_posix,
-                    op: c.op.clone(),
-                    before_hash,
-                    after_hash,
-                    unified,
-                });
-            }
-
-            Ok(out)
-        }
-
         let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
         let profile = args.common.profile.as_deref().unwrap_or("default");
         let target = args.common.target.as_deref().unwrap_or("all");
@@ -1649,7 +1550,12 @@ async fn call_preview_in_process(args: PreviewArgs) -> anyhow::Result<(String, s
                     },
                 });
                 if args.diff {
-                    let files = preview_diff_files(&plan, &desired, &roots, &mut warnings)?;
+                    let files = crate::app::preview_diff::preview_diff_files(
+                        &plan,
+                        &desired,
+                        &roots,
+                        &mut warnings,
+                    )?;
                     data["diff"] = serde_json::json!({
                         "changes": plan.changes,
                         "summary": plan.summary,

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -1,0 +1,13 @@
+use std::path::Path;
+
+use crate::targets::TargetRoot;
+
+pub(crate) fn best_root_idx(roots: &[TargetRoot], target: &str, path: &Path) -> Option<usize> {
+    roots
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.target == target)
+        .filter(|(_, r)| path.strip_prefix(&r.root).is_ok())
+        .max_by_key(|(_, r)| r.root.components().count())
+        .map(|(idx, _)| idx)
+}

--- a/src/target_manifest.rs
+++ b/src/target_manifest.rs
@@ -228,16 +228,6 @@ fn ensure_safe_relative_path(p: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn best_root_idx(roots: &[TargetRoot], target: &str, path: &Path) -> Option<usize> {
-    roots
-        .iter()
-        .enumerate()
-        .filter(|(_, r)| r.target == target)
-        .filter(|(_, r)| path.strip_prefix(&r.root).is_ok())
-        .max_by_key(|(_, r)| r.root.components().count())
-        .map(|(idx, _)| idx)
-}
-
 pub(crate) fn manifests_missing_for_desired(
     roots: &[TargetRoot],
     desired: &crate::deploy::DesiredState,
@@ -248,7 +238,7 @@ pub(crate) fn manifests_missing_for_desired(
 
     let mut used: Vec<bool> = vec![false; roots.len()];
     for tp in desired.keys() {
-        if let Some(idx) = best_root_idx(roots, &tp.target, &tp.path) {
+        if let Some(idx) = crate::roots::best_root_idx(roots, &tp.target, &tp.path) {
             used[idx] = true;
         }
     }


### PR DESCRIPTION
Closes #617.

## Summary
- Introduce `src/app/preview_diff.rs` for shared preview per-file diff generation.
- Deduplicate `best_root_idx` as `src/roots.rs` and use it from the relevant code paths.

## Rationale
- The preview per-file diff payload was duplicated in CLI and MCP; this refactor keeps them consistent and reduces maintenance overhead.

## Testing
- `openspec validate refactor-app-preview-diff --type change --strict --no-interactive`
- `just check`
