### PR TITLE
refactor(app): centralize next_actions_detailed

### DIFF
--- a/openspec/changes/refactor-app-next-actions-detailed/.openspec.yaml
+++ b/openspec/changes/refactor-app-next-actions-detailed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-next-actions-detailed/README.md
+++ b/openspec/changes/refactor-app-next-actions-detailed/README.md
@@ -1,0 +1,3 @@
+# refactor-app-next-actions-detailed
+
+Refactor: centralize status next_actions_detailed generation between CLI and MCP

--- a/openspec/changes/refactor-app-next-actions-detailed/proposal.md
+++ b/openspec/changes/refactor-app-next-actions-detailed/proposal.md
@@ -1,0 +1,22 @@
+# Change: Refactor status next_actions_detailed generation into app layer
+
+## Why
+CLI `status --json` and the MCP `status` tool both emit:
+- `next_actions` (ordered command strings)
+- `next_actions_detailed` (objects with `action` + `command`)
+
+While ordering and action-code mapping are already shared in `src/app/next_actions.rs`, the final `next_actions_detailed` construction is still duplicated in the CLI and MCP handlers.
+
+Centralizing the `next_actions_detailed` construction reduces the risk of drift over time and keeps the JSON output stable.
+
+## What Changes
+- Add a small shared helper in `src/app/next_actions.rs` to build `next_actions` + `next_actions_detailed` together.
+- Update CLI `status --json` and MCP `status` to reuse it.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (status next_actions_detailed behavior remains consistent).
+- Affected code:
+  - `src/app/next_actions.rs`
+  - `src/cli/commands/status.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-next-actions-detailed/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-next-actions-detailed/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: status next_actions_detailed remains consistent across CLI and MCP
+The system SHALL centralize the construction of `next_actions` and `next_actions_detailed` so that CLI `status --json` and the MCP `status` tool keep equivalent output over time.
+
+#### Scenario: status next_actions_detailed remains consistent
+- **GIVEN** a status report that yields one or more suggested `next_actions`
+- **WHEN** the user runs `agentpack status --json`
+- **AND** an MCP client calls the `status` tool
+- **THEN** both responses include equivalent `next_actions` ordering and `next_actions_detailed.action` codes (modulo surface-appropriate flags)

--- a/openspec/changes/refactor-app-next-actions-detailed/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-next-actions-detailed/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: status next_actions_detailed remains consistent across CLI and MCP
+The system SHALL centralize the construction of `next_actions` and `next_actions_detailed` so that the MCP `status` tool stays consistent with CLI `status --json` over time.
+
+#### Scenario: status next_actions_detailed remains consistent
+- **GIVEN** a status report that yields one or more suggested `next_actions`
+- **WHEN** an MCP client calls the `status` tool
+- **AND** a user runs `agentpack status --json`
+- **THEN** both responses include equivalent `next_actions` ordering and `next_actions_detailed.action` codes (modulo surface-appropriate flags)

--- a/openspec/changes/refactor-app-next-actions-detailed/tasks.md
+++ b/openspec/changes/refactor-app-next-actions-detailed/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared status next_actions_detailed generation
+- [x] Run `openspec validate refactor-app-next-actions-detailed --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared next_actions_detailed helper under `src/app/next_actions.rs`
+- [x] Update CLI status and MCP status to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/next_actions.rs
+++ b/src/app/next_actions.rs
@@ -8,6 +8,27 @@ pub(crate) fn ordered_next_actions(actions: &std::collections::BTreeSet<String>)
     out
 }
 
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct NextActionDetailed {
+    pub action: String,
+    pub command: String,
+}
+
+pub(crate) fn ordered_next_actions_detailed(
+    actions: &std::collections::BTreeSet<String>,
+) -> (Vec<String>, Vec<NextActionDetailed>) {
+    let ordered = ordered_next_actions(actions);
+    let detailed = ordered
+        .iter()
+        .cloned()
+        .map(|command| NextActionDetailed {
+            action: next_action_code(&command).to_string(),
+            command,
+        })
+        .collect();
+    (ordered, detailed)
+}
+
 pub(crate) fn next_action_code(action: &str) -> &'static str {
     match next_action_subcommand(action) {
         Some("bootstrap") => "bootstrap",


### PR DESCRIPTION
Closes #644.

Centralizes status `next_actions_detailed` construction in `src/app/next_actions.rs` and reuses it from both:
- CLI `status --json`
- MCP `status` tool

No behavior change intended; this is a small refactor to reduce drift.

Tests:
- `cargo fmt --all`
- `just check`