### PR TITLE
refactor(mcp): extract evolve_propose tool module

### DIFF
--- a/openspec/changes/refactor-mcp-evolve-propose-tool-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-evolve-propose-tool-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-mcp-evolve-propose-tool-module/README.md
+++ b/openspec/changes/refactor-mcp-evolve-propose-tool-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-evolve-propose-tool-module
+
+Refactor: extract MCP evolve_propose tool implementation into a dedicated module

--- a/openspec/changes/refactor-mcp-evolve-propose-tool-module/proposal.md
+++ b/openspec/changes/refactor-mcp-evolve-propose-tool-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP evolve_propose tool implementation into its own module
+
+## Why
+`src/mcp/tools.rs` contains implementations for many tools and is large. Extracting the `evolve_propose` tool handler into a dedicated module improves readability and makes future changes safer and easier to review.
+
+## What Changes
+- Move the `evolve_propose` tool implementation (`call_evolve_propose_in_process`) from `src/mcp/tools.rs` into `src/mcp/tools/evolve_propose.rs`.
+- Keep the public MCP surface and JSON output unchanged.
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/evolve_propose.rs`

--- a/openspec/changes/refactor-mcp-evolve-propose-tool-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-evolve-propose-tool-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP evolve_propose tool implementation is modularized without behavior change
+The system SHALL allow the MCP `evolve_propose` tool implementation to be moved into a dedicated module file while preserving the tool schema, output envelopes, error behavior, and confirmation/guardrails semantics.
+
+#### Scenario: MCP evolve_propose tool continues to behave the same after refactor
+- **GIVEN** an MCP client that calls the `evolve_propose` tool
+- **WHEN** the implementation is refactored to a dedicated module file
+- **THEN** the responses (envelope fields and `data` payload shape) remain unchanged

--- a/openspec/changes/refactor-mcp-evolve-propose-tool-module/tasks.md
+++ b/openspec/changes/refactor-mcp-evolve-propose-tool-module/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for extracting MCP evolve_propose tool implementation
+- [x] Run `openspec validate refactor-mcp-evolve-propose-tool-module --strict --no-interactive`
+
+## 2. Implementation
+- [x] Extract `call_evolve_propose_in_process` into `src/mcp/tools/evolve_propose.rs`
+- [x] Keep `src/mcp/tools.rs` behavior unchanged (including errors/envelope/commands)
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -20,6 +20,7 @@ use crate::user_error::UserError;
 use super::confirm::{CONFIRM_TOKEN_TTL, ConfirmTokenBinding};
 use super::{AgentpackMcp, confirm};
 
+mod evolve_propose;
 mod evolve_restore;
 mod explain;
 
@@ -533,139 +534,7 @@ async fn call_evolve_restore_in_process(
 async fn call_evolve_propose_in_process(
     args: EvolveProposeArgs,
 ) -> anyhow::Result<(String, serde_json::Value)> {
-    tokio::task::spawn_blocking(move || {
-        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
-        let profile = args.common.profile.as_deref().unwrap_or("default");
-        let target = args.common.target.as_deref().unwrap_or("all");
-        let machine_override = args.common.machine.as_deref();
-        let dry_run = args.common.dry_run.unwrap_or(false);
-
-        let action_prefix = {
-            let mut out = String::from("agentpack");
-            if let Some(repo) = args.common.repo.as_deref() {
-                out.push_str(&format!(" --repo {repo}"));
-            }
-            if profile != "default" {
-                out.push_str(&format!(" --profile {profile}"));
-            }
-            if target != "all" {
-                out.push_str(&format!(" --target {target}"));
-            }
-            if let Some(machine) = machine_override {
-                out.push_str(&format!(" --machine {machine}"));
-            }
-            out
-        };
-
-        let scope = match args.scope.unwrap_or(EvolveScopeArg::Global) {
-            EvolveScopeArg::Global => crate::handlers::evolve::EvolveScope::Global,
-            EvolveScopeArg::Machine => crate::handlers::evolve::EvolveScope::Machine,
-            EvolveScopeArg::Project => crate::handlers::evolve::EvolveScope::Project,
-        };
-
-        let engine = match crate::engine::Engine::load(repo_override.as_deref(), machine_override) {
-            Ok(v) => v,
-            Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = envelope_error("evolve.propose", &code, &message, details);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                return Ok((text, envelope));
-            }
-        };
-
-        let result = crate::handlers::evolve::evolve_propose_in(
-            &engine,
-            crate::handlers::evolve::EvolveProposeInput {
-                profile,
-                target_filter: target,
-                action_prefix: &action_prefix,
-                module_filter: args.module_id.as_deref(),
-                scope,
-                branch_override: args.branch.as_deref(),
-                dry_run,
-                confirmed: args.yes,
-                json: true,
-            },
-        );
-
-        let (text, envelope) = match result {
-            Ok(crate::handlers::evolve::EvolveProposeOutcome::Noop(report)) => {
-                let data = crate::app::evolve_propose_json::evolve_propose_json_data_noop(
-                    report.reason,
-                    report.summary,
-                    report.skipped,
-                );
-                let mut envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
-                envelope.warnings = report.warnings;
-                let text = serde_json::to_string_pretty(&envelope)?;
-                let envelope = serde_json::to_value(&envelope)?;
-                (text, envelope)
-            }
-            Ok(crate::handlers::evolve::EvolveProposeOutcome::DryRun(report)) => {
-                let data = crate::app::evolve_propose_json::evolve_propose_json_data_dry_run(
-                    report.candidates,
-                    report.skipped,
-                    report.summary,
-                );
-                let mut envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
-                envelope.warnings = report.warnings;
-                let text = serde_json::to_string_pretty(&envelope)?;
-                let envelope = serde_json::to_value(&envelope)?;
-                (text, envelope)
-            }
-            Ok(crate::handlers::evolve::EvolveProposeOutcome::Created(report)) => {
-                let data = crate::app::evolve_propose_json::evolve_propose_json_data_created(
-                    report.branch,
-                    report.scope,
-                    report.files,
-                    report.files_posix,
-                    report.committed,
-                );
-                let envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                let envelope = serde_json::to_value(&envelope)?;
-                (text, envelope)
-            }
-            Ok(crate::handlers::evolve::EvolveProposeOutcome::NeedsConfirmation) => {
-                let err = UserError::confirm_required("evolve propose");
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = envelope_error("evolve.propose", &code, &message, details);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                (text, envelope)
-            }
-            Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = envelope_error("evolve.propose", &code, &message, details);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                (text, envelope)
-            }
-        };
-
-        Ok((text, envelope))
-    })
-    .await
-    .context("mcp evolve_propose handler task join")?
+    evolve_propose::call_evolve_propose_in_process(args).await
 }
 
 async fn call_preview_in_process(args: PreviewArgs) -> anyhow::Result<(String, serde_json::Value)> {

--- a/src/mcp/tools/evolve_propose.rs
+++ b/src/mcp/tools/evolve_propose.rs
@@ -1,0 +1,141 @@
+use anyhow::Context as _;
+
+use crate::user_error::UserError;
+
+pub(super) async fn call_evolve_propose_in_process(
+    args: super::EvolveProposeArgs,
+) -> anyhow::Result<(String, serde_json::Value)> {
+    tokio::task::spawn_blocking(move || {
+        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
+        let profile = args.common.profile.as_deref().unwrap_or("default");
+        let target = args.common.target.as_deref().unwrap_or("all");
+        let machine_override = args.common.machine.as_deref();
+        let dry_run = args.common.dry_run.unwrap_or(false);
+
+        let action_prefix = {
+            let mut out = String::from("agentpack");
+            if let Some(repo) = args.common.repo.as_deref() {
+                out.push_str(&format!(" --repo {repo}"));
+            }
+            if profile != "default" {
+                out.push_str(&format!(" --profile {profile}"));
+            }
+            if target != "all" {
+                out.push_str(&format!(" --target {target}"));
+            }
+            if let Some(machine) = machine_override {
+                out.push_str(&format!(" --machine {machine}"));
+            }
+            out
+        };
+
+        let scope = match args.scope.unwrap_or(super::EvolveScopeArg::Global) {
+            super::EvolveScopeArg::Global => crate::handlers::evolve::EvolveScope::Global,
+            super::EvolveScopeArg::Machine => crate::handlers::evolve::EvolveScope::Machine,
+            super::EvolveScopeArg::Project => crate::handlers::evolve::EvolveScope::Project,
+        };
+
+        let engine = match crate::engine::Engine::load(repo_override.as_deref(), machine_override) {
+            Ok(v) => v,
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("evolve.propose", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                return Ok((text, envelope));
+            }
+        };
+
+        let result = crate::handlers::evolve::evolve_propose_in(
+            &engine,
+            crate::handlers::evolve::EvolveProposeInput {
+                profile,
+                target_filter: target,
+                action_prefix: &action_prefix,
+                module_filter: args.module_id.as_deref(),
+                scope,
+                branch_override: args.branch.as_deref(),
+                dry_run,
+                confirmed: args.yes,
+                json: true,
+            },
+        );
+
+        let (text, envelope) = match result {
+            Ok(crate::handlers::evolve::EvolveProposeOutcome::Noop(report)) => {
+                let data = crate::app::evolve_propose_json::evolve_propose_json_data_noop(
+                    report.reason,
+                    report.summary,
+                    report.skipped,
+                );
+                let mut envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
+                envelope.warnings = report.warnings;
+                let text = serde_json::to_string_pretty(&envelope)?;
+                let envelope = serde_json::to_value(&envelope)?;
+                (text, envelope)
+            }
+            Ok(crate::handlers::evolve::EvolveProposeOutcome::DryRun(report)) => {
+                let data = crate::app::evolve_propose_json::evolve_propose_json_data_dry_run(
+                    report.candidates,
+                    report.skipped,
+                    report.summary,
+                );
+                let mut envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
+                envelope.warnings = report.warnings;
+                let text = serde_json::to_string_pretty(&envelope)?;
+                let envelope = serde_json::to_value(&envelope)?;
+                (text, envelope)
+            }
+            Ok(crate::handlers::evolve::EvolveProposeOutcome::Created(report)) => {
+                let data = crate::app::evolve_propose_json::evolve_propose_json_data_created(
+                    report.branch,
+                    report.scope,
+                    report.files,
+                    report.files_posix,
+                    report.committed,
+                );
+                let envelope = crate::output::JsonEnvelope::ok("evolve.propose", data);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                let envelope = serde_json::to_value(&envelope)?;
+                (text, envelope)
+            }
+            Ok(crate::handlers::evolve::EvolveProposeOutcome::NeedsConfirmation) => {
+                let err = UserError::confirm_required("evolve propose");
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("evolve.propose", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                (text, envelope)
+            }
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("evolve.propose", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                (text, envelope)
+            }
+        };
+
+        Ok((text, envelope))
+    })
+    .await
+    .context("mcp evolve_propose handler task join")?
+}


### PR DESCRIPTION
## Why
`src/mcp/tools.rs` is large and contains many tool implementations; extracting `evolve_propose` makes the MCP layer easier to navigate and review.

## What
- Move `call_evolve_propose_in_process` into `src/mcp/tools/evolve_propose.rs`.
- Keep MCP tool schema + JSON envelopes unchanged.

## Verification
- `openspec validate refactor-mcp-evolve-propose-tool-module --strict --no-interactive`
- `cargo fmt --all`
- `just check`

Fixes #680
