### PR TITLE
refactor(mcp): extract rollback tool module

### DIFF
--- a/openspec/changes/refactor-mcp-rollback-tool-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-rollback-tool-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-mcp-rollback-tool-module/README.md
+++ b/openspec/changes/refactor-mcp-rollback-tool-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-rollback-tool-module
+
+Refactor: extract MCP rollback tool implementation into a dedicated module

--- a/openspec/changes/refactor-mcp-rollback-tool-module/proposal.md
+++ b/openspec/changes/refactor-mcp-rollback-tool-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP rollback tool implementation into its own module
+
+## Why
+`src/mcp/tools.rs` contains implementations for many tools and is large. Extracting the `rollback` tool handler into a dedicated module improves readability and makes future changes safer and easier to review.
+
+## What Changes
+- Move the `rollback` tool implementation (`call_rollback_in_process`) from `src/mcp/tools.rs` into `src/mcp/tools/rollback.rs`.
+- Keep the public MCP surface and JSON output unchanged.
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/rollback.rs`

--- a/openspec/changes/refactor-mcp-rollback-tool-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-rollback-tool-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP rollback tool implementation is modularized without behavior change
+The system SHALL allow the MCP `rollback` tool implementation to be moved into a dedicated module file while preserving the tool schema, output envelopes, error behavior, and confirmation/guardrails semantics.
+
+#### Scenario: MCP rollback tool continues to behave the same after refactor
+- **GIVEN** an MCP client that calls the `rollback` tool
+- **WHEN** the implementation is refactored to a dedicated module file
+- **THEN** the responses (envelope fields and `data` payload shape) remain unchanged

--- a/openspec/changes/refactor-mcp-rollback-tool-module/tasks.md
+++ b/openspec/changes/refactor-mcp-rollback-tool-module/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for extracting MCP rollback tool implementation
+- [x] Run `openspec validate refactor-mcp-rollback-tool-module --strict --no-interactive`
+
+## 2. Implementation
+- [x] Extract `call_rollback_in_process` into `src/mcp/tools/rollback.rs`
+- [x] Keep `src/mcp/tools.rs` behavior unchanged (including errors/envelope/commands)
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/rollback.rs
+++ b/src/mcp/tools/rollback.rs
@@ -1,0 +1,45 @@
+use anyhow::Context as _;
+
+use crate::user_error::UserError;
+
+pub(super) async fn call_rollback_in_process(
+    args: super::RollbackArgs,
+) -> anyhow::Result<(String, serde_json::Value)> {
+    tokio::task::spawn_blocking(move || {
+        let home = crate::paths::AgentpackHome::resolve().context("resolve agentpack home")?;
+
+        let super::RollbackArgs {
+            repo: _repo_override,
+            to: snapshot_id,
+            yes,
+        } = args;
+        let result = crate::handlers::rollback::rollback(&home, &snapshot_id, true, yes);
+
+        let (text, envelope) = match result {
+            Ok(event) => {
+                let data = crate::app::rollback_json::rollback_json_data(&snapshot_id, &event.id);
+                let envelope = crate::output::JsonEnvelope::ok("rollback", data);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                let envelope = serde_json::to_value(&envelope)?;
+                (text, envelope)
+            }
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("rollback", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                (text, envelope)
+            }
+        };
+
+        Ok((text, envelope))
+    })
+    .await
+    .context("mcp rollback handler task join")?
+}


### PR DESCRIPTION
## Why
`src/mcp/tools.rs` is large and contains many tool implementations; extracting `rollback` makes the MCP layer easier to navigate and review.

## What
- Move `call_rollback_in_process` into `src/mcp/tools/rollback.rs`.
- Keep MCP tool schema + JSON envelopes unchanged.

## Verification
- `openspec validate refactor-mcp-rollback-tool-module --strict --no-interactive`
- `cargo fmt --all`
- `just check`

Fixes #683
