### PR TITLE
refactor(app): centralize evolve.restore JSON data

### DIFF
--- a/openspec/changes/refactor-app-evolve-restore-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-evolve-restore-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-evolve-restore-json-data/README.md
+++ b/openspec/changes/refactor-app-evolve-restore-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-evolve-restore-json-data
+
+Refactor: centralize evolve.restore JSON data construction

--- a/openspec/changes/refactor-app-evolve-restore-json-data/proposal.md
+++ b/openspec/changes/refactor-app-evolve-restore-json-data/proposal.md
@@ -1,0 +1,21 @@
+# Change: Refactor evolve.restore JSON data construction into app layer
+
+## Why
+CLI `evolve restore --json` and the MCP `evolve_restore` tool both build the same `data` payload:
+- `restored`
+- `summary`
+- `reason`
+
+Today, the final `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add a small shared helper in `src/app/` to construct the `evolve.restore` JSON `data` object deterministically.
+- Update CLI `evolve restore --json` and the MCP `evolve_restore` tool to reuse it.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (evolve.restore JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/evolve.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-evolve-restore-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-evolve-restore-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: evolve.restore JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `evolve.restore` JSON `data` payload so that CLI `evolve restore --json` and the MCP `evolve_restore` tool keep equivalent output over time.
+
+#### Scenario: evolve.restore JSON payload remains consistent
+- **GIVEN** a repo state with missing desired outputs (or none)
+- **WHEN** the user runs `agentpack evolve restore --json`
+- **AND** an MCP client calls the `evolve_restore` tool
+- **THEN** both responses include equivalent `data` fields (`restored`, `summary`, `reason`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-evolve-restore-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-evolve-restore-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: evolve.restore JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `evolve.restore` JSON `data` payload so that the MCP `evolve_restore` tool stays consistent with CLI `evolve restore --json` over time.
+
+#### Scenario: evolve.restore JSON payload remains consistent
+- **GIVEN** a repo state with missing desired outputs (or none)
+- **WHEN** an MCP client calls the `evolve_restore` tool
+- **AND** a user runs `agentpack evolve restore --json`
+- **THEN** both responses include equivalent `data` fields (`restored`, `summary`, `reason`) modulo surface-appropriate flags

--- a/openspec/changes/refactor-app-evolve-restore-json-data/tasks.md
+++ b/openspec/changes/refactor-app-evolve-restore-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared evolve.restore JSON data construction
+- [x] Run `openspec validate refactor-app-evolve-restore-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared evolve.restore JSON data builder under `src/app/`
+- [x] Update CLI evolve restore and MCP evolve_restore to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/evolve_restore_json.rs
+++ b/src/app/evolve_restore_json.rs
@@ -1,0 +1,11 @@
+pub(crate) fn evolve_restore_json_data(
+    restored: Vec<crate::handlers::evolve::EvolveRestoreItem>,
+    summary: crate::handlers::evolve::EvolveRestoreSummary,
+    reason: &'static str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "restored": restored,
+        "summary": summary,
+        "reason": reason,
+    })
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod deploy_json;
 pub(crate) mod doctor_json;
 pub(crate) mod doctor_next_actions;
+pub(crate) mod evolve_restore_json;
 pub(crate) mod next_actions;
 pub(crate) mod operator_assets;
 pub(crate) mod plan_json;

--- a/src/cli/commands/evolve.rs
+++ b/src/cli/commands/evolve.rs
@@ -1,3 +1,4 @@
+use crate::app::evolve_restore_json::evolve_restore_json_data;
 use crate::engine::Engine;
 use crate::output::{JsonEnvelope, print_json};
 
@@ -262,14 +263,8 @@ fn evolve_restore(
     };
 
     if cli.json {
-        let mut envelope = JsonEnvelope::ok(
-            "evolve.restore",
-            serde_json::json!({
-                "restored": report.restored,
-                "summary": report.summary,
-                "reason": report.reason,
-            }),
-        );
+        let data = evolve_restore_json_data(report.restored, report.summary, report.reason);
+        let mut envelope = JsonEnvelope::ok("evolve.restore", data);
         envelope.warnings = report.warnings;
         print_json(&envelope)?;
     } else {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -853,14 +853,12 @@ async fn call_evolve_restore_in_process(
 
         let (text, envelope) = match result {
             Ok(crate::handlers::evolve::EvolveRestoreOutcome::Done(report)) => {
-                let mut envelope = crate::output::JsonEnvelope::ok(
-                    "evolve.restore",
-                    serde_json::json!({
-                        "restored": report.restored,
-                        "summary": report.summary,
-                        "reason": report.reason,
-                    }),
+                let data = crate::app::evolve_restore_json::evolve_restore_json_data(
+                    report.restored,
+                    report.summary,
+                    report.reason,
                 );
+                let mut envelope = crate::output::JsonEnvelope::ok("evolve.restore", data);
                 envelope.warnings = report.warnings;
                 let text = serde_json::to_string_pretty(&envelope)?;
                 let envelope = serde_json::to_value(&envelope)?;


### PR DESCRIPTION
Fixes #665

## Summary
- Centralizes `evolve.restore` JSON `data` construction in `src/app/evolve_restore_json.rs`.
- Reuses the shared builder from both CLI (`agentpack evolve restore --json`) and MCP (`evolve_restore`).

## Spec
- OpenSpec change: `refactor-app-evolve-restore-json-data`
- Validation: `openspec validate refactor-app-evolve-restore-json-data --strict --no-interactive`

## Tests
- `just check`
