### PR TITLE
refactor(app): centralize explain JSON data

### DIFF
--- a/openspec/changes/refactor-app-explain-json-data/.openspec.yaml
+++ b/openspec/changes/refactor-app-explain-json-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-app-explain-json-data/README.md
+++ b/openspec/changes/refactor-app-explain-json-data/README.md
@@ -1,0 +1,3 @@
+# refactor-app-explain-json-data
+
+Refactor: centralize explain JSON data construction

--- a/openspec/changes/refactor-app-explain-json-data/proposal.md
+++ b/openspec/changes/refactor-app-explain-json-data/proposal.md
@@ -1,0 +1,20 @@
+# Change: Refactor explain JSON data construction into app layer
+
+## Why
+CLI `agentpack explain * --json` and the MCP `explain` tool both construct `data` payloads for:
+- `explain.plan` (used by `explain plan` and `explain diff`)
+- `explain.status`
+
+Today, the final JSON `data` object construction is duplicated across the CLI and MCP handlers. Centralizing it reduces the risk of output drift over time while keeping the stable `--json` contract unchanged.
+
+## What Changes
+- Add small shared helpers in `src/app/` to construct the `explain.plan` and `explain.status` JSON `data` objects deterministically.
+- Update CLI `explain` and the MCP `explain` tool to reuse the shared construction.
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (explain JSON payload remains consistent).
+- Affected code:
+  - `src/app/*`
+  - `src/cli/commands/explain.rs`
+  - `src/mcp/tools.rs`
+- No user-facing behavior change expected.

--- a/openspec/changes/refactor-app-explain-json-data/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-app-explain-json-data/specs/agentpack-cli/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: explain JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `explain.plan` and `explain.status` JSON `data` payloads so that CLI `agentpack explain * --json` and the MCP `explain` tool keep equivalent output over time.
+
+#### Scenario: explain.plan JSON payload remains consistent
+- **GIVEN** a repo state that produces an `explain.plan` response
+- **WHEN** the user runs `agentpack explain plan --json` (or `agentpack explain diff --json`)
+- **AND** an MCP client calls the `explain` tool with `kind=plan` (or `kind=diff`)
+- **THEN** both responses include equivalent `data` fields (`profile`, `targets`, `changes`)
+
+#### Scenario: explain.status JSON payload remains consistent
+- **GIVEN** a repo state that produces an `explain.status` response
+- **WHEN** the user runs `agentpack explain status --json`
+- **AND** an MCP client calls the `explain` tool with `kind=status`
+- **THEN** both responses include equivalent `data` fields (`profile`, `targets`, `drift`)

--- a/openspec/changes/refactor-app-explain-json-data/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-app-explain-json-data/specs/agentpack-mcp/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: explain JSON payload remains consistent across CLI and MCP
+The system SHALL centralize the construction of the `explain.plan` and `explain.status` JSON `data` payloads so that the MCP `explain` tool stays consistent with CLI `agentpack explain * --json` over time.
+
+#### Scenario: explain.plan JSON payload remains consistent
+- **GIVEN** a repo state that produces an `explain.plan` response
+- **WHEN** an MCP client calls the `explain` tool with `kind=plan` (or `kind=diff`)
+- **AND** a user runs `agentpack explain plan --json` (or `agentpack explain diff --json`)
+- **THEN** both responses include equivalent `data` fields (`profile`, `targets`, `changes`)
+
+#### Scenario: explain.status JSON payload remains consistent
+- **GIVEN** a repo state that produces an `explain.status` response
+- **WHEN** an MCP client calls the `explain` tool with `kind=status`
+- **AND** a user runs `agentpack explain status --json`
+- **THEN** both responses include equivalent `data` fields (`profile`, `targets`, `drift`)

--- a/openspec/changes/refactor-app-explain-json-data/tasks.md
+++ b/openspec/changes/refactor-app-explain-json-data/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for shared explain JSON data construction
+- [x] Run `openspec validate refactor-app-explain-json-data --strict --no-interactive`
+
+## 2. Implementation
+- [x] Add shared explain JSON data builders under `src/app/`
+- [x] Update CLI explain and MCP explain to use them
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/app/explain_json.rs
+++ b/src/app/explain_json.rs
@@ -1,0 +1,51 @@
+#[derive(serde::Serialize)]
+pub(crate) struct ExplainedModule {
+    pub(crate) module_id: String,
+    pub(crate) module_type: Option<String>,
+    pub(crate) layer: Option<String>,
+    pub(crate) module_path: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct ExplainedChange {
+    pub(crate) op: String,
+    pub(crate) target: String,
+    pub(crate) path: String,
+    pub(crate) path_posix: String,
+    pub(crate) modules: Vec<ExplainedModule>,
+}
+
+#[derive(serde::Serialize)]
+pub(crate) struct ExplainedDrift {
+    pub(crate) kind: String,
+    pub(crate) target: String,
+    pub(crate) path: String,
+    pub(crate) path_posix: String,
+    pub(crate) expected: Option<String>,
+    pub(crate) actual: Option<String>,
+    pub(crate) modules: Vec<String>,
+}
+
+pub(crate) fn explain_plan_json_data(
+    profile: &str,
+    targets: Vec<String>,
+    changes: Vec<ExplainedChange>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "profile": profile,
+        "targets": targets,
+        "changes": changes,
+    })
+}
+
+pub(crate) fn explain_status_json_data(
+    profile: &str,
+    targets: Vec<String>,
+    drift: Vec<ExplainedDrift>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "profile": profile,
+        "targets": targets,
+        "drift": drift,
+    })
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod doctor_json;
 pub(crate) mod doctor_next_actions;
 pub(crate) mod evolve_propose_json;
 pub(crate) mod evolve_restore_json;
+pub(crate) mod explain_json;
 pub(crate) mod next_actions;
 pub(crate) mod operator_assets;
 pub(crate) mod plan_json;


### PR DESCRIPTION
Fixes #671

## Summary
- Centralizes `explain.plan` and `explain.status` JSON `data` construction in `src/app/explain_json.rs`.
- Reuses the shared builders from both CLI (`agentpack explain * --json`) and MCP (`explain`).

## Spec
- OpenSpec change: `refactor-app-explain-json-data`
- Validation: `openspec validate refactor-app-explain-json-data --strict --no-interactive`

## Tests
- `just check`
