### PR TITLE
refactor(app): share operator assets checks

### DIFF
--- a/openspec/changes/refactor-app-operator-assets/.openspec.yaml
+++ b/openspec/changes/refactor-app-operator-assets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-operator-assets/README.md
+++ b/openspec/changes/refactor-app-operator-assets/README.md
@@ -1,0 +1,3 @@
+# refactor-app-operator-assets
+
+Refactor: share operator assets checks between CLI and MCP

--- a/openspec/changes/refactor-app-operator-assets/proposal.md
+++ b/openspec/changes/refactor-app-operator-assets/proposal.md
@@ -1,0 +1,22 @@
+# Change: Refactor operator assets checks into app layer
+
+## Why
+The operator assets checks (used for `status` warnings / next actions) are duplicated between:
+- CLI `status` (`src/cli/commands/status.rs`)
+- MCP `status` tool (`src/mcp/tools.rs`)
+
+This duplication increases the risk of drift (different warning messages, different suggestion behavior) and makes maintenance harder.
+
+## What Changes
+- Introduce a small shared helper module under `src/app/` for:
+  - extracting `agentpack_version` from operator assets
+  - checking operator asset files / command directories and emitting warnings + suggestions
+- Wire both CLI status and MCP status to use the shared helpers.
+
+## Impact
+- Affected specs: `agentpack-cli` (status warnings are shared by MCP), `agentpack-mcp` (status tool reuses the CLI envelope).
+- Affected code:
+  - `src/app/operator_assets.rs` (new)
+  - `src/cli/commands/status.rs` (dedupe helpers)
+  - `src/mcp/tools.rs` (dedupe helpers)
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-operator-assets/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-operator-assets/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: operator assets warnings remain consistent across CLI and MCP
+The system SHALL centralize the operator assets checking logic used by CLI `status` and the MCP `status` tool so that warnings and suggested actions remain consistent over time.
+
+#### Scenario: status operator assets warnings remain consistent
+- **GIVEN** a repo/profile/target where operator assets are missing or outdated
+- **WHEN** the user runs `agentpack status`
+- **AND** an MCP client calls the `status` tool
+- **THEN** both surfaces emit equivalent warnings and suggested remediation actions

--- a/openspec/changes/refactor-app-operator-assets/tasks.md
+++ b/openspec/changes/refactor-app-operator-assets/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared operator assets checks
+- [x] Run `openspec validate refactor-app-operator-assets --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add `src/app/operator_assets.rs`
+- [x] Update CLI status and MCP status to use shared helpers
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod next_actions;
+pub(crate) mod operator_assets;
 pub(crate) mod preview_diff;

--- a/src/app/operator_assets.rs
+++ b/src/app/operator_assets.rs
@@ -1,0 +1,128 @@
+use anyhow::Context as _;
+
+pub(crate) fn extract_agentpack_version(text: &str) -> Option<String> {
+    for line in text.lines() {
+        if let Some((_, rest)) = line.split_once("agentpack_version:") {
+            let mut value = rest.trim();
+            value = value.trim_end_matches("-->");
+            value = value.trim();
+            value = value.trim_matches(|c| c == '"' || c == '\'');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+pub(crate) fn check_operator_file(
+    path: &std::path::Path,
+    location: &str,
+    current: &str,
+    warnings: &mut Vec<String>,
+    suggested: &str,
+    record_next_action: &mut impl FnMut(&str),
+) -> anyhow::Result<()> {
+    if !path.exists() {
+        warnings.push(format!(
+            "operator assets missing ({location}): {}; run: {suggested}",
+            path.display()
+        ));
+        record_next_action(suggested);
+        return Ok(());
+    }
+
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("read operator asset {}", path.display()))?;
+    let Some(have) = extract_agentpack_version(&text) else {
+        warnings.push(format!(
+            "operator assets missing agentpack_version ({location}): {}; run: {suggested}",
+            path.display()
+        ));
+        record_next_action(suggested);
+        return Ok(());
+    };
+
+    if have != current {
+        warnings.push(format!(
+            "operator assets outdated ({location}): {} has {}, want {}; run: {suggested}",
+            path.display(),
+            have,
+            current
+        ));
+        record_next_action(suggested);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn check_operator_command_dir(
+    dir: &std::path::Path,
+    location: &str,
+    current: &str,
+    warnings: &mut Vec<String>,
+    suggested: &str,
+    record_next_action: &mut impl FnMut(&str),
+) -> anyhow::Result<()> {
+    if !dir.exists() {
+        warnings.push(format!(
+            "operator assets missing ({location}): {}; run: {suggested}",
+            dir.display()
+        ));
+        record_next_action(suggested);
+        return Ok(());
+    }
+
+    let mut missing = Vec::new();
+    let mut missing_version = None;
+    for name in [
+        "ap-doctor.md",
+        "ap-update.md",
+        "ap-preview.md",
+        "ap-plan.md",
+        "ap-deploy.md",
+        "ap-status.md",
+        "ap-diff.md",
+        "ap-explain.md",
+        "ap-evolve.md",
+    ] {
+        let path = dir.join(name);
+        if !path.exists() {
+            missing.push(name.to_string());
+            continue;
+        }
+        let text = std::fs::read_to_string(&path)
+            .with_context(|| format!("read operator asset {}", path.display()))?;
+        let Some(have) = extract_agentpack_version(&text) else {
+            missing_version = Some(path);
+            continue;
+        };
+        if have != current {
+            warnings.push(format!(
+                "operator assets outdated ({location}): {} has {}, want {}; run: {suggested}",
+                path.display(),
+                have,
+                current
+            ));
+        }
+    }
+
+    if let Some(path) = missing_version {
+        warnings.push(format!(
+            "operator assets missing agentpack_version ({location}): {}; run: {suggested}",
+            path.display()
+        ));
+        record_next_action(suggested);
+        return Ok(());
+    }
+
+    if !missing.is_empty() {
+        warnings.push(format!(
+            "operator assets incomplete ({location}): missing {}; run: {suggested}",
+            missing.join(", "),
+        ));
+        record_next_action(suggested);
+    }
+
+    Ok(())
+}

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -1,6 +1,7 @@
 use anyhow::Context as _;
 
 use crate::app::next_actions::{next_action_code, ordered_next_actions};
+use crate::app::operator_assets::{check_operator_command_dir, check_operator_file};
 use crate::config::TargetScope;
 use crate::engine::Engine;
 use crate::output::{JsonEnvelope, print_json};
@@ -309,21 +310,6 @@ fn get_bool(
     }
 }
 
-fn extract_agentpack_version(text: &str) -> Option<String> {
-    for line in text.lines() {
-        if let Some((_, rest)) = line.split_once("agentpack_version:") {
-            let mut value = rest.trim();
-            value = value.trim_end_matches("-->");
-            value = value.trim();
-            value = value.trim_matches(|c| c == '"' || c == '\'');
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-        }
-    }
-    None
-}
-
 fn warn_operator_assets_if_outdated(
     engine: &Engine,
     cli: &crate::cli::args::Cli,
@@ -332,6 +318,12 @@ fn warn_operator_assets_if_outdated(
     next_actions: &mut NextActions,
 ) -> anyhow::Result<()> {
     let current = env!("CARGO_PKG_VERSION");
+    let mut record_next_action = |suggested: &str| {
+        next_actions.human.insert(suggested.to_string());
+        next_actions
+            .json
+            .insert(format!("{suggested} --yes --json"));
+    };
 
     for target in targets {
         match target.as_str() {
@@ -350,7 +342,7 @@ fn warn_operator_assets_if_outdated(
                         current,
                         warnings,
                         &bootstrap_action(cli, "codex", "user"),
-                        next_actions,
+                        &mut record_next_action,
                     )?;
                 }
                 if allow_project {
@@ -364,7 +356,7 @@ fn warn_operator_assets_if_outdated(
                         current,
                         warnings,
                         &bootstrap_action(cli, "codex", "project"),
-                        next_actions,
+                        &mut record_next_action,
                     )?;
                 }
             }
@@ -386,7 +378,7 @@ fn warn_operator_assets_if_outdated(
                         current,
                         warnings,
                         &bootstrap_action(cli, "claude_code", "user"),
-                        next_actions,
+                        &mut record_next_action,
                     )?;
                     if check_user_skills {
                         let skills_dir = super::super::util::expand_tilde("~/.claude/skills")?;
@@ -396,7 +388,7 @@ fn warn_operator_assets_if_outdated(
                             current,
                             warnings,
                             &bootstrap_action(cli, "claude_code", "user"),
-                            next_actions,
+                            &mut record_next_action,
                         )?;
                     }
                 }
@@ -408,7 +400,7 @@ fn warn_operator_assets_if_outdated(
                         current,
                         warnings,
                         &bootstrap_action(cli, "claude_code", "project"),
-                        next_actions,
+                        &mut record_next_action,
                     )?;
                     if check_repo_skills {
                         check_operator_file(
@@ -420,143 +412,13 @@ fn warn_operator_assets_if_outdated(
                             current,
                             warnings,
                             &bootstrap_action(cli, "claude_code", "project"),
-                            next_actions,
+                            &mut record_next_action,
                         )?;
                     }
                 }
             }
             _ => {}
         }
-    }
-
-    Ok(())
-}
-
-fn check_operator_file(
-    path: &std::path::Path,
-    location: &str,
-    current: &str,
-    warnings: &mut Vec<String>,
-    suggested: &str,
-    next_actions: &mut NextActions,
-) -> anyhow::Result<()> {
-    if !path.exists() {
-        warnings.push(format!(
-            "operator assets missing ({location}): {}; run: {suggested}",
-            path.display()
-        ));
-        next_actions.human.insert(suggested.to_string());
-        next_actions
-            .json
-            .insert(format!("{suggested} --yes --json"));
-        return Ok(());
-    }
-
-    let text = std::fs::read_to_string(path)
-        .with_context(|| format!("read operator asset {}", path.display()))?;
-    let Some(have) = extract_agentpack_version(&text) else {
-        warnings.push(format!(
-            "operator assets missing agentpack_version ({location}): {}; run: {suggested}",
-            path.display()
-        ));
-        next_actions.human.insert(suggested.to_string());
-        next_actions
-            .json
-            .insert(format!("{suggested} --yes --json"));
-        return Ok(());
-    };
-
-    if have != current {
-        warnings.push(format!(
-            "operator assets outdated ({location}): {} has {}, want {}; run: {suggested}",
-            path.display(),
-            have,
-            current
-        ));
-        next_actions.human.insert(suggested.to_string());
-        next_actions
-            .json
-            .insert(format!("{suggested} --yes --json"));
-    }
-
-    Ok(())
-}
-
-fn check_operator_command_dir(
-    dir: &std::path::Path,
-    location: &str,
-    current: &str,
-    warnings: &mut Vec<String>,
-    suggested: &str,
-    next_actions: &mut NextActions,
-) -> anyhow::Result<()> {
-    if !dir.exists() {
-        warnings.push(format!(
-            "operator assets missing ({location}): {}; run: {suggested}",
-            dir.display()
-        ));
-        next_actions.human.insert(suggested.to_string());
-        next_actions
-            .json
-            .insert(format!("{suggested} --yes --json"));
-        return Ok(());
-    }
-
-    let mut missing = Vec::new();
-    let mut missing_version = None;
-    for name in [
-        "ap-doctor.md",
-        "ap-update.md",
-        "ap-preview.md",
-        "ap-plan.md",
-        "ap-deploy.md",
-        "ap-status.md",
-        "ap-diff.md",
-        "ap-explain.md",
-        "ap-evolve.md",
-    ] {
-        let path = dir.join(name);
-        if !path.exists() {
-            missing.push(name.to_string());
-            continue;
-        }
-        let text = std::fs::read_to_string(&path)
-            .with_context(|| format!("read operator asset {}", path.display()))?;
-        let Some(have) = extract_agentpack_version(&text) else {
-            missing_version = Some(path);
-            continue;
-        };
-        if have != current {
-            warnings.push(format!(
-                "operator assets outdated ({location}): {} has {}, want {}; run: {suggested}",
-                path.display(),
-                have,
-                current
-            ));
-        }
-    }
-
-    if let Some(path) = missing_version {
-        warnings.push(format!(
-            "operator assets missing agentpack_version ({location}): {}; run: {suggested}",
-            path.display()
-        ));
-        next_actions.human.insert(suggested.to_string());
-        next_actions
-            .json
-            .insert(format!("{suggested} --yes --json"));
-        return Ok(());
-    }
-
-    if !missing.is_empty() {
-        warnings.push(format!(
-            "operator assets incomplete ({location}): missing {}; run: {suggested}",
-            missing.join(", "),
-        ));
-        next_actions.human.insert(suggested.to_string());
-        next_actions
-            .json
-            .insert(format!("{suggested} --yes --json"));
     }
 
     Ok(())


### PR DESCRIPTION
Closes #623.

## What
- Add `src/app/operator_assets.rs` with shared operator assets helpers.
- Reuse the shared helpers from CLI `status` and MCP `status`.

## Why
Reduce duplication and prevent CLI/MCP warning + suggestion drift.

## Tests
- `just check`
- `openspec validate refactor-app-operator-assets --type change --strict --no-interactive`