### PR TITLE
refactor(app): share status next_actions suggestions

### DIFF
--- a/openspec/changes/refactor-app-status-next-actions-suggestions/.openspec.yaml
+++ b/openspec/changes/refactor-app-status-next-actions-suggestions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-status-next-actions-suggestions/README.md
+++ b/openspec/changes/refactor-app-status-next-actions-suggestions/README.md
@@ -1,0 +1,3 @@
+# refactor-app-status-next-actions-suggestions
+
+Refactor: share status next_actions suggestions between CLI and MCP

--- a/openspec/changes/refactor-app-status-next-actions-suggestions/proposal.md
+++ b/openspec/changes/refactor-app-status-next-actions-suggestions/proposal.md
@@ -1,0 +1,18 @@
+# Change: Refactor status next_actions suggestions to shared helper
+
+## Why
+CLI `status` and the MCP `status` tool both suggest `next_actions` based on the same drift summary signals (e.g. when to suggest `preview --diff`, `deploy --apply`, or `evolve propose`).
+
+Today this suggestion logic is duplicated across the two surfaces, which increases the risk of drift over time.
+
+## What Changes
+- Centralize the status `next_actions` suggestion logic under the app layer.
+- Update CLI `status` and the MCP `status` tool to reuse the shared helper.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (status next_actions suggestions).
+- Affected code:
+  - `src/app/` (new shared helper)
+  - `src/cli/commands/status.rs` (dedupe)
+  - `src/mcp/tools.rs` (dedupe)
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-status-next-actions-suggestions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-status-next-actions-suggestions/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: status next_actions suggestions remain consistent across CLI and MCP
+The system SHALL centralize the status `next_actions` suggestion logic so that CLI `status --json` and the MCP `status` tool keep equivalent suggestion behavior over time.
+
+#### Scenario: status next_actions suggestions remain consistent
+- **GIVEN** a drift summary that indicates `modified` and/or `missing` changes
+- **WHEN** the user runs `agentpack status --json`
+- **AND** an MCP client calls the `status` tool
+- **THEN** both responses include equivalent suggested `next_actions` (modulo surface-appropriate `--json` / `--yes` flags)

--- a/openspec/changes/refactor-app-status-next-actions-suggestions/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-status-next-actions-suggestions/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: status next_actions suggestions remain consistent across CLI and MCP
+The system SHALL centralize the status `next_actions` suggestion logic so that the MCP `status` tool stays consistent with CLI `status --json` over time.
+
+#### Scenario: status next_actions suggestions remain consistent
+- **GIVEN** a drift summary that indicates `extra` changes but no `modified` or `missing`
+- **WHEN** an MCP client calls the `status` tool
+- **AND** a user runs `agentpack status --json`
+- **THEN** both responses include equivalent suggested `next_actions` (modulo surface-appropriate `--json` / `--yes` flags)

--- a/openspec/changes/refactor-app-status-next-actions-suggestions/tasks.md
+++ b/openspec/changes/refactor-app-status-next-actions-suggestions/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared status next_actions suggestions
+- [x] Run `openspec validate refactor-app-status-next-actions-suggestions --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared status next_actions suggestion helper under `src/app/`
+- [x] Update CLI status and MCP status to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod next_actions;
 pub(crate) mod operator_assets;
 pub(crate) mod preview_diff;
 pub(crate) mod status_drift;
+pub(crate) mod status_next_actions;

--- a/src/app/status_next_actions.rs
+++ b/src/app/status_next_actions.rs
@@ -1,0 +1,60 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum StatusNextAction {
+    PreviewDiff,
+    DeployApply,
+    EvolvePropose,
+}
+
+impl StatusNextAction {
+    pub(crate) fn human_command(self, prefix: &str) -> String {
+        format!("{prefix} {}", self.human_suffix())
+    }
+
+    pub(crate) fn json_command(self, prefix: &str) -> String {
+        format!("{prefix} {}", self.json_suffix())
+    }
+
+    fn human_suffix(self) -> &'static str {
+        match self {
+            StatusNextAction::PreviewDiff => "preview --diff",
+            StatusNextAction::DeployApply => "deploy --apply",
+            StatusNextAction::EvolvePropose => "evolve propose",
+        }
+    }
+
+    fn json_suffix(self) -> &'static str {
+        match self {
+            StatusNextAction::PreviewDiff => "preview --diff --json",
+            StatusNextAction::DeployApply => "deploy --apply --yes --json",
+            StatusNextAction::EvolvePropose => "evolve propose --yes --json",
+        }
+    }
+}
+
+pub(crate) fn status_next_actions(
+    summary_modified: u64,
+    summary_missing: u64,
+    summary_extra: u64,
+    any_manifest: bool,
+    needs_deploy_apply: bool,
+) -> std::collections::BTreeSet<StatusNextAction> {
+    let mut out = std::collections::BTreeSet::new();
+
+    if needs_deploy_apply {
+        out.insert(StatusNextAction::DeployApply);
+    }
+
+    if summary_modified > 0 || summary_missing > 0 {
+        out.insert(StatusNextAction::PreviewDiff);
+        out.insert(StatusNextAction::DeployApply);
+
+        // Only suggest evolve when there is a reliable baseline (a previous deploy wrote manifests).
+        if any_manifest {
+            out.insert(StatusNextAction::EvolvePropose);
+        }
+    } else if summary_extra > 0 {
+        out.insert(StatusNextAction::PreviewDiff);
+    }
+
+    out
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -12,6 +12,7 @@ use crate::app::operator_assets::{
     OperatorAssetsStatusPaths, warn_operator_assets_if_outdated_for_status,
 };
 use crate::app::status_drift::{drift_summary_by_root, filter_drift_by_kind};
+use crate::app::status_next_actions::status_next_actions;
 use crate::user_error::UserError;
 
 use super::confirm::{CONFIRM_TOKEN_TTL, ConfirmTokenBinding};
@@ -453,30 +454,14 @@ async fn call_status_in_process(args: StatusArgs) -> anyhow::Result<(String, ser
             let summary = report.summary;
             let any_manifest = report.any_manifest;
 
-            if report.needs_deploy_apply {
-                next_actions
-                    .json
-                    .insert(format!("{prefix} deploy --apply --yes --json"));
-            }
-
-            if summary.modified > 0 || summary.missing > 0 {
-                next_actions
-                    .json
-                    .insert(format!("{prefix} preview --diff --json"));
-                next_actions
-                    .json
-                    .insert(format!("{prefix} deploy --apply --yes --json"));
-
-                // Only suggest evolve when there is a reliable baseline (a previous deploy wrote manifests).
-                if any_manifest {
-                    next_actions
-                        .json
-                        .insert(format!("{prefix} evolve propose --yes --json"));
-                }
-            } else if summary.extra > 0 {
-                next_actions
-                    .json
-                    .insert(format!("{prefix} preview --diff --json"));
+            for action in status_next_actions(
+                summary.modified,
+                summary.missing,
+                summary.extra,
+                any_manifest,
+                report.needs_deploy_apply,
+            ) {
+                next_actions.json.insert(action.json_command(&prefix));
             }
 
             let summary_total = summary;


### PR DESCRIPTION
Closes #638.

Moves the shared status `next_actions` suggestion logic into the app layer and reuses it from both:
- `agentpack status`
- MCP `status` tool

No behavior change intended; this is a small refactor to reduce drift between handlers.

Tests:
- `cargo fmt --all`
- `just check`