### PR TITLE
refactor(app): share status next_actions helpers

### DIFF
--- a/openspec/changes/refactor-app-next-actions/.openspec.yaml
+++ b/openspec/changes/refactor-app-next-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-next-actions/README.md
+++ b/openspec/changes/refactor-app-next-actions/README.md
@@ -1,0 +1,3 @@
+# refactor-app-next-actions
+
+Refactor: share status next_actions ordering between CLI and MCP

--- a/openspec/changes/refactor-app-next-actions/proposal.md
+++ b/openspec/changes/refactor-app-next-actions/proposal.md
@@ -1,0 +1,22 @@
+# Change: Refactor status next_actions ordering into app layer
+
+## Why
+The “next actions” helpers (ordering + action codes) are currently duplicated between:
+- CLI `status --json` (`src/cli/commands/status.rs`)
+- MCP `status` tool (`src/mcp/tools.rs`)
+
+This duplication increases the risk of drift (different ordering, different `next_actions_detailed.action` codes) and makes future changes harder to review.
+
+## What Changes
+- Introduce a small shared helper module under `src/app/` for:
+  - ordering next action commands
+  - mapping commands → stable action codes (for `next_actions_detailed`)
+- Wire both CLI status and MCP status to use this shared module.
+
+## Impact
+- Affected specs: `agentpack-cli` (status additive fields), `agentpack-mcp` (status tool reuses the CLI envelope).
+- Affected code:
+  - `src/app/next_actions.rs` (new)
+  - `src/cli/commands/status.rs` (dedupe helpers)
+  - `src/mcp/tools.rs` (dedupe helpers)
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: status next_actions ordering is consistent across CLI and MCP
+The system SHALL centralize the `next_actions` ordering and `next_actions_detailed.action` mapping logic so that CLI `status --json` and the MCP `status` tool remain consistent over time.
+
+#### Scenario: next_actions and next_actions_detailed remain consistent
+- **GIVEN** the same repo/profile/target inputs
+- **WHEN** the user runs `agentpack status --json`
+- **AND** an MCP client calls the `status` tool
+- **THEN** both responses include equivalent ordering for `data.next_actions`
+- **AND** both use the same `next_actions_detailed.action` codes for equivalent commands

--- a/openspec/changes/refactor-app-next-actions/tasks.md
+++ b/openspec/changes/refactor-app-next-actions/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared next_actions ordering
+- [x] Run `openspec validate refactor-app-next-actions --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add `src/app/next_actions.rs`
+- [x] Update CLI status and MCP status to use shared helpers
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod next_actions;
 pub(crate) mod preview_diff;

--- a/src/app/next_actions.rs
+++ b/src/app/next_actions.rs
@@ -1,0 +1,86 @@
+pub(crate) fn ordered_next_actions(actions: &std::collections::BTreeSet<String>) -> Vec<String> {
+    let mut out: Vec<String> = actions.iter().cloned().collect();
+    out.sort_by(|a, b| {
+        next_action_priority(a)
+            .cmp(&next_action_priority(b))
+            .then_with(|| a.cmp(b))
+    });
+    out
+}
+
+pub(crate) fn next_action_code(action: &str) -> &'static str {
+    match next_action_subcommand(action) {
+        Some("bootstrap") => "bootstrap",
+        Some("doctor") => "doctor",
+        Some("update") => "update",
+        Some("preview") => {
+            if action.contains(" --diff") {
+                "preview_diff"
+            } else {
+                "preview"
+            }
+        }
+        Some("diff") => "diff",
+        Some("plan") => "plan",
+        Some("deploy") => {
+            if action.contains(" --apply") {
+                "deploy_apply"
+            } else {
+                "deploy"
+            }
+        }
+        Some("status") => "status",
+        Some("evolve") => {
+            if action.contains(" propose") {
+                "evolve_propose"
+            } else if action.contains(" restore") {
+                "evolve_restore"
+            } else {
+                "evolve"
+            }
+        }
+        Some("rollback") => "rollback",
+        _ => "other",
+    }
+}
+
+fn next_action_priority(action: &str) -> u8 {
+    match next_action_subcommand(action) {
+        Some("bootstrap") => 0,
+        Some("doctor") => 10,
+        Some("update") => 20,
+        Some("preview") => 30,
+        Some("diff") => 40,
+        Some("plan") => 50,
+        Some("deploy") => 60,
+        Some("status") => 70,
+        Some("evolve") => {
+            if action.contains(" propose") {
+                80
+            } else {
+                81
+            }
+        }
+        Some("rollback") => 90,
+        _ => 100,
+    }
+}
+
+fn next_action_subcommand(action: &str) -> Option<&str> {
+    let mut iter = action.split_whitespace();
+    // Skip program name ("agentpack") and global flags (and their args).
+    let _ = iter.next()?;
+
+    while let Some(tok) = iter.next() {
+        if !tok.starts_with("--") {
+            return Some(tok);
+        }
+
+        // Skip flag value for the flags we know to take an argument.
+        if matches!(tok, "--repo" | "--profile" | "--target" | "--machine") {
+            let _ = iter.next();
+        }
+    }
+
+    None
+}

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -1,5 +1,6 @@
 use anyhow::Context as _;
 
+use crate::app::next_actions::{next_action_code, ordered_next_actions};
 use crate::config::TargetScope;
 use crate::engine::Engine;
 use crate::output::{JsonEnvelope, print_json};
@@ -588,91 +589,4 @@ fn action_prefix(cli: &crate::cli::args::Cli) -> String {
         out.push_str(&format!(" --machine {machine}"));
     }
     out
-}
-
-fn ordered_next_actions(actions: &std::collections::BTreeSet<String>) -> Vec<String> {
-    let mut out: Vec<String> = actions.iter().cloned().collect();
-    out.sort_by(|a, b| {
-        next_action_priority(a)
-            .cmp(&next_action_priority(b))
-            .then_with(|| a.cmp(b))
-    });
-    out
-}
-
-fn next_action_priority(action: &str) -> u8 {
-    match next_action_subcommand(action) {
-        Some("bootstrap") => 0,
-        Some("doctor") => 10,
-        Some("update") => 20,
-        Some("preview") => 30,
-        Some("diff") => 40,
-        Some("plan") => 50,
-        Some("deploy") => 60,
-        Some("status") => 70,
-        Some("evolve") => {
-            if action.contains(" propose") {
-                80
-            } else {
-                81
-            }
-        }
-        Some("rollback") => 90,
-        _ => 100,
-    }
-}
-
-fn next_action_code(action: &str) -> &'static str {
-    match next_action_subcommand(action) {
-        Some("bootstrap") => "bootstrap",
-        Some("doctor") => "doctor",
-        Some("update") => "update",
-        Some("preview") => {
-            if action.contains(" --diff") {
-                "preview_diff"
-            } else {
-                "preview"
-            }
-        }
-        Some("diff") => "diff",
-        Some("plan") => "plan",
-        Some("deploy") => {
-            if action.contains(" --apply") {
-                "deploy_apply"
-            } else {
-                "deploy"
-            }
-        }
-        Some("status") => "status",
-        Some("evolve") => {
-            if action.contains(" propose") {
-                "evolve_propose"
-            } else if action.contains(" restore") {
-                "evolve_restore"
-            } else {
-                "evolve"
-            }
-        }
-        Some("rollback") => "rollback",
-        _ => "other",
-    }
-}
-
-fn next_action_subcommand(action: &str) -> Option<&str> {
-    let mut iter = action.split_whitespace();
-    // Skip program name ("agentpack") and global flags (and their args).
-    let _ = iter.next()?;
-
-    while let Some(tok) = iter.next() {
-        if !tok.starts_with("--") {
-            return Some(tok);
-        }
-
-        // Skip flag value for the flags we know to take an argument.
-        if matches!(tok, "--repo" | "--profile" | "--target" | "--machine") {
-            let _ = iter.next();
-        }
-    }
-
-    None
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -7,6 +7,7 @@ use rmcp::{
     model::{CallToolRequestParam, CallToolResult, Content, JsonObject, Tool, ToolAnnotations},
 };
 
+use crate::app::next_actions::{next_action_code, ordered_next_actions};
 use crate::user_error::UserError;
 
 use super::confirm::{CONFIRM_TOKEN_TTL, ConfirmTokenBinding};
@@ -282,93 +283,6 @@ fn bootstrap_action(common: &CommonArgs, target: &str, scope: &str) -> String {
     }
     out.push_str(&format!(" --target {target} bootstrap --scope {scope}"));
     out
-}
-
-fn ordered_next_actions(actions: &std::collections::BTreeSet<String>) -> Vec<String> {
-    let mut out: Vec<String> = actions.iter().cloned().collect();
-    out.sort_by(|a, b| {
-        next_action_priority(a)
-            .cmp(&next_action_priority(b))
-            .then_with(|| a.cmp(b))
-    });
-    out
-}
-
-fn next_action_priority(action: &str) -> u8 {
-    match next_action_subcommand(action) {
-        Some("bootstrap") => 0,
-        Some("doctor") => 10,
-        Some("update") => 20,
-        Some("preview") => 30,
-        Some("diff") => 40,
-        Some("plan") => 50,
-        Some("deploy") => 60,
-        Some("status") => 70,
-        Some("evolve") => {
-            if action.contains(" propose") {
-                80
-            } else {
-                81
-            }
-        }
-        Some("rollback") => 90,
-        _ => 100,
-    }
-}
-
-fn next_action_code(action: &str) -> &'static str {
-    match next_action_subcommand(action) {
-        Some("bootstrap") => "bootstrap",
-        Some("doctor") => "doctor",
-        Some("update") => "update",
-        Some("preview") => {
-            if action.contains(" --diff") {
-                "preview_diff"
-            } else {
-                "preview"
-            }
-        }
-        Some("diff") => "diff",
-        Some("plan") => "plan",
-        Some("deploy") => {
-            if action.contains(" --apply") {
-                "deploy_apply"
-            } else {
-                "deploy"
-            }
-        }
-        Some("status") => "status",
-        Some("evolve") => {
-            if action.contains(" propose") {
-                "evolve_propose"
-            } else if action.contains(" restore") {
-                "evolve_restore"
-            } else {
-                "evolve"
-            }
-        }
-        Some("rollback") => "rollback",
-        _ => "other",
-    }
-}
-
-fn next_action_subcommand(action: &str) -> Option<&str> {
-    let mut iter = action.split_whitespace();
-    // Skip program name (usually "agentpack") and global flags (and their args).
-    let _ = iter.next()?;
-
-    while let Some(tok) = iter.next() {
-        if !tok.starts_with("--") {
-            return Some(tok);
-        }
-
-        // Skip flag value for the flags we know to take an argument.
-        if matches!(tok, "--repo" | "--profile" | "--target" | "--machine") {
-            let _ = iter.next();
-        }
-    }
-
-    None
 }
 
 fn extract_agentpack_version(text: &str) -> Option<String> {


### PR DESCRIPTION
Closes #620.

## What
- Centralize next_actions ordering + action code mapping under `src/app/next_actions.rs`.
- Wire CLI `status --json` and MCP `status` to use the shared helpers.

## Why
Avoid drift between CLI and MCP (ordering + `next_actions_detailed.action`).

## Tests
- `just check`
- `openspec validate refactor-app-next-actions --type change --strict --no-interactive`