### PR TITLE
refactor(app): centralize plan/diff JSON data

### DIFF
--- a/openspec/changes/refactor-app-plan-diff-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-plan-diff-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-plan-diff-json-data/README.md
+++ b/openspec/changes/refactor-app-plan-diff-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-plan-diff-json-data
+
+Refactor: centralize plan/diff JSON data construction

--- a/openspec/changes/refactor-app-plan-diff-json-data/proposal.md
+++ b/openspec/changes/refactor-app-plan-diff-json-data/proposal.md
@@ -1,0 +1,23 @@
+# Change: Refactor plan/diff JSON data construction into app layer
+
+## Why
+CLI `plan --json` / `diff --json` and the MCP `plan` / `diff` tools all construct the same `data` payload:
+- `profile`
+- `targets`
+- `changes`
+- `summary`
+
+Today, the final `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add a small shared helper in `src/app/` to construct the plan/diff JSON `data` object deterministically.
+- Update CLI `plan --json` / `diff --json` and the MCP `plan` / `diff` tools to reuse it.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (plan/diff JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/plan.rs`
+  - `src/cli/commands/diff.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-plan-diff-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-plan-diff-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: plan/diff JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `plan`/`diff` JSON `data` payload so that CLI `plan --json` / `diff --json` and the MCP `plan` / `diff` tools keep equivalent output over time.
+
+#### Scenario: plan/diff JSON payload remains consistent
+- **GIVEN** a repo state that yields a plan with one or more changes
+- **WHEN** the user runs `agentpack plan --json` and `agentpack diff --json`
+- **AND** an MCP client calls the `plan` and `diff` tools
+- **THEN** each corresponding response includes equivalent `data` fields (`profile`, `targets`, `changes`, `summary`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-plan-diff-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-plan-diff-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: plan/diff JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `plan`/`diff` JSON `data` payload so that the MCP `plan` / `diff` tools stay consistent with CLI `plan --json` / `diff --json` over time.
+
+#### Scenario: plan/diff JSON payload remains consistent
+- **GIVEN** a repo state that yields a plan with one or more changes
+- **WHEN** an MCP client calls the `plan` and `diff` tools
+- **AND** a user runs `agentpack plan --json` and `agentpack diff --json`
+- **THEN** each corresponding response includes equivalent `data` fields (`profile`, `targets`, `changes`, `summary`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-plan-diff-json-data/tasks.md
+++ b/openspec/changes/refactor-app-plan-diff-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared plan/diff JSON data construction
+- [x] Run `openspec validate refactor-app-plan-diff-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared plan/diff JSON data builder under `src/app/`
+- [x] Update CLI plan/diff and MCP plan/diff to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod doctor_json;
 pub(crate) mod doctor_next_actions;
 pub(crate) mod next_actions;
 pub(crate) mod operator_assets;
+pub(crate) mod plan_json;
 pub(crate) mod preview_diff;
 pub(crate) mod preview_json;
 pub(crate) mod status_drift;

--- a/src/app/plan_json.rs
+++ b/src/app/plan_json.rs
@@ -1,0 +1,12 @@
+pub(crate) fn plan_json_data(
+    profile: &str,
+    targets: Vec<String>,
+    plan: crate::deploy::PlanResult,
+) -> serde_json::Value {
+    serde_json::json!({
+        "profile": profile,
+        "targets": targets,
+        "changes": plan.changes,
+        "summary": plan.summary,
+    })
+}

--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -1,3 +1,4 @@
+use crate::app::plan_json::plan_json_data;
 use crate::handlers::read_only::read_only_context;
 use crate::output::{JsonEnvelope, print_json};
 
@@ -18,15 +19,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     )?;
 
     if ctx.cli.json {
-        let mut envelope = JsonEnvelope::ok(
-            "diff",
-            serde_json::json!({
-                "profile": ctx.cli.profile,
-                "targets": targets,
-                "changes": plan.changes,
-                "summary": plan.summary,
-            }),
-        );
+        let data = plan_json_data(ctx.cli.profile.as_str(), targets, plan);
+        let mut envelope = JsonEnvelope::ok("diff", data);
         envelope.warnings = warnings;
         print_json(&envelope)?;
         return Ok(());

--- a/src/cli/commands/plan.rs
+++ b/src/cli/commands/plan.rs
@@ -1,3 +1,4 @@
+use crate::app::plan_json::plan_json_data;
 use crate::handlers::read_only::read_only_context;
 use crate::output::{JsonEnvelope, print_json};
 
@@ -17,15 +18,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     )?;
 
     if ctx.cli.json {
-        let mut envelope = JsonEnvelope::ok(
-            "plan",
-            serde_json::json!({
-                "profile": ctx.cli.profile,
-                "targets": targets,
-                "changes": plan.changes,
-                "summary": plan.summary,
-            }),
-        );
+        let data = plan_json_data(ctx.cli.profile.as_str(), targets, plan);
+        let mut envelope = JsonEnvelope::ok("plan", data);
         envelope.warnings = warnings;
         print_json(&envelope)?;
     } else {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -215,15 +215,8 @@ async fn call_read_only_in_process(
                 warnings,
                 ..
             }) => {
-                let mut envelope = crate::output::JsonEnvelope::ok(
-                    command,
-                    serde_json::json!({
-                        "profile": profile,
-                        "targets": targets,
-                        "changes": plan.changes,
-                        "summary": plan.summary,
-                    }),
-                );
+                let data = crate::app::plan_json::plan_json_data(profile, targets, plan);
+                let mut envelope = crate::output::JsonEnvelope::ok(command, data);
                 envelope.warnings = warnings;
                 let text = serde_json::to_string_pretty(&envelope)?;
                 let envelope = serde_json::to_value(&envelope)?;


### PR DESCRIPTION
Context
- CLI plan/diff and MCP plan/diff were assembling the same JSON data payload in multiple places.

What changed
- Added src/app/plan_json.rs to centralize plan-like JSON data construction.
- Updated CLI plan --json / diff --json and MCP plan/diff tools to reuse the shared builder.
- Added OpenSpec change refactor-app-plan-diff-json-data (no user-facing behavior change).

Why
- Reduce the risk of CLI/MCP JSON payload drift while keeping the stable --json contract unchanged.

Verification
- cargo fmt --all
- just check

Fixes #656
