### PR TITLE
refactor(app): centralize evolve.propose JSON data

### DIFF
--- a/openspec/changes/refactor-app-evolve-propose-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-evolve-propose-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-evolve-propose-json-data/README.md
+++ b/openspec/changes/refactor-app-evolve-propose-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-evolve-propose-json-data
+
+Refactor: centralize evolve.propose JSON data construction

--- a/openspec/changes/refactor-app-evolve-propose-json-data/proposal.md
+++ b/openspec/changes/refactor-app-evolve-propose-json-data/proposal.md
@@ -1,0 +1,18 @@
+# Change: Refactor evolve.propose JSON data construction into app layer
+
+## Why
+CLI `evolve propose --json` and the MCP `evolve_propose` tool both build the same `data` payload for the `evolve.propose` command (with shapes that depend on the outcome: noop / dry-run / created).
+
+Today, the final `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add small shared helpers in `src/app/` to construct the `evolve.propose` JSON `data` objects deterministically.
+- Update CLI `evolve propose --json` and the MCP `evolve_propose` tool to reuse the shared construction.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (evolve.propose JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/evolve.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-evolve-propose-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-evolve-propose-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: evolve.propose JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `evolve.propose` JSON `data` payload so that CLI `evolve propose --json` and the MCP `evolve_propose` tool keep equivalent output over time.
+
+#### Scenario: evolve.propose JSON payload remains consistent
+- **GIVEN** a repo state that results in `evolve.propose` producing one of: noop / dry-run / created
+- **WHEN** the user runs `agentpack evolve propose --json`
+- **AND** an MCP client calls the `evolve_propose` tool
+- **THEN** both responses include equivalent `data` fields for the corresponding outcome

--- a/openspec/changes/refactor-app-evolve-propose-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-evolve-propose-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: evolve.propose JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `evolve.propose` JSON `data` payload so that the MCP `evolve_propose` tool stays consistent with CLI `evolve propose --json` over time.
+
+#### Scenario: evolve.propose JSON payload remains consistent
+- **GIVEN** a repo state that results in `evolve.propose` producing one of: noop / dry-run / created
+- **WHEN** an MCP client calls the `evolve_propose` tool
+- **AND** a user runs `agentpack evolve propose --json`
+- **THEN** both responses include equivalent `data` fields for the corresponding outcome

--- a/openspec/changes/refactor-app-evolve-propose-json-data/tasks.md
+++ b/openspec/changes/refactor-app-evolve-propose-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared evolve.propose JSON data construction
+- [x] Run `openspec validate refactor-app-evolve-propose-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared evolve.propose JSON data builder under `src/app/`
+- [x] Update CLI evolve propose and MCP evolve_propose to use it
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/evolve_propose_json.rs
+++ b/src/app/evolve_propose_json.rs
@@ -1,0 +1,43 @@
+pub(crate) fn evolve_propose_json_data_noop(
+    reason: &'static str,
+    summary: crate::handlers::evolve::EvolveProposeSummary,
+    skipped: Vec<crate::handlers::evolve::EvolveProposeSkippedItem>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "created": false,
+        "reason": reason,
+        "summary": summary,
+        "skipped": skipped,
+    })
+}
+
+pub(crate) fn evolve_propose_json_data_dry_run(
+    candidates: Vec<crate::handlers::evolve::EvolveProposeItem>,
+    skipped: Vec<crate::handlers::evolve::EvolveProposeSkippedItem>,
+    summary: crate::handlers::evolve::EvolveProposeSummary,
+) -> serde_json::Value {
+    serde_json::json!({
+        "created": false,
+        "reason": "dry_run",
+        "candidates": candidates,
+        "skipped": skipped,
+        "summary": summary,
+    })
+}
+
+pub(crate) fn evolve_propose_json_data_created(
+    branch: String,
+    scope: crate::handlers::evolve::EvolveScope,
+    files: Vec<String>,
+    files_posix: Vec<String>,
+    committed: bool,
+) -> serde_json::Value {
+    serde_json::json!({
+        "created": true,
+        "branch": branch,
+        "scope": scope,
+        "files": files,
+        "files_posix": files_posix,
+        "committed": committed,
+    })
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod deploy_json;
 pub(crate) mod doctor_json;
 pub(crate) mod doctor_next_actions;
+pub(crate) mod evolve_propose_json;
 pub(crate) mod evolve_restore_json;
 pub(crate) mod next_actions;
 pub(crate) mod operator_assets;

--- a/src/cli/commands/evolve.rs
+++ b/src/cli/commands/evolve.rs
@@ -1,3 +1,7 @@
+use crate::app::evolve_propose_json::{
+    evolve_propose_json_data_created, evolve_propose_json_data_dry_run,
+    evolve_propose_json_data_noop,
+};
 use crate::app::evolve_restore_json::evolve_restore_json_data;
 use crate::engine::Engine;
 use crate::output::{JsonEnvelope, print_json};
@@ -81,15 +85,9 @@ fn evolve_propose(
     match outcome {
         crate::handlers::evolve::EvolveProposeOutcome::Noop(report) => {
             if cli.json {
-                let mut envelope = JsonEnvelope::ok(
-                    "evolve.propose",
-                    serde_json::json!({
-                        "created": false,
-                        "reason": report.reason,
-                        "summary": report.summary,
-                        "skipped": report.skipped,
-                    }),
-                );
+                let data =
+                    evolve_propose_json_data_noop(report.reason, report.summary, report.skipped);
+                let mut envelope = JsonEnvelope::ok("evolve.propose", data);
                 envelope.warnings = report.warnings;
                 print_json(&envelope)?;
             } else {
@@ -136,16 +134,12 @@ fn evolve_propose(
         }
         crate::handlers::evolve::EvolveProposeOutcome::DryRun(report) => {
             if cli.json {
-                let mut envelope = JsonEnvelope::ok(
-                    "evolve.propose",
-                    serde_json::json!({
-                        "created": false,
-                        "reason": "dry_run",
-                        "candidates": report.candidates,
-                        "skipped": report.skipped,
-                        "summary": report.summary,
-                    }),
+                let data = evolve_propose_json_data_dry_run(
+                    report.candidates,
+                    report.skipped,
+                    report.summary,
                 );
+                let mut envelope = JsonEnvelope::ok("evolve.propose", data);
                 envelope.warnings = report.warnings;
                 print_json(&envelope)?;
             } else {
@@ -195,17 +189,14 @@ fn evolve_propose(
             }
 
             if cli.json {
-                let envelope = JsonEnvelope::ok(
-                    "evolve.propose",
-                    serde_json::json!({
-                        "created": true,
-                        "branch": report.branch,
-                        "scope": report.scope,
-                        "files": report.files,
-                        "files_posix": report.files_posix,
-                        "committed": report.committed,
-                    }),
+                let data = evolve_propose_json_data_created(
+                    report.branch,
+                    report.scope,
+                    report.files,
+                    report.files_posix,
+                    report.committed,
                 );
+                let envelope = JsonEnvelope::ok("evolve.propose", data);
                 print_json(&envelope)?;
             } else {
                 println!("Created proposal branch: {}", report.branch);

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -966,48 +966,38 @@ async fn call_evolve_propose_in_process(
 
         let (text, envelope) = match result {
             Ok(crate::handlers::evolve::EvolveProposeOutcome::Noop(report)) => {
-                let mut envelope = crate::output::JsonEnvelope::ok(
-                    "evolve.propose",
-                    serde_json::json!({
-                        "created": false,
-                        "reason": report.reason,
-                        "summary": report.summary,
-                        "skipped": report.skipped,
-                    }),
+                let data = crate::app::evolve_propose_json::evolve_propose_json_data_noop(
+                    report.reason,
+                    report.summary,
+                    report.skipped,
                 );
+                let mut envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
                 envelope.warnings = report.warnings;
                 let text = serde_json::to_string_pretty(&envelope)?;
                 let envelope = serde_json::to_value(&envelope)?;
                 (text, envelope)
             }
             Ok(crate::handlers::evolve::EvolveProposeOutcome::DryRun(report)) => {
-                let mut envelope = crate::output::JsonEnvelope::ok(
-                    "evolve.propose",
-                    serde_json::json!({
-                        "created": false,
-                        "reason": "dry_run",
-                        "candidates": report.candidates,
-                        "skipped": report.skipped,
-                        "summary": report.summary,
-                    }),
+                let data = crate::app::evolve_propose_json::evolve_propose_json_data_dry_run(
+                    report.candidates,
+                    report.skipped,
+                    report.summary,
                 );
+                let mut envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
                 envelope.warnings = report.warnings;
                 let text = serde_json::to_string_pretty(&envelope)?;
                 let envelope = serde_json::to_value(&envelope)?;
                 (text, envelope)
             }
             Ok(crate::handlers::evolve::EvolveProposeOutcome::Created(report)) => {
-                let envelope = crate::output::JsonEnvelope::ok(
-                    "evolve.propose",
-                    serde_json::json!({
-                        "created": true,
-                        "branch": report.branch,
-                        "scope": report.scope,
-                        "files": report.files,
-                        "files_posix": report.files_posix,
-                        "committed": report.committed,
-                    }),
+                let data = crate::app::evolve_propose_json::evolve_propose_json_data_created(
+                    report.branch,
+                    report.scope,
+                    report.files,
+                    report.files_posix,
+                    report.committed,
                 );
+                let envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 let envelope = serde_json::to_value(&envelope)?;
                 (text, envelope)


### PR DESCRIPTION
Fixes #668

## Summary
- Centralizes `evolve.propose` JSON `data` construction in `src/app/evolve_propose_json.rs`.
- Reuses the shared builders from both CLI (`agentpack evolve propose --json`) and MCP (`evolve_propose`).

## Spec
- OpenSpec change: `refactor-app-evolve-propose-json-data`
- Validation: `openspec validate refactor-app-evolve-propose-json-data --strict --no-interactive`

## Tests
- `just check`
