### PR TITLE
refactor(mcp): extract status tool module

### DIFF
--- a/openspec/changes/refactor-mcp-status-tool-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-status-tool-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-mcp-status-tool-module/README.md
+++ b/openspec/changes/refactor-mcp-status-tool-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-status-tool-module
+
+Refactor: extract MCP status tool implementation into a dedicated module

--- a/openspec/changes/refactor-mcp-status-tool-module/proposal.md
+++ b/openspec/changes/refactor-mcp-status-tool-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP status tool implementation into its own module
+
+## Why
+`src/mcp/tools.rs` contains implementations for many tools and is large. Extracting the `status` tool handler into a dedicated module improves readability and makes future changes safer and easier to review.
+
+## What Changes
+- Move the `status` tool implementation (`call_status_in_process`) from `src/mcp/tools.rs` into `src/mcp/tools/status.rs`.
+- Keep the public MCP surface and JSON output unchanged.
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/status.rs`

--- a/openspec/changes/refactor-mcp-status-tool-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-status-tool-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,11 @@
+# agentpack-mcp (delta)
+
+## ADDED Requirements
+
+### Requirement: MCP tool handlers are modular
+The MCP tool handler implementations SHALL be organized as dedicated Rust modules to keep the server maintainable, while preserving the existing external MCP behavior and Agentpack JSON envelope semantics.
+
+#### Scenario: Status tool handler extracted into a module
+- **WHEN** the MCP server is built
+- **THEN** the `status` tool handler implementation lives in `src/mcp/tools/status.rs`
+- **AND** the `tools/list` and `tools/call` behavior remains unchanged

--- a/openspec/changes/refactor-mcp-status-tool-module/tasks.md
+++ b/openspec/changes/refactor-mcp-status-tool-module/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for extracting MCP status tool implementation
+- [x] Run `openspec validate refactor-mcp-status-tool-module --strict --no-interactive`
+
+## 2. Implementation
+- [x] Extract `call_status_in_process` into `src/mcp/tools/status.rs`
+- [x] Keep `src/mcp/tools.rs` behavior unchanged (including errors/envelope/commands)
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -9,12 +9,6 @@ use rmcp::{
 
 use crate::app::doctor_json::doctor_json_data;
 use crate::app::doctor_next_actions::doctor_next_actions;
-use crate::app::operator_assets::{
-    OperatorAssetsStatusPaths, warn_operator_assets_if_outdated_for_status,
-};
-use crate::app::status_drift::{drift_summary_by_root, filter_drift_by_kind};
-use crate::app::status_json::status_json_data;
-use crate::app::status_next_actions::status_next_actions;
 use crate::user_error::UserError;
 
 use super::confirm::{CONFIRM_TOKEN_TTL, ConfirmTokenBinding};
@@ -24,6 +18,7 @@ mod evolve_propose;
 mod evolve_restore;
 mod explain;
 mod rollback;
+mod status;
 
 pub(super) const TOOLS_INSTRUCTIONS: &str = "Agentpack MCP server (stdio). Tools: plan, diff, preview, status, doctor, deploy, deploy_apply, rollback, evolve_propose, evolve_restore, explain.";
 
@@ -259,37 +254,6 @@ fn action_prefix(repo: Option<&str>, target: &str) -> String {
     out
 }
 
-fn action_prefix_common(common: &CommonArgs) -> String {
-    let mut out = String::from("agentpack");
-    if let Some(repo) = &common.repo {
-        out.push_str(&format!(" --repo {repo}"));
-    }
-    let profile = common.profile.as_deref().unwrap_or("default");
-    if profile != "default" {
-        out.push_str(&format!(" --profile {profile}"));
-    }
-    let target = common.target.as_deref().unwrap_or("all");
-    if target != "all" {
-        out.push_str(&format!(" --target {target}"));
-    }
-    if let Some(machine) = &common.machine {
-        out.push_str(&format!(" --machine {machine}"));
-    }
-    out
-}
-
-fn bootstrap_action(common: &CommonArgs, target: &str, scope: &str) -> String {
-    let mut out = String::from("agentpack");
-    if let Some(repo) = &common.repo {
-        out.push_str(&format!(" --repo {repo}"));
-    }
-    if let Some(machine) = &common.machine {
-        out.push_str(&format!(" --machine {machine}"));
-    }
-    out.push_str(&format!(" --target {target} bootstrap --scope {scope}"));
-    out
-}
-
 async fn call_doctor_in_process(args: DoctorArgs) -> anyhow::Result<(String, serde_json::Value)> {
     tokio::task::spawn_blocking(move || {
         let repo_override = args.repo.as_ref().map(std::path::PathBuf::from);
@@ -355,129 +319,7 @@ async fn call_doctor_in_process(args: DoctorArgs) -> anyhow::Result<(String, ser
 }
 
 async fn call_status_in_process(args: StatusArgs) -> anyhow::Result<(String, serde_json::Value)> {
-    tokio::task::spawn_blocking(move || {
-        #[derive(Default)]
-        struct NextActions {
-            json: std::collections::BTreeSet<String>,
-        }
-
-        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
-        let profile = args.common.profile.as_deref().unwrap_or("default");
-        let target = args.common.target.as_deref().unwrap_or("all");
-        let machine_override = args.common.machine.as_deref();
-
-        let result = (|| -> anyhow::Result<(String, serde_json::Value)> {
-            let engine = crate::engine::Engine::load(repo_override.as_deref(), machine_override)?;
-            let targets = crate::cli::util::selected_targets(&engine.manifest, target)?;
-            let render = engine.desired_state(profile, target)?;
-            let desired = render.desired;
-            let mut warnings = render.warnings;
-            let roots = render.roots;
-
-            let mut next_actions = NextActions::default();
-            if targets
-                .iter()
-                .any(|t| matches!(t.as_str(), "codex" | "claude_code"))
-            {
-                let codex_home = crate::cli::util::codex_home_for_manifest(&engine.manifest)?;
-                let claude_user_commands_dir =
-                    crate::cli::util::expand_tilde("~/.claude/commands")?;
-                let claude_user_skills_dir = crate::cli::util::expand_tilde("~/.claude/skills")?;
-                let mut record_next_action = |suggested: &str| {
-                    next_actions
-                        .json
-                        .insert(format!("{suggested} --yes --json"));
-                };
-                warn_operator_assets_if_outdated_for_status(
-                    &engine,
-                    &targets,
-                    OperatorAssetsStatusPaths {
-                        codex_home: &codex_home,
-                        claude_user_commands_dir: &claude_user_commands_dir,
-                        claude_user_skills_dir: &claude_user_skills_dir,
-                    },
-                    &mut warnings,
-                    &mut |target, scope| bootstrap_action(&args.common, target, scope),
-                    &mut record_next_action,
-                )?;
-            }
-            let prefix = action_prefix_common(&args.common);
-
-            let report = crate::handlers::status::status_drift_report(
-                &desired,
-                &roots,
-                warnings,
-                crate::handlers::status::ExtraScanHashMode::IncludeHashes,
-            )?;
-            let warnings = report.warnings;
-            let drift = report.drift;
-            let summary = report.summary;
-            let any_manifest = report.any_manifest;
-
-            for action in status_next_actions(
-                summary.modified,
-                summary.missing,
-                summary.extra,
-                any_manifest,
-                report.needs_deploy_apply,
-            ) {
-                next_actions.json.insert(action.json_command(&prefix));
-            }
-
-            let summary_total = summary;
-            let only_kinds: std::collections::BTreeSet<&'static str> = args
-                .only
-                .as_deref()
-                .unwrap_or_default()
-                .iter()
-                .map(|o| match o {
-                    StatusOnly::Missing => "missing",
-                    StatusOnly::Modified => "modified",
-                    StatusOnly::Extra => "extra",
-                })
-                .collect();
-
-            let (drift, summary, summary_total_opt) =
-                filter_drift_by_kind(drift, &only_kinds, summary_total);
-            let summary_by_root = drift_summary_by_root(&drift);
-
-            let data = status_json_data(
-                profile,
-                targets,
-                drift,
-                summary,
-                summary_by_root,
-                summary_total_opt,
-                &next_actions.json,
-            )?;
-
-            let mut envelope = crate::output::JsonEnvelope::ok("status", data);
-            envelope.warnings = warnings;
-
-            let text = serde_json::to_string_pretty(&envelope)?;
-            let envelope = serde_json::to_value(&envelope)?;
-            Ok((text, envelope))
-        })();
-
-        match result {
-            Ok(v) => Ok(v),
-            Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = envelope_error("status", &code, &message, details);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                Ok((text, envelope))
-            }
-        }
-    })
-    .await
-    .context("mcp status handler task join")?
+    status::call_status_in_process(args).await
 }
 
 async fn call_explain_in_process(args: ExplainArgs) -> anyhow::Result<(String, serde_json::Value)> {

--- a/src/mcp/tools/status.rs
+++ b/src/mcp/tools/status.rs
@@ -1,0 +1,170 @@
+use std::collections::BTreeSet;
+
+use anyhow::Context as _;
+
+use crate::app::operator_assets::{
+    OperatorAssetsStatusPaths, warn_operator_assets_if_outdated_for_status,
+};
+use crate::app::status_drift::{drift_summary_by_root, filter_drift_by_kind};
+use crate::app::status_json::status_json_data;
+use crate::app::status_next_actions::status_next_actions;
+use crate::user_error::UserError;
+
+fn action_prefix_common(common: &super::CommonArgs) -> String {
+    let mut out = String::from("agentpack");
+    if let Some(repo) = &common.repo {
+        out.push_str(&format!(" --repo {repo}"));
+    }
+    let profile = common.profile.as_deref().unwrap_or("default");
+    if profile != "default" {
+        out.push_str(&format!(" --profile {profile}"));
+    }
+    let target = common.target.as_deref().unwrap_or("all");
+    if target != "all" {
+        out.push_str(&format!(" --target {target}"));
+    }
+    if let Some(machine) = &common.machine {
+        out.push_str(&format!(" --machine {machine}"));
+    }
+    out
+}
+
+fn bootstrap_action(common: &super::CommonArgs, target: &str, scope: &str) -> String {
+    let mut out = String::from("agentpack");
+    if let Some(repo) = &common.repo {
+        out.push_str(&format!(" --repo {repo}"));
+    }
+    if let Some(machine) = &common.machine {
+        out.push_str(&format!(" --machine {machine}"));
+    }
+    out.push_str(&format!(" --target {target} bootstrap --scope {scope}"));
+    out
+}
+
+pub(super) async fn call_status_in_process(
+    args: super::StatusArgs,
+) -> anyhow::Result<(String, serde_json::Value)> {
+    tokio::task::spawn_blocking(move || {
+        #[derive(Default)]
+        struct NextActions {
+            json: BTreeSet<String>,
+        }
+
+        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
+        let profile = args.common.profile.as_deref().unwrap_or("default");
+        let target = args.common.target.as_deref().unwrap_or("all");
+        let machine_override = args.common.machine.as_deref();
+
+        let result = (|| -> anyhow::Result<(String, serde_json::Value)> {
+            let engine = crate::engine::Engine::load(repo_override.as_deref(), machine_override)?;
+            let targets = crate::cli::util::selected_targets(&engine.manifest, target)?;
+            let render = engine.desired_state(profile, target)?;
+            let desired = render.desired;
+            let mut warnings = render.warnings;
+            let roots = render.roots;
+
+            let mut next_actions = NextActions::default();
+            if targets
+                .iter()
+                .any(|t| matches!(t.as_str(), "codex" | "claude_code"))
+            {
+                let codex_home = crate::cli::util::codex_home_for_manifest(&engine.manifest)?;
+                let claude_user_commands_dir =
+                    crate::cli::util::expand_tilde("~/.claude/commands")?;
+                let claude_user_skills_dir = crate::cli::util::expand_tilde("~/.claude/skills")?;
+                let mut record_next_action = |suggested: &str| {
+                    next_actions
+                        .json
+                        .insert(format!("{suggested} --yes --json"));
+                };
+                warn_operator_assets_if_outdated_for_status(
+                    &engine,
+                    &targets,
+                    OperatorAssetsStatusPaths {
+                        codex_home: &codex_home,
+                        claude_user_commands_dir: &claude_user_commands_dir,
+                        claude_user_skills_dir: &claude_user_skills_dir,
+                    },
+                    &mut warnings,
+                    &mut |target, scope| bootstrap_action(&args.common, target, scope),
+                    &mut record_next_action,
+                )?;
+            }
+            let prefix = action_prefix_common(&args.common);
+
+            let report = crate::handlers::status::status_drift_report(
+                &desired,
+                &roots,
+                warnings,
+                crate::handlers::status::ExtraScanHashMode::IncludeHashes,
+            )?;
+            let warnings = report.warnings;
+            let drift = report.drift;
+            let summary = report.summary;
+            let any_manifest = report.any_manifest;
+
+            for action in status_next_actions(
+                summary.modified,
+                summary.missing,
+                summary.extra,
+                any_manifest,
+                report.needs_deploy_apply,
+            ) {
+                next_actions.json.insert(action.json_command(&prefix));
+            }
+
+            let summary_total = summary;
+            let only_kinds: BTreeSet<&'static str> = args
+                .only
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|o| match o {
+                    super::StatusOnly::Missing => "missing",
+                    super::StatusOnly::Modified => "modified",
+                    super::StatusOnly::Extra => "extra",
+                })
+                .collect();
+
+            let (drift, summary, summary_total_opt) =
+                filter_drift_by_kind(drift, &only_kinds, summary_total);
+            let summary_by_root = drift_summary_by_root(&drift);
+
+            let data = status_json_data(
+                profile,
+                targets,
+                drift,
+                summary,
+                summary_by_root,
+                summary_total_opt,
+                &next_actions.json,
+            )?;
+
+            let mut envelope = crate::output::JsonEnvelope::ok("status", data);
+            envelope.warnings = warnings;
+
+            let text = serde_json::to_string_pretty(&envelope)?;
+            let envelope = serde_json::to_value(&envelope)?;
+            Ok((text, envelope))
+        })();
+
+        match result {
+            Ok(v) => Ok(v),
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("status", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                Ok((text, envelope))
+            }
+        }
+    })
+    .await
+    .context("mcp status handler task join")?
+}


### PR DESCRIPTION
Fixes #686

## Summary
- Extract MCP `status` tool handler into `src/mcp/tools/status.rs`.
- Keep MCP surface + Agentpack JSON envelope semantics unchanged.

## Verification
- `openspec validate refactor-mcp-status-tool-module --strict --no-interactive`
- `just check`
