### PR TITLE
refactor(app): centralize rollback JSON data

### DIFF
--- a/openspec/changes/refactor-app-rollback-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-rollback-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-rollback-json-data/README.md
+++ b/openspec/changes/refactor-app-rollback-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-rollback-json-data
+
+Refactor: centralize rollback JSON data construction

--- a/openspec/changes/refactor-app-rollback-json-data/proposal.md
+++ b/openspec/changes/refactor-app-rollback-json-data/proposal.md
@@ -1,0 +1,20 @@
+# Change: Refactor rollback JSON data construction into app layer
+
+## Why
+CLI `rollback --json` and the MCP `rollback` tool both build the same `data` payload:
+- `rolled_back_to`
+- `event_snapshot_id`
+
+Today, the final `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add a small shared helper in `src/app/` to construct the `rollback` JSON `data` object deterministically.
+- Update CLI `rollback --json` and the MCP `rollback` tool to reuse it.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (rollback JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/rollback.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-rollback-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-rollback-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: rollback JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `rollback` JSON `data` payload so that CLI `rollback --json` and the MCP `rollback` tool keep equivalent output over time.
+
+#### Scenario: rollback JSON payload remains consistent
+- **GIVEN** an existing snapshot id that can be rolled back to
+- **WHEN** the user runs `agentpack rollback --to <snapshot_id> --json`
+- **AND** an MCP client calls the `rollback` tool
+- **THEN** both responses include equivalent `data` fields (`rolled_back_to`, `event_snapshot_id`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-rollback-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-rollback-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: rollback JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `rollback` JSON `data` payload so that the MCP `rollback` tool stays consistent with CLI `rollback --json` over time.
+
+#### Scenario: rollback JSON payload remains consistent
+- **GIVEN** an existing snapshot id that can be rolled back to
+- **WHEN** an MCP client calls the `rollback` tool
+- **AND** a user runs `agentpack rollback --to <snapshot_id> --json`
+- **THEN** both responses include equivalent `data` fields (`rolled_back_to`, `event_snapshot_id`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-rollback-json-data/tasks.md
+++ b/openspec/changes/refactor-app-rollback-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared rollback JSON data construction
+- [x] Run `openspec validate refactor-app-rollback-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared rollback JSON data builder under `src/app/`
+- [x] Update CLI rollback and MCP rollback to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod operator_assets;
 pub(crate) mod plan_json;
 pub(crate) mod preview_diff;
 pub(crate) mod preview_json;
+pub(crate) mod rollback_json;
 pub(crate) mod status_drift;
 pub(crate) mod status_json;
 pub(crate) mod status_next_actions;

--- a/src/app/rollback_json.rs
+++ b/src/app/rollback_json.rs
@@ -1,0 +1,9 @@
+pub(crate) fn rollback_json_data(
+    rolled_back_to: &str,
+    event_snapshot_id: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "rolled_back_to": rolled_back_to,
+        "event_snapshot_id": event_snapshot_id,
+    })
+}

--- a/src/cli/commands/rollback.rs
+++ b/src/cli/commands/rollback.rs
@@ -1,3 +1,4 @@
+use crate::app::rollback_json::rollback_json_data;
 use crate::handlers::rollback::rollback;
 use crate::output::{JsonEnvelope, print_json};
 
@@ -6,13 +7,8 @@ use super::Ctx;
 pub(crate) fn run(ctx: &Ctx<'_>, snapshot_id: &str) -> anyhow::Result<()> {
     let event = rollback(ctx.home, snapshot_id, ctx.cli.json, ctx.cli.yes)?;
     if ctx.cli.json {
-        let envelope = JsonEnvelope::ok(
-            "rollback",
-            serde_json::json!({
-                "rolled_back_to": snapshot_id,
-                "event_snapshot_id": event.id,
-            }),
-        );
+        let data = rollback_json_data(snapshot_id, &event.id);
+        let envelope = JsonEnvelope::ok("rollback", data);
         print_json(&envelope)?;
     } else {
         println!("Rolled back to snapshot {snapshot_id}. Event: {}", event.id);

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -787,13 +787,8 @@ async fn call_rollback_in_process(
 
         let (text, envelope) = match result {
             Ok(event) => {
-                let envelope = crate::output::JsonEnvelope::ok(
-                    "rollback",
-                    serde_json::json!({
-                        "rolled_back_to": snapshot_id,
-                        "event_snapshot_id": event.id,
-                    }),
-                );
+                let data = crate::app::rollback_json::rollback_json_data(&snapshot_id, &event.id);
+                let envelope = crate::output::JsonEnvelope::ok("rollback", data);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 let envelope = serde_json::to_value(&envelope)?;
                 (text, envelope)


### PR DESCRIPTION
Context
- CLI rollback --json and the MCP rollback tool were assembling the same JSON data payload in multiple places.

What changed
- Added src/app/rollback_json.rs to centralize rollback JSON data construction.
- Updated CLI rollback --json and MCP rollback to reuse the shared builder.
- Added OpenSpec change refactor-app-rollback-json-data (no user-facing behavior change).

Why
- Reduce the risk of CLI/MCP JSON payload drift while keeping the stable --json contract unchanged.

Verification
- cargo fmt --all
- just check

Fixes #659
