### PR TITLE
refactor(mcp): extract evolve_restore tool module

### DIFF
--- a/openspec/changes/refactor-mcp-evolve-restore-tool-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-evolve-restore-tool-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-mcp-evolve-restore-tool-module/README.md
+++ b/openspec/changes/refactor-mcp-evolve-restore-tool-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-evolve-restore-tool-module
+
+Refactor: extract MCP evolve_restore tool implementation into a dedicated module

--- a/openspec/changes/refactor-mcp-evolve-restore-tool-module/proposal.md
+++ b/openspec/changes/refactor-mcp-evolve-restore-tool-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP evolve_restore tool implementation into its own module
+
+## Why
+`src/mcp/tools.rs` contains implementations for many tools and is large. Extracting the `evolve_restore` tool handler into a dedicated module improves readability and makes future changes safer and easier to review.
+
+## What Changes
+- Move the `evolve_restore` tool implementation (`call_evolve_restore_in_process`) from `src/mcp/tools.rs` into `src/mcp/tools/evolve_restore.rs`.
+- Keep the public MCP surface and JSON output unchanged.
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/evolve_restore.rs`

--- a/openspec/changes/refactor-mcp-evolve-restore-tool-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-evolve-restore-tool-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP evolve_restore tool implementation is modularized without behavior change
+The system SHALL allow the MCP `evolve_restore` tool implementation to be moved into a dedicated module file while preserving the tool schema, output envelopes, error behavior, and confirmation/guardrails semantics.
+
+#### Scenario: MCP evolve_restore tool continues to behave the same after refactor
+- **GIVEN** an MCP client that calls the `evolve_restore` tool
+- **WHEN** the implementation is refactored to a dedicated module file
+- **THEN** the responses (envelope fields and `data` payload shape) remain unchanged

--- a/openspec/changes/refactor-mcp-evolve-restore-tool-module/tasks.md
+++ b/openspec/changes/refactor-mcp-evolve-restore-tool-module/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for extracting MCP evolve_restore tool implementation
+- [x] Run `openspec validate refactor-mcp-evolve-restore-tool-module --strict --no-interactive`
+
+## 2. Implementation
+- [x] Extract `call_evolve_restore_in_process` into `src/mcp/tools/evolve_restore.rs`
+- [x] Keep `src/mcp/tools.rs` behavior unchanged (including errors/envelope/commands)
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -20,6 +20,7 @@ use crate::user_error::UserError;
 use super::confirm::{CONFIRM_TOKEN_TTL, ConfirmTokenBinding};
 use super::{AgentpackMcp, confirm};
 
+mod evolve_restore;
 mod explain;
 
 pub(super) const TOOLS_INSTRUCTIONS: &str = "Agentpack MCP server (stdio). Tools: plan, diff, preview, status, doctor, deploy, deploy_apply, rollback, evolve_propose, evolve_restore, explain.";
@@ -526,86 +527,7 @@ async fn call_rollback_in_process(
 async fn call_evolve_restore_in_process(
     args: EvolveRestoreArgs,
 ) -> anyhow::Result<(String, serde_json::Value)> {
-    tokio::task::spawn_blocking(move || {
-        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
-        let profile = args.common.profile.as_deref().unwrap_or("default");
-        let target = args.common.target.as_deref().unwrap_or("all");
-        let machine_override = args.common.machine.as_deref();
-        let dry_run = args.common.dry_run.unwrap_or(false);
-
-        let engine = match crate::engine::Engine::load(repo_override.as_deref(), machine_override) {
-            Ok(v) => v,
-            Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = envelope_error("evolve.restore", &code, &message, details);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                return Ok((text, envelope));
-            }
-        };
-
-        let result = crate::handlers::evolve::evolve_restore_in(
-            &engine,
-            profile,
-            target,
-            args.module_id.as_deref(),
-            dry_run,
-            args.yes,
-            true,
-        );
-
-        let (text, envelope) = match result {
-            Ok(crate::handlers::evolve::EvolveRestoreOutcome::Done(report)) => {
-                let data = crate::app::evolve_restore_json::evolve_restore_json_data(
-                    report.restored,
-                    report.summary,
-                    report.reason,
-                );
-                let mut envelope = crate::output::JsonEnvelope::ok("evolve.restore", data);
-                envelope.warnings = report.warnings;
-                let text = serde_json::to_string_pretty(&envelope)?;
-                let envelope = serde_json::to_value(&envelope)?;
-                (text, envelope)
-            }
-            Ok(crate::handlers::evolve::EvolveRestoreOutcome::NeedsConfirmation) => {
-                let err = UserError::confirm_required("evolve restore");
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = envelope_error("evolve.restore", &code, &message, details);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                (text, envelope)
-            }
-            Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = envelope_error("evolve.restore", &code, &message, details);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                (text, envelope)
-            }
-        };
-
-        Ok((text, envelope))
-    })
-    .await
-    .context("mcp evolve_restore handler task join")?
+    evolve_restore::call_evolve_restore_in_process(args).await
 }
 
 async fn call_evolve_propose_in_process(

--- a/src/mcp/tools/evolve_restore.rs
+++ b/src/mcp/tools/evolve_restore.rs
@@ -1,0 +1,88 @@
+use anyhow::Context as _;
+
+use crate::user_error::UserError;
+
+pub(super) async fn call_evolve_restore_in_process(
+    args: super::EvolveRestoreArgs,
+) -> anyhow::Result<(String, serde_json::Value)> {
+    tokio::task::spawn_blocking(move || {
+        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
+        let profile = args.common.profile.as_deref().unwrap_or("default");
+        let target = args.common.target.as_deref().unwrap_or("all");
+        let machine_override = args.common.machine.as_deref();
+        let dry_run = args.common.dry_run.unwrap_or(false);
+
+        let engine = match crate::engine::Engine::load(repo_override.as_deref(), machine_override) {
+            Ok(v) => v,
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("evolve.restore", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                return Ok((text, envelope));
+            }
+        };
+
+        let result = crate::handlers::evolve::evolve_restore_in(
+            &engine,
+            profile,
+            target,
+            args.module_id.as_deref(),
+            dry_run,
+            args.yes,
+            true,
+        );
+
+        let (text, envelope) = match result {
+            Ok(crate::handlers::evolve::EvolveRestoreOutcome::Done(report)) => {
+                let data = crate::app::evolve_restore_json::evolve_restore_json_data(
+                    report.restored,
+                    report.summary,
+                    report.reason,
+                );
+                let mut envelope = crate::output::JsonEnvelope::ok("evolve.restore", data);
+                envelope.warnings = report.warnings;
+                let text = serde_json::to_string_pretty(&envelope)?;
+                let envelope = serde_json::to_value(&envelope)?;
+                (text, envelope)
+            }
+            Ok(crate::handlers::evolve::EvolveRestoreOutcome::NeedsConfirmation) => {
+                let err = UserError::confirm_required("evolve restore");
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("evolve.restore", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                (text, envelope)
+            }
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("evolve.restore", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                (text, envelope)
+            }
+        };
+
+        Ok((text, envelope))
+    })
+    .await
+    .context("mcp evolve_restore handler task join")?
+}


### PR DESCRIPTION
## Why
`src/mcp/tools.rs` is large and contains many tool implementations; extracting `evolve_restore` makes the MCP layer easier to navigate and review.

## What
- Move `call_evolve_restore_in_process` into `src/mcp/tools/evolve_restore.rs`.
- Keep MCP tool schema + JSON envelopes unchanged.

## Verification
- `openspec validate refactor-mcp-evolve-restore-tool-module --strict --no-interactive`
- `cargo fmt --all`
- `just check`

Fixes #677
