### PR TITLE
refactor(mcp): extract preview tool module

### DIFF
--- a/openspec/changes/refactor-mcp-preview-tool-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-preview-tool-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-mcp-preview-tool-module/README.md
+++ b/openspec/changes/refactor-mcp-preview-tool-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-preview-tool-module
+
+Refactor: extract MCP preview tool implementation into a dedicated module

--- a/openspec/changes/refactor-mcp-preview-tool-module/proposal.md
+++ b/openspec/changes/refactor-mcp-preview-tool-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP preview tool implementation into its own module
+
+## Why
+`src/mcp/tools.rs` contains implementations for many tools and is large. Extracting the `preview` tool handler into a dedicated module improves readability and makes future changes safer and easier to review.
+
+## What Changes
+- Move the `preview` tool implementation (`call_preview_in_process`) from `src/mcp/tools.rs` into `src/mcp/tools/preview.rs`.
+- Keep the public MCP surface and JSON output unchanged.
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/preview.rs`

--- a/openspec/changes/refactor-mcp-preview-tool-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-preview-tool-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,11 @@
+# agentpack-mcp (delta)
+
+## ADDED Requirements
+
+### Requirement: MCP preview tool handler is modular
+The system SHALL implement the MCP `preview` tool handler in a dedicated Rust module, while preserving the existing external MCP behavior and Agentpack JSON envelope semantics.
+
+#### Scenario: Preview tool handler extracted into a module
+- **WHEN** the MCP server is built
+- **THEN** the `preview` tool handler implementation lives in `src/mcp/tools/preview.rs`
+- **AND** the `tools/list` and `tools/call` behavior remains unchanged

--- a/openspec/changes/refactor-mcp-preview-tool-module/tasks.md
+++ b/openspec/changes/refactor-mcp-preview-tool-module/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for extracting MCP preview tool implementation
+- [x] Run `openspec validate refactor-mcp-preview-tool-module --strict --no-interactive`
+
+## 2. Implementation
+- [x] Extract `call_preview_in_process` into `src/mcp/tools/preview.rs`
+- [x] Keep `src/mcp/tools.rs` behavior unchanged (including errors/envelope/commands)
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/preview.rs
+++ b/src/mcp/tools/preview.rs
@@ -1,0 +1,65 @@
+use anyhow::Context as _;
+
+use crate::user_error::UserError;
+
+pub(super) async fn call_preview_in_process(
+    args: super::PreviewArgs,
+) -> anyhow::Result<(String, serde_json::Value)> {
+    tokio::task::spawn_blocking(move || {
+        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
+        let profile = args.common.profile.as_deref().unwrap_or("default");
+        let target = args.common.target.as_deref().unwrap_or("all");
+        let machine_override = args.common.machine.as_deref();
+
+        let result = crate::handlers::read_only::read_only_context(
+            repo_override.as_deref(),
+            machine_override,
+            profile,
+            target,
+        );
+
+        let (text, envelope) = match result {
+            Ok(crate::handlers::read_only::ReadOnlyContext {
+                targets,
+                desired,
+                plan,
+                mut warnings,
+                roots,
+            }) => {
+                let data = crate::app::preview_json::preview_json_data(
+                    profile,
+                    targets,
+                    plan,
+                    desired,
+                    roots,
+                    args.diff,
+                    &mut warnings,
+                )?;
+
+                let mut envelope = crate::output::JsonEnvelope::ok("preview", data);
+                envelope.warnings = warnings;
+
+                let text = serde_json::to_string_pretty(&envelope)?;
+                let envelope = serde_json::to_value(&envelope)?;
+                (text, envelope)
+            }
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("preview", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                (text, envelope)
+            }
+        };
+
+        Ok((text, envelope))
+    })
+    .await
+    .context("mcp preview handler task join")?
+}


### PR DESCRIPTION
Fixes #689

## Summary
- Extract MCP `preview` tool handler into `src/mcp/tools/preview.rs`.
- Keep MCP surface + Agentpack JSON envelope semantics unchanged.

## Verification
- `openspec validate refactor-mcp-preview-tool-module --strict --no-interactive`
- `just check`
