### PR TITLE
refactor(cli): reuse next_actions ordering in doctor

### DIFF
--- a/openspec/changes/refactor-cli-doctor-next-actions/.openspec.yaml
+++ b/openspec/changes/refactor-cli-doctor-next-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-cli-doctor-next-actions/README.md
+++ b/openspec/changes/refactor-cli-doctor-next-actions/README.md
@@ -1,0 +1,3 @@
+# refactor-cli-doctor-next-actions
+
+Refactor: use shared next_actions ordering in CLI doctor

--- a/openspec/changes/refactor-cli-doctor-next-actions/proposal.md
+++ b/openspec/changes/refactor-cli-doctor-next-actions/proposal.md
@@ -1,0 +1,16 @@
+# Change: Refactor doctor next_actions ordering to shared helper
+
+## Why
+CLI `doctor` currently has its own `ordered_next_actions` helper, while other surfaces (e.g. status / MCP) use the shared app-layer helper.
+
+This duplication increases the risk of ordering drift across commands and makes future changes harder to review.
+
+## What Changes
+- Reuse `src/app/next_actions.rs` ordering helper from CLI `doctor`.
+- Remove the local duplicated ordering implementation from `src/cli/commands/doctor.rs`.
+
+## Impact
+- Affected specs: `agentpack-cli` (doctor JSON field ordering), `agentpack-mcp` (no change; already uses shared helper).
+- Affected code:
+  - `src/cli/commands/doctor.rs` (dedupe)
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-cli-doctor-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-cli-doctor-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: doctor next_actions ordering remains consistent
+The system SHALL reuse the shared `next_actions` ordering helper for CLI `doctor` so that ordering behavior stays consistent across commands and interfaces over time.
+
+#### Scenario: doctor next_actions remain consistently ordered
+- **GIVEN** a `doctor` report that emits multiple `next_actions`
+- **WHEN** the user runs `agentpack doctor --json`
+- **THEN** `data.next_actions` are ordered consistently with the shared ordering helper used by other commands

--- a/openspec/changes/refactor-cli-doctor-next-actions/tasks.md
+++ b/openspec/changes/refactor-cli-doctor-next-actions/tasks.md
@@ -1,0 +1,10 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared doctor next_actions ordering
+- [x] Run `openspec validate refactor-cli-doctor-next-actions --strict --no-interactive`
+
+## 2. Implementation
+- [x] Update CLI doctor to use shared next_actions ordering helper
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -2,6 +2,7 @@ use anyhow::Context as _;
 
 use super::Ctx;
 
+use crate::app::next_actions::ordered_next_actions;
 use crate::engine::Engine;
 use crate::output::{JsonEnvelope, print_json};
 
@@ -124,49 +125,4 @@ fn action_prefix(cli: &crate::cli::args::Cli) -> String {
         out.push_str(&format!(" --machine {machine}"));
     }
     out
-}
-
-fn ordered_next_actions(actions: &std::collections::BTreeSet<String>) -> Vec<String> {
-    let mut out: Vec<String> = actions.iter().cloned().collect();
-    out.sort_by(|a, b| {
-        next_action_priority(a)
-            .cmp(&next_action_priority(b))
-            .then_with(|| a.cmp(b))
-    });
-    out
-}
-
-fn next_action_priority(action: &str) -> u8 {
-    match next_action_subcommand(action) {
-        Some("bootstrap") => 0,
-        Some("doctor") => 10,
-        Some("update") => 20,
-        Some("preview") => 30,
-        Some("diff") => 40,
-        Some("plan") => 50,
-        Some("deploy") => 60,
-        Some("status") => 70,
-        Some("evolve") => 80,
-        Some("rollback") => 90,
-        _ => 100,
-    }
-}
-
-fn next_action_subcommand(action: &str) -> Option<&str> {
-    let mut iter = action.split_whitespace();
-    // Skip program name (usually "agentpack") and global flags (and their args).
-    let _ = iter.next()?;
-
-    while let Some(tok) = iter.next() {
-        if !tok.starts_with("--") {
-            return Some(tok);
-        }
-
-        // Skip flag value for the flags we know to take an argument.
-        if matches!(tok, "--repo" | "--profile" | "--target" | "--machine") {
-            let _ = iter.next();
-        }
-    }
-
-    None
 }


### PR DESCRIPTION
Closes #632\n\n## Summary\nReuses the shared app-layer next_actions ordering helper for CLI `agentpack doctor` and removes duplicated local ordering logic.\n\n## Changes\n- CLI doctor now calls `crate::app::next_actions::ordered_next_actions`.\n- Deleted the local ordering helpers from `src/cli/commands/doctor.rs`.\n\n## Testing\n- `cargo fmt --all`\n- `just check`\n- `openspec validate refactor-cli-doctor-next-actions --type change --strict --no-interactive`\n\n## Notes\nNo user-facing behavior change expected; this is a refactor to reduce drift risk across surfaces.