### PR TITLE
refactor(app): centralize preview JSON data

### DIFF
--- a/openspec/changes/refactor-app-preview-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-preview-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-preview-json-data/README.md
+++ b/openspec/changes/refactor-app-preview-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-preview-json-data
+
+Refactor: centralize preview JSON data construction

--- a/openspec/changes/refactor-app-preview-json-data/proposal.md
+++ b/openspec/changes/refactor-app-preview-json-data/proposal.md
@@ -1,0 +1,22 @@
+# Change: Refactor preview JSON data construction into app layer
+
+## Why
+CLI `preview --json` and the MCP `preview` tool both build the same `data` payload:
+- `profile`
+- `targets`
+- `plan` (`changes`, `summary`)
+- optional `diff` (`changes`, `summary`, `files`)
+
+Today, the final `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add a small shared helper in `src/app/` to construct the `preview` JSON `data` object deterministically.
+- Update CLI `preview --json` and the MCP `preview` tool to reuse it.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (preview JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/preview.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-preview-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-preview-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: preview JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `preview` JSON `data` payload so that CLI `preview --json` and the MCP `preview` tool keep equivalent output over time.
+
+#### Scenario: preview JSON payload remains consistent
+- **GIVEN** a preview result that yields a plan and optional diffs
+- **WHEN** the user runs `agentpack preview --json` (optionally with `--diff`)
+- **AND** an MCP client calls the `preview` tool (optionally with `diff=true`)
+- **THEN** both responses include equivalent `data` fields (`profile`, `targets`, `plan`, optional `diff`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-preview-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-preview-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: preview JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `preview` JSON `data` payload so that the MCP `preview` tool stays consistent with CLI `preview --json` over time.
+
+#### Scenario: preview JSON payload remains consistent
+- **GIVEN** a preview result that yields a plan and optional diffs
+- **WHEN** an MCP client calls the `preview` tool (optionally with `diff=true`)
+- **AND** a user runs `agentpack preview --json` (optionally with `--diff`)
+- **THEN** both responses include equivalent `data` fields (`profile`, `targets`, `plan`, optional `diff`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-preview-json-data/tasks.md
+++ b/openspec/changes/refactor-app-preview-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared preview JSON data construction
+- [x] Run `openspec validate refactor-app-preview-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared preview JSON data builder under `src/app/`
+- [x] Update CLI preview and MCP preview to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod doctor_next_actions;
 pub(crate) mod next_actions;
 pub(crate) mod operator_assets;
 pub(crate) mod preview_diff;
+pub(crate) mod preview_json;
 pub(crate) mod status_drift;
 pub(crate) mod status_json;
 pub(crate) mod status_next_actions;

--- a/src/app/preview_json.rs
+++ b/src/app/preview_json.rs
@@ -1,0 +1,44 @@
+use crate::app::preview_diff::preview_diff_files;
+
+pub(crate) fn preview_json_data(
+    profile: &str,
+    targets: Vec<String>,
+    plan: crate::deploy::PlanResult,
+    desired: crate::deploy::DesiredState,
+    roots: Vec<crate::targets::TargetRoot>,
+    diff: bool,
+    warnings: &mut Vec<String>,
+) -> anyhow::Result<serde_json::Value> {
+    if !diff {
+        return Ok(serde_json::json!({
+            "profile": profile,
+            "targets": targets,
+            "plan": {
+                "changes": plan.changes,
+                "summary": plan.summary,
+            },
+        }));
+    }
+
+    let plan_changes = plan.changes.clone();
+    let plan_summary = plan.summary.clone();
+
+    let files = preview_diff_files(&plan, &desired, &roots, warnings)?;
+
+    let mut data = serde_json::json!({
+        "profile": profile,
+        "targets": targets,
+        "plan": {
+            "changes": plan_changes,
+            "summary": plan_summary,
+        },
+    });
+
+    data["diff"] = serde_json::json!({
+        "changes": plan.changes,
+        "summary": plan.summary,
+        "files": files,
+    });
+
+    Ok(data)
+}

--- a/src/cli/commands/preview.rs
+++ b/src/cli/commands/preview.rs
@@ -1,4 +1,4 @@
-use crate::app::preview_diff::preview_diff_files;
+use crate::app::preview_json::preview_json_data;
 use crate::handlers::read_only::read_only_context;
 use crate::output::{JsonEnvelope, print_json};
 
@@ -19,24 +19,15 @@ pub(crate) fn run(ctx: &Ctx<'_>, diff: bool) -> anyhow::Result<()> {
     )?;
 
     if ctx.cli.json {
-        let plan_changes = plan.changes.clone();
-        let plan_summary = plan.summary.clone();
-        let mut data = serde_json::json!({
-            "profile": ctx.cli.profile,
-            "targets": targets,
-            "plan": {
-                "changes": plan_changes,
-                "summary": plan_summary,
-            },
-        });
-        if diff {
-            let files = preview_diff_files(&plan, &desired, &roots, &mut warnings)?;
-            data["diff"] = serde_json::json!({
-                "changes": plan.changes,
-                "summary": plan.summary,
-                "files": files,
-            });
-        }
+        let data = preview_json_data(
+            ctx.cli.profile.as_str(),
+            targets,
+            plan,
+            desired,
+            roots,
+            diff,
+            &mut warnings,
+        )?;
 
         let mut envelope = JsonEnvelope::ok("preview", data);
         envelope.warnings = warnings;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1083,29 +1083,15 @@ async fn call_preview_in_process(args: PreviewArgs) -> anyhow::Result<(String, s
                 mut warnings,
                 roots,
             }) => {
-                let plan_changes = plan.changes.clone();
-                let plan_summary = plan.summary.clone();
-                let mut data = serde_json::json!({
-                    "profile": profile,
-                    "targets": targets,
-                    "plan": {
-                        "changes": plan_changes,
-                        "summary": plan_summary,
-                    },
-                });
-                if args.diff {
-                    let files = crate::app::preview_diff::preview_diff_files(
-                        &plan,
-                        &desired,
-                        &roots,
-                        &mut warnings,
-                    )?;
-                    data["diff"] = serde_json::json!({
-                        "changes": plan.changes,
-                        "summary": plan.summary,
-                        "files": files,
-                    });
-                }
+                let data = crate::app::preview_json::preview_json_data(
+                    profile,
+                    targets,
+                    plan,
+                    desired,
+                    roots,
+                    args.diff,
+                    &mut warnings,
+                )?;
 
                 let mut envelope = crate::output::JsonEnvelope::ok("preview", data);
                 envelope.warnings = warnings;


### PR DESCRIPTION
Context
- CLI preview --json and the MCP preview tool were assembling the same data payload in two places.

What changed
- Added src/app/preview_json.rs to centralize preview JSON data construction.
- Updated CLI preview and MCP preview to reuse the shared builder.
- Added OpenSpec change refactor-app-preview-json-data (no user-facing behavior change).

Why
- Reduce the risk of CLI/MCP JSON payload drift while keeping the stable --json contract unchanged.

Verification
- cargo fmt --all
- just check

Fixes #653
