### PR TITLE
refactor(app): share status drift summary helpers

### DIFF
--- a/openspec/changes/refactor-app-status-drift-summary/.openspec.yaml
+++ b/openspec/changes/refactor-app-status-drift-summary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-status-drift-summary/README.md
+++ b/openspec/changes/refactor-app-status-drift-summary/README.md
@@ -1,0 +1,3 @@
+# refactor-app-status-drift-summary
+
+Refactor: share status drift summary helpers between CLI and MCP

--- a/openspec/changes/refactor-app-status-drift-summary/proposal.md
+++ b/openspec/changes/refactor-app-status-drift-summary/proposal.md
@@ -1,0 +1,21 @@
+# Change: Refactor status drift summary helpers into app layer
+
+## Why
+The `status` drift summary helpers (notably `summary_by_root` and the filtered `summary` recomputation) are duplicated between:
+- CLI `status --json` (`src/cli/commands/status.rs`)
+- MCP `status` tool (`src/mcp/tools.rs`)
+
+This duplication increases the risk of drift (ordering, counts, and grouping behavior) and makes future changes harder to review.
+
+## What Changes
+- Introduce small shared helpers under `src/app/` for:
+  - computing drift summaries (`summary`, `summary_by_root`)
+- Wire both CLI status and MCP status to use this shared module.
+
+## Impact
+- Affected specs: `agentpack-cli` (status json), `agentpack-mcp` (status tool reuses the CLI envelope).
+- Affected code:
+  - `src/app/status_drift.rs` (new)
+  - `src/cli/commands/status.rs` (dedupe helpers)
+  - `src/mcp/tools.rs` (dedupe helpers)
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-status-drift-summary/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-status-drift-summary/specs/agentpack-cli/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: status drift summaries are consistent across CLI and MCP
+The system SHALL centralize status drift summary computations (`summary`, `summary_by_root`) so that CLI `status --json` and the MCP `status` tool remain consistent over time.
+
+#### Scenario: drift summaries remain consistent
+- **GIVEN** the same repo/profile/target inputs and drift state
+- **WHEN** the user runs `agentpack status --json`
+- **AND** an MCP client calls the `status` tool
+- **THEN** both responses include equivalent `data.summary`
+- **AND** both responses include equivalent `data.summary_by_root` ordering and counts

--- a/openspec/changes/refactor-app-status-drift-summary/tasks.md
+++ b/openspec/changes/refactor-app-status-drift-summary/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared status drift summary helpers
+- [x] Run `openspec validate refactor-app-status-drift-summary --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add `src/app/status_drift.rs`
+- [x] Update CLI status and MCP status to use shared helpers
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod next_actions;
 pub(crate) mod operator_assets;
 pub(crate) mod preview_diff;
+pub(crate) mod status_drift;

--- a/src/app/status_drift.rs
+++ b/src/app/status_drift.rs
@@ -1,0 +1,49 @@
+#[derive(serde::Serialize)]
+pub(crate) struct DriftSummaryByRoot {
+    pub(crate) target: String,
+    pub(crate) root: String,
+    pub(crate) root_posix: String,
+    pub(crate) summary: crate::handlers::status::DriftSummary,
+}
+
+pub(crate) fn drift_summary(
+    drift: &[crate::handlers::status::DriftItem],
+) -> crate::handlers::status::DriftSummary {
+    let mut summary = crate::handlers::status::DriftSummary::default();
+    for d in drift {
+        match d.kind.as_str() {
+            "modified" => summary.modified += 1,
+            "missing" => summary.missing += 1,
+            "extra" => summary.extra += 1,
+            _ => {}
+        }
+    }
+    summary
+}
+
+pub(crate) fn drift_summary_by_root(
+    drift: &[crate::handlers::status::DriftItem],
+) -> Vec<DriftSummaryByRoot> {
+    let mut by_root: std::collections::BTreeMap<(String, String), DriftSummaryByRoot> =
+        std::collections::BTreeMap::new();
+
+    for d in drift {
+        let root = d.root.as_deref().unwrap_or("<unknown>").to_string();
+        let root_posix = d.root_posix.as_deref().unwrap_or("<unknown>").to_string();
+        let key = (d.target.clone(), root_posix.clone());
+        let entry = by_root.entry(key).or_insert_with(|| DriftSummaryByRoot {
+            target: d.target.clone(),
+            root,
+            root_posix,
+            summary: crate::handlers::status::DriftSummary::default(),
+        });
+        match d.kind.as_str() {
+            "modified" => entry.summary.modified += 1,
+            "missing" => entry.summary.missing += 1,
+            "extra" => entry.summary.extra += 1,
+            _ => {}
+        }
+    }
+
+    by_root.into_values().collect()
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -9,6 +9,7 @@ use rmcp::{
 
 use crate::app::next_actions::{next_action_code, ordered_next_actions};
 use crate::app::operator_assets::{check_operator_command_dir, check_operator_file};
+use crate::app::status_drift::{drift_summary, drift_summary_by_root};
 use crate::user_error::UserError;
 
 use super::confirm::{CONFIRM_TOKEN_TTL, ConfirmTokenBinding};
@@ -527,14 +528,6 @@ async fn call_status_in_process(args: StatusArgs) -> anyhow::Result<(String, ser
         }
 
         #[derive(serde::Serialize)]
-        struct DriftSummaryByRoot {
-            target: String,
-            root: String,
-            root_posix: String,
-            summary: crate::handlers::status::DriftSummary,
-        }
-
-        #[derive(serde::Serialize)]
         struct NextActionDetailed {
             action: String,
             command: String,
@@ -620,46 +613,11 @@ async fn call_status_in_process(args: StatusArgs) -> anyhow::Result<(String, ser
                     .into_iter()
                     .filter(|d| only_kinds.contains(d.kind.as_str()))
                     .collect();
-
-                let mut summary = crate::handlers::status::DriftSummary::default();
-                for d in &drift {
-                    match d.kind.as_str() {
-                        "modified" => summary.modified += 1,
-                        "missing" => summary.missing += 1,
-                        "extra" => summary.extra += 1,
-                        _ => {}
-                    }
-                }
+                let summary = drift_summary(&drift);
 
                 (drift, summary, Some(summary_total))
             };
-
-            let summary_by_root =
-                |drift: &[crate::handlers::status::DriftItem]| -> Vec<DriftSummaryByRoot> {
-                    let mut by_root: std::collections::BTreeMap<
-                        (String, String),
-                        DriftSummaryByRoot,
-                    > = std::collections::BTreeMap::new();
-                    for d in drift {
-                        let root = d.root.as_deref().unwrap_or("<unknown>").to_string();
-                        let root_posix = d.root_posix.as_deref().unwrap_or("<unknown>").to_string();
-                        let key = (d.target.clone(), root_posix.clone());
-                        let entry = by_root.entry(key).or_insert_with(|| DriftSummaryByRoot {
-                            target: d.target.clone(),
-                            root,
-                            root_posix,
-                            summary: crate::handlers::status::DriftSummary::default(),
-                        });
-                        match d.kind.as_str() {
-                            "modified" => entry.summary.modified += 1,
-                            "missing" => entry.summary.missing += 1,
-                            "extra" => entry.summary.extra += 1,
-                            _ => {}
-                        }
-                    }
-                    by_root.into_values().collect()
-                };
-            let summary_by_root = summary_by_root(&drift);
+            let summary_by_root = drift_summary_by_root(&drift);
 
             let mut data = serde_json::json!({
                 "profile": profile,


### PR DESCRIPTION
Closes #626.

## What
- Add `src/app/status_drift.rs` with shared drift summary helpers.
- Reuse them from CLI `status --json` and the MCP `status` tool.

## Why
Avoid CLI/MCP drift for `summary` and `summary_by_root` computations.

## Tests
- `just check`
- `openspec validate refactor-app-status-drift-summary --type change --strict --no-interactive`