### PR TITLE
refactor(app): share doctor next_actions suggestions

### DIFF
--- a/openspec/changes/refactor-app-doctor-next-actions-suggestions/.openspec.yaml
+++ b/openspec/changes/refactor-app-doctor-next-actions-suggestions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-doctor-next-actions-suggestions/README.md
+++ b/openspec/changes/refactor-app-doctor-next-actions-suggestions/README.md
@@ -1,0 +1,3 @@
+# refactor-app-doctor-next-actions-suggestions
+
+Refactor: share doctor next_actions suggestions between CLI and MCP

--- a/openspec/changes/refactor-app-doctor-next-actions-suggestions/proposal.md
+++ b/openspec/changes/refactor-app-doctor-next-actions-suggestions/proposal.md
@@ -1,0 +1,18 @@
+# Change: Refactor doctor next_actions suggestions to shared helper
+
+## Why
+CLI `doctor` and the MCP `doctor` tool both generate `next_actions` suggestions by parsing the same `DoctorReport` signals (e.g. root suggestions like `create directory: mkdir -p ...` and the `doctor --fix` suggestion when `.gitignore` is missing the target manifest ignore rule).
+
+Today this suggestion logic is duplicated across the two surfaces, which increases the risk of drift over time.
+
+## What Changes
+- Centralize the doctor `next_actions` suggestion logic under the app layer.
+- Update CLI `doctor` and the MCP `doctor` tool to reuse the shared helper.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (doctor next_actions suggestions).
+- Affected code:
+  - `src/app/` (new shared helper)
+  - `src/cli/commands/doctor.rs` (dedupe)
+  - `src/mcp/tools.rs` (dedupe)
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-doctor-next-actions-suggestions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-doctor-next-actions-suggestions/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: doctor next_actions suggestions remain consistent across CLI and MCP
+The system SHALL centralize the doctor `next_actions` suggestion logic so that CLI `doctor --json` and the MCP `doctor` tool keep equivalent suggestion behavior over time.
+
+#### Scenario: doctor next_actions suggestions remain consistent
+- **GIVEN** a doctor report that includes a root suggestion like `create directory: mkdir -p ...`
+- **WHEN** the user runs `agentpack doctor --json`
+- **AND** an MCP client calls the `doctor` tool
+- **THEN** both responses include equivalent suggested `next_actions` (modulo surface-appropriate `--json` / `--yes` flags)

--- a/openspec/changes/refactor-app-doctor-next-actions-suggestions/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-doctor-next-actions-suggestions/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: doctor next_actions suggestions remain consistent across CLI and MCP
+The system SHALL centralize the doctor `next_actions` suggestion logic so that the MCP `doctor` tool stays consistent with CLI `doctor --json` over time.
+
+#### Scenario: doctor next_actions suggestions remain consistent
+- **GIVEN** a doctor report that indicates `.gitignore` needs fixing
+- **WHEN** an MCP client calls the `doctor` tool
+- **AND** a user runs `agentpack doctor --json`
+- **THEN** both responses include equivalent suggested `next_actions` (modulo surface-appropriate `--json` / `--yes` flags)

--- a/openspec/changes/refactor-app-doctor-next-actions-suggestions/tasks.md
+++ b/openspec/changes/refactor-app-doctor-next-actions-suggestions/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared doctor next_actions suggestions
+- [x] Run `openspec validate refactor-app-doctor-next-actions-suggestions --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared doctor next_actions suggestion helper under `src/app/`
+- [x] Update CLI doctor and MCP doctor to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/doctor_next_actions.rs
+++ b/src/app/doctor_next_actions.rs
@@ -1,0 +1,38 @@
+use std::collections::BTreeSet;
+
+use crate::handlers::doctor::DoctorRootCheck;
+
+#[derive(Default)]
+pub(crate) struct DoctorNextActions {
+    pub human: BTreeSet<String>,
+    pub json: BTreeSet<String>,
+}
+
+pub(crate) fn doctor_next_actions(
+    roots: &[DoctorRootCheck],
+    needs_gitignore_fix: bool,
+    fix: bool,
+    prefix: &str,
+) -> DoctorNextActions {
+    let mut out = DoctorNextActions::default();
+
+    for c in roots {
+        if let Some(suggestion) = &c.suggestion {
+            if let Some((_, cmd)) = suggestion.split_once(':') {
+                let cmd = cmd.trim();
+                if !cmd.is_empty() {
+                    out.human.insert(cmd.to_string());
+                    out.json.insert(cmd.to_string());
+                }
+            }
+        }
+    }
+
+    if needs_gitignore_fix && !fix {
+        out.human.insert(format!("{prefix} doctor --fix"));
+        out.json
+            .insert(format!("{prefix} doctor --fix --yes --json"));
+    }
+
+    out
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod doctor_next_actions;
 pub(crate) mod next_actions;
 pub(crate) mod operator_assets;
 pub(crate) mod preview_diff;


### PR DESCRIPTION
Closes #641.

Moves the shared doctor `next_actions` suggestion logic into the app layer and reuses it from both:
- `agentpack doctor`
- MCP `doctor` tool

No behavior change intended; this is a small refactor to reduce drift between handlers.

Tests:
- `cargo fmt --all`
- `just check`