### PR TITLE
refactor(app): share status drift filtering

### DIFF
--- a/openspec/changes/refactor-app-status-drift-filter/.openspec.yaml
+++ b/openspec/changes/refactor-app-status-drift-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-status-drift-filter/README.md
+++ b/openspec/changes/refactor-app-status-drift-filter/README.md
@@ -1,0 +1,3 @@
+# refactor-app-status-drift-filter
+
+Refactor: share status drift filtering between CLI and MCP

--- a/openspec/changes/refactor-app-status-drift-filter/proposal.md
+++ b/openspec/changes/refactor-app-status-drift-filter/proposal.md
@@ -1,0 +1,23 @@
+# Change: Refactor status drift filtering into app layer
+
+## Why
+The `status --only ...` drift filtering logic is duplicated between:
+- CLI `status` (`src/cli/commands/status.rs`)
+- MCP `status` tool (`src/mcp/tools.rs`)
+
+While the underlying drift summary helpers are already shared, the “filter and recompute” flow is still duplicated, increasing the risk of behavior drift.
+
+## What Changes
+- Extend the shared `src/app/status_drift.rs` helpers with a small function that:
+  - filters drift items by kind
+  - recomputes the filtered `summary`
+  - returns `summary_total` when filtering is active
+- Wire both CLI status and MCP status to use this shared helper.
+
+## Impact
+- Affected specs: `agentpack-cli` (status json fields), `agentpack-mcp` (status tool reuses the CLI envelope).
+- Affected code:
+  - `src/app/status_drift.rs` (add helper)
+  - `src/cli/commands/status.rs` (dedupe filter logic)
+  - `src/mcp/tools.rs` (dedupe filter logic)
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-status-drift-filter/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-status-drift-filter/specs/agentpack-cli/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: status drift filtering remains consistent across CLI and MCP
+The system SHALL centralize the `status --only` drift filtering behavior so that CLI `status --json` and the MCP `status` tool apply equivalent filtering and `summary_total` behavior over time.
+
+#### Scenario: drift filtering remains consistent
+- **GIVEN** a drift report containing multiple drift kinds
+- **WHEN** the user runs `agentpack status --only modified --json`
+- **AND** an MCP client calls the `status` tool with `only: ["modified"]`
+- **THEN** both responses include equivalent filtered `data.drift`
+- **AND** both include equivalent `data.summary`
+- **AND** both include equivalent `data.summary_total`

--- a/openspec/changes/refactor-app-status-drift-filter/tasks.md
+++ b/openspec/changes/refactor-app-status-drift-filter/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared status drift filtering
+- [x] Run `openspec validate refactor-app-status-drift-filter --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared drift filtering helper under `src/app/status_drift.rs`
+- [x] Update CLI status and MCP status to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/status_drift.rs
+++ b/src/app/status_drift.rs
@@ -47,3 +47,24 @@ pub(crate) fn drift_summary_by_root(
 
     by_root.into_values().collect()
 }
+
+pub(crate) fn filter_drift_by_kind(
+    drift: Vec<crate::handlers::status::DriftItem>,
+    only_kinds: &std::collections::BTreeSet<&'static str>,
+    summary_total: crate::handlers::status::DriftSummary,
+) -> (
+    Vec<crate::handlers::status::DriftItem>,
+    crate::handlers::status::DriftSummary,
+    Option<crate::handlers::status::DriftSummary>,
+) {
+    if only_kinds.is_empty() {
+        return (drift, summary_total, None);
+    }
+
+    let drift: Vec<crate::handlers::status::DriftItem> = drift
+        .into_iter()
+        .filter(|d| only_kinds.contains(d.kind.as_str()))
+        .collect();
+    let summary = drift_summary(&drift);
+    (drift, summary, Some(summary_total))
+}


### PR DESCRIPTION
Closes #629.

## What
- Add `filter_drift_by_kind` helper in `src/app/status_drift.rs`.
- Reuse it from CLI `status` and MCP `status` tool.

## Why
Keep `--only` filtering behavior consistent across CLI and MCP.

## Tests
- `just check`
- `openspec validate refactor-app-status-drift-filter --type change --strict --no-interactive`