### PR TITLE
refactor(app): centralize deploy JSON data

### DIFF
--- a/openspec/changes/refactor-app-deploy-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-deploy-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-deploy-json-data/README.md
+++ b/openspec/changes/refactor-app-deploy-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-deploy-json-data
+
+Refactor: centralize deploy JSON data construction

--- a/openspec/changes/refactor-app-deploy-json-data/proposal.md
+++ b/openspec/changes/refactor-app-deploy-json-data/proposal.md
@@ -1,0 +1,25 @@
+# Change: Refactor deploy JSON data construction into app layer
+
+## Why
+CLI `deploy --json` and the MCP `deploy` / `deploy_apply` tools all construct the same `data` payload for the `deploy` envelope:
+- `applied` (boolean)
+- optional `reason` (e.g., `no_changes`)
+- optional `snapshot_id`
+- `profile`
+- `targets`
+- `changes`
+- `summary`
+
+Today, the final `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add a small shared helper in `src/app/` to construct the `deploy` JSON `data` object deterministically.
+- Update CLI `deploy --json` and the MCP `deploy` / `deploy_apply` tools to reuse it.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (deploy JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/deploy.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-deploy-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-deploy-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: deploy JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `deploy` JSON `data` payload so that CLI `deploy --json` and the MCP `deploy` / `deploy_apply` tools keep equivalent output over time.
+
+#### Scenario: deploy JSON payload remains consistent
+- **GIVEN** a deployment plan that yields either no changes or applyable changes
+- **WHEN** a user runs `agentpack deploy --json` (optionally with `--apply`)
+- **AND** an MCP client calls `deploy` and `deploy_apply`
+- **THEN** the responses include equivalent `data` fields (`applied`, optional `reason`, optional `snapshot_id`, `profile`, `targets`, `changes`, `summary`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-deploy-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-deploy-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: deploy JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `deploy` JSON `data` payload so that the MCP `deploy` / `deploy_apply` tools stay consistent with CLI `deploy --json` over time.
+
+#### Scenario: deploy JSON payload remains consistent
+- **GIVEN** a deployment plan that yields either no changes or applyable changes
+- **WHEN** an MCP client calls `deploy` and `deploy_apply`
+- **AND** a user runs `agentpack deploy --json` (optionally with `--apply`)
+- **THEN** the responses include equivalent `data` fields (`applied`, optional `reason`, optional `snapshot_id`, `profile`, `targets`, `changes`, `summary`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-deploy-json-data/tasks.md
+++ b/openspec/changes/refactor-app-deploy-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared deploy JSON data construction
+- [x] Run `openspec validate refactor-app-deploy-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared deploy JSON data builder under `src/app/`
+- [x] Update CLI deploy and MCP deploy/deploy_apply to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/deploy_json.rs
+++ b/src/app/deploy_json.rs
@@ -1,0 +1,44 @@
+pub(crate) fn deploy_json_data_dry_run(
+    profile: &str,
+    targets: Vec<String>,
+    plan: crate::deploy::PlanResult,
+) -> serde_json::Value {
+    serde_json::json!({
+        "applied": false,
+        "profile": profile,
+        "targets": targets,
+        "changes": plan.changes,
+        "summary": plan.summary,
+    })
+}
+
+pub(crate) fn deploy_json_data_no_changes(
+    profile: &str,
+    targets: Vec<String>,
+    plan: crate::deploy::PlanResult,
+) -> serde_json::Value {
+    serde_json::json!({
+        "applied": false,
+        "reason": "no_changes",
+        "profile": profile,
+        "targets": targets,
+        "changes": plan.changes,
+        "summary": plan.summary,
+    })
+}
+
+pub(crate) fn deploy_json_data_applied(
+    profile: &str,
+    targets: Vec<String>,
+    plan: crate::deploy::PlanResult,
+    snapshot_id: String,
+) -> serde_json::Value {
+    serde_json::json!({
+        "applied": true,
+        "snapshot_id": snapshot_id,
+        "profile": profile,
+        "targets": targets,
+        "changes": plan.changes,
+        "summary": plan.summary,
+    })
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod deploy_json;
 pub(crate) mod doctor_json;
 pub(crate) mod doctor_next_actions;
 pub(crate) mod next_actions;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1130,16 +1130,9 @@ async fn deploy_plan_envelope_in_process(args: CommonArgs) -> anyhow::Result<ser
                 warnings,
                 ..
             }) => {
-                let mut envelope = crate::output::JsonEnvelope::ok(
-                    "deploy",
-                    serde_json::json!({
-                        "applied": false,
-                        "profile": profile,
-                        "targets": targets,
-                        "changes": plan.changes,
-                        "summary": plan.summary,
-                    }),
-                );
+                let data =
+                    crate::app::deploy_json::deploy_json_data_dry_run(profile, targets, plan);
+                let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
                 envelope.warnings = warnings;
                 serde_json::to_value(&envelope).context("serialize deploy envelope")
             }
@@ -1181,16 +1174,9 @@ async fn call_deploy_apply_in_process(
 
             let will_apply = !args.common.dry_run.unwrap_or(false);
             if !will_apply {
-                let mut envelope = crate::output::JsonEnvelope::ok(
-                    "deploy",
-                    serde_json::json!({
-                        "applied": false,
-                        "profile": profile,
-                        "targets": targets,
-                        "changes": plan.changes,
-                        "summary": plan.summary,
-                    }),
-                );
+                let data =
+                    crate::app::deploy_json::deploy_json_data_dry_run(profile, targets, plan);
+                let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
                 envelope.warnings = warnings;
 
                 let text = serde_json::to_string_pretty(&envelope)?;
@@ -1213,17 +1199,10 @@ async fn call_deploy_apply_in_process(
 
             match outcome {
                 crate::handlers::deploy::DeployApplyOutcome::NoChanges => {
-                    let mut envelope = crate::output::JsonEnvelope::ok(
-                        "deploy",
-                        serde_json::json!({
-                            "applied": false,
-                            "reason": "no_changes",
-                            "profile": profile,
-                            "targets": targets,
-                            "changes": plan.changes,
-                            "summary": plan.summary,
-                        }),
+                    let data = crate::app::deploy_json::deploy_json_data_no_changes(
+                        profile, targets, plan,
                     );
+                    let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
                     envelope.warnings = warnings;
 
                     let text = serde_json::to_string_pretty(&envelope)?;
@@ -1231,17 +1210,13 @@ async fn call_deploy_apply_in_process(
                     Ok((text, envelope))
                 }
                 crate::handlers::deploy::DeployApplyOutcome::Applied { snapshot_id } => {
-                    let mut envelope = crate::output::JsonEnvelope::ok(
-                        "deploy",
-                        serde_json::json!({
-                            "applied": true,
-                            "snapshot_id": snapshot_id,
-                            "profile": profile,
-                            "targets": targets,
-                            "changes": plan.changes,
-                            "summary": plan.summary,
-                        }),
+                    let data = crate::app::deploy_json::deploy_json_data_applied(
+                        profile,
+                        targets,
+                        plan,
+                        snapshot_id,
                     );
+                    let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
                     envelope.warnings = warnings;
 
                     let text = serde_json::to_string_pretty(&envelope)?;


### PR DESCRIPTION
Context
- CLI deploy --json and the MCP deploy/deploy_apply tools were assembling the same JSON data payload in multiple places.

What changed
- Added src/app/deploy_json.rs to centralize deploy JSON data construction.
- Updated CLI deploy --json and MCP deploy/deploy_apply to reuse the shared builder.
- Added OpenSpec change refactor-app-deploy-json-data (no user-facing behavior change).

Why
- Reduce the risk of CLI/MCP JSON payload drift while keeping the stable --json contract unchanged.

Verification
- cargo fmt --all
- just check

Fixes #662
