### PR TITLE
refactor(app): centralize status json data

### DIFF
--- a/openspec/changes/refactor-app-status-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-status-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-status-json-data/README.md
+++ b/openspec/changes/refactor-app-status-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-status-json-data
+
+Refactor: centralize status JSON data construction

--- a/openspec/changes/refactor-app-status-json-data/proposal.md
+++ b/openspec/changes/refactor-app-status-json-data/proposal.md
@@ -1,0 +1,20 @@
+# Change: Refactor status JSON data construction into app layer
+
+## Why
+CLI `status --json` and the MCP `status` tool both build the same `data` payload:
+- drift (`drift`, `summary`, `summary_by_root`, and optional `summary_total`)
+- suggested next actions (`next_actions`, `next_actions_detailed`)
+
+Today, the final `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add a small shared helper in `src/app/` to construct the `status` JSON `data` object deterministically.
+- Update CLI `status --json` and the MCP `status` tool to reuse it.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (status JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/status.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-status-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-status-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: status JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `status` JSON `data` payload so that CLI `status --json` and the MCP `status` tool keep equivalent output over time.
+
+#### Scenario: status JSON payload remains consistent
+- **GIVEN** a status report that yields drift and one or more suggested `next_actions`
+- **WHEN** the user runs `agentpack status --json`
+- **AND** an MCP client calls the `status` tool
+- **THEN** both responses include equivalent `data` fields (`drift`, `summary`, `summary_by_root`, optional `summary_total`, `next_actions`, `next_actions_detailed`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-status-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-status-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: status JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `status` JSON `data` payload so that the MCP `status` tool stays consistent with CLI `status --json` over time.
+
+#### Scenario: status JSON payload remains consistent
+- **GIVEN** a status report that yields drift and one or more suggested `next_actions`
+- **WHEN** an MCP client calls the `status` tool
+- **AND** a user runs `agentpack status --json`
+- **THEN** both responses include equivalent `data` fields (`drift`, `summary`, `summary_by_root`, optional `summary_total`, `next_actions`, `next_actions_detailed`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-status-json-data/tasks.md
+++ b/openspec/changes/refactor-app-status-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared status JSON data construction
+- [x] Run `openspec validate refactor-app-status-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared status JSON data builder under `src/app/`
+- [x] Update CLI status and MCP status to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,4 +3,5 @@ pub(crate) mod next_actions;
 pub(crate) mod operator_assets;
 pub(crate) mod preview_diff;
 pub(crate) mod status_drift;
+pub(crate) mod status_json;
 pub(crate) mod status_next_actions;

--- a/src/app/status_json.rs
+++ b/src/app/status_json.rs
@@ -1,0 +1,48 @@
+use anyhow::Context as _;
+
+use crate::app::next_actions::ordered_next_actions_detailed;
+
+pub(crate) fn status_json_data(
+    profile: &str,
+    targets: Vec<String>,
+    drift: Vec<crate::handlers::status::DriftItem>,
+    summary: crate::handlers::status::DriftSummary,
+    summary_by_root: Vec<crate::app::status_drift::DriftSummaryByRoot>,
+    summary_total_opt: Option<crate::handlers::status::DriftSummary>,
+    next_actions: &std::collections::BTreeSet<String>,
+) -> anyhow::Result<serde_json::Value> {
+    let mut data = serde_json::json!({
+        "profile": profile,
+        "targets": targets,
+        "drift": drift,
+        "summary": summary,
+        "summary_by_root": summary_by_root,
+    });
+
+    if let Some(summary_total) = summary_total_opt {
+        data.as_object_mut()
+            .context("status json data must be an object")?
+            .insert(
+                "summary_total".to_string(),
+                serde_json::to_value(summary_total).context("serialize summary_total")?,
+            );
+    }
+
+    if !next_actions.is_empty() {
+        let (ordered, detailed) = ordered_next_actions_detailed(next_actions);
+        data.as_object_mut()
+            .context("status json data must be an object")?
+            .insert(
+                "next_actions".to_string(),
+                serde_json::to_value(&ordered).context("serialize next_actions")?,
+            );
+        data.as_object_mut()
+            .context("status json data must be an object")?
+            .insert(
+                "next_actions_detailed".to_string(),
+                serde_json::to_value(&detailed).context("serialize next_actions_detailed")?,
+            );
+    }
+
+    Ok(data)
+}


### PR DESCRIPTION
Closes #647.

Moves the final `status` JSON `data` object construction into a shared app helper to keep CLI and MCP outputs aligned.

Tests:
- cargo fmt --all
- just check
