### PR TITLE
refactor(app): centralize doctor json data

### DIFF
--- a/openspec/changes/refactor-app-doctor-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-doctor-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-doctor-json-data/README.md
+++ b/openspec/changes/refactor-app-doctor-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-doctor-json-data
+
+Refactor: centralize doctor JSON data construction

--- a/openspec/changes/refactor-app-doctor-json-data/proposal.md
+++ b/openspec/changes/refactor-app-doctor-json-data/proposal.md
@@ -1,0 +1,22 @@
+# Change: Refactor doctor JSON data construction into app layer
+
+## Why
+CLI `doctor --json` and the MCP `doctor` tool both build the same `data` payload:
+- `machine_id`
+- `roots`
+- `gitignore_fixes`
+- optional `next_actions`
+
+Today, the final `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add a small shared helper in `src/app/` to construct the `doctor` JSON `data` object deterministically.
+- Update CLI `doctor --json` and the MCP `doctor` tool to reuse it.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (doctor JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/doctor.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-doctor-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-doctor-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: doctor JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `doctor` JSON `data` payload so that CLI `doctor --json` and the MCP `doctor` tool keep equivalent output over time.
+
+#### Scenario: doctor JSON payload remains consistent
+- **GIVEN** a doctor report that yields one or more suggested `next_actions`
+- **WHEN** the user runs `agentpack doctor --json`
+- **AND** an MCP client calls the `doctor` tool
+- **THEN** both responses include equivalent `data` fields (`machine_id`, `roots`, `gitignore_fixes`, optional `next_actions`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-doctor-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-doctor-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: doctor JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `doctor` JSON `data` payload so that the MCP `doctor` tool stays consistent with CLI `doctor --json` over time.
+
+#### Scenario: doctor JSON payload remains consistent
+- **GIVEN** a doctor report that yields one or more suggested `next_actions`
+- **WHEN** an MCP client calls the `doctor` tool
+- **AND** a user runs `agentpack doctor --json`
+- **THEN** both responses include equivalent `data` fields (`machine_id`, `roots`, `gitignore_fixes`, optional `next_actions`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-doctor-json-data/tasks.md
+++ b/openspec/changes/refactor-app-doctor-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared doctor JSON data construction
+- [x] Run `openspec validate refactor-app-doctor-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared doctor JSON data builder under `src/app/`
+- [x] Update CLI doctor and MCP doctor to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/doctor_json.rs
+++ b/src/app/doctor_json.rs
@@ -1,0 +1,28 @@
+use anyhow::Context as _;
+
+use crate::app::next_actions::ordered_next_actions;
+
+pub(crate) fn doctor_json_data(
+    machine_id: String,
+    roots: Vec<crate::handlers::doctor::DoctorRootCheck>,
+    gitignore_fixes: Vec<crate::handlers::doctor::DoctorGitignoreFix>,
+    next_actions: &std::collections::BTreeSet<String>,
+) -> anyhow::Result<serde_json::Value> {
+    let mut data = serde_json::json!({
+        "machine_id": machine_id,
+        "roots": roots,
+        "gitignore_fixes": gitignore_fixes,
+    });
+
+    if !next_actions.is_empty() {
+        let ordered = ordered_next_actions(next_actions);
+        data.as_object_mut()
+            .context("doctor json data must be an object")?
+            .insert(
+                "next_actions".to_string(),
+                serde_json::to_value(&ordered).context("serialize next_actions")?,
+            );
+    }
+
+    Ok(data)
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod doctor_json;
 pub(crate) mod doctor_next_actions;
 pub(crate) mod next_actions;
 pub(crate) mod operator_assets;

--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -1,7 +1,6 @@
-use anyhow::Context as _;
-
 use super::Ctx;
 
+use crate::app::doctor_json::doctor_json_data;
 use crate::app::doctor_next_actions::doctor_next_actions;
 use crate::app::next_actions::ordered_next_actions;
 use crate::engine::Engine;
@@ -28,20 +27,7 @@ pub(crate) fn run(ctx: &Ctx<'_>, fix: bool) -> anyhow::Result<()> {
     } = report;
 
     if ctx.cli.json {
-        let mut data = serde_json::json!({
-            "machine_id": machine_id,
-            "roots": checks,
-            "gitignore_fixes": gitignore_fixes,
-        });
-        if !next_actions.json.is_empty() {
-            let ordered = ordered_next_actions(&next_actions.json);
-            data.as_object_mut()
-                .context("doctor json data must be an object")?
-                .insert(
-                    "next_actions".to_string(),
-                    serde_json::to_value(&ordered).context("serialize next_actions")?,
-                );
-        }
+        let data = doctor_json_data(machine_id, checks, gitignore_fixes, &next_actions.json)?;
         let mut envelope = JsonEnvelope::ok("doctor", data);
         envelope.warnings = warnings;
         print_json(&envelope)?;


### PR DESCRIPTION
Closes #650.

Moves the final `doctor` JSON `data` object construction into a shared app helper to keep CLI and MCP outputs aligned.

Tests:
- cargo fmt --all
- just check
