### PR TITLE
refactor(mcp): extract deploy_apply tool module

### DIFF
--- a/openspec/changes/refactor-mcp-deploy-apply-tool-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-deploy-apply-tool-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-mcp-deploy-apply-tool-module/README.md
+++ b/openspec/changes/refactor-mcp-deploy-apply-tool-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-deploy-apply-tool-module
+
+Refactor: extract MCP deploy_apply tool implementation into a dedicated module

--- a/openspec/changes/refactor-mcp-deploy-apply-tool-module/proposal.md
+++ b/openspec/changes/refactor-mcp-deploy-apply-tool-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP deploy_apply tool implementation into its own module
+
+## Why
+`src/mcp/tools.rs` contains implementations for many tools and is large. Extracting the `deploy_apply` tool handler into a dedicated module improves readability and makes future changes safer and easier to review.
+
+## What Changes
+- Move the `deploy_apply` tool implementation from `src/mcp/tools.rs` into `src/mcp/tools/deploy_apply.rs`.
+- Keep the public MCP surface and JSON output unchanged.
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/deploy_apply.rs`

--- a/openspec/changes/refactor-mcp-deploy-apply-tool-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-deploy-apply-tool-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,11 @@
+# agentpack-mcp (delta)
+
+## ADDED Requirements
+
+### Requirement: MCP deploy_apply tool handler is modular
+The system SHALL implement the MCP `deploy_apply` tool handler in a dedicated Rust module, while preserving the existing external MCP behavior and Agentpack JSON envelope semantics.
+
+#### Scenario: Deploy apply tool handler extracted into a module
+- **WHEN** the MCP server is built
+- **THEN** the `deploy_apply` tool handler implementation lives in `src/mcp/tools/deploy_apply.rs`
+- **AND** the `tools/list` and `tools/call` behavior remains unchanged

--- a/openspec/changes/refactor-mcp-deploy-apply-tool-module/tasks.md
+++ b/openspec/changes/refactor-mcp-deploy-apply-tool-module/tasks.md
@@ -1,0 +1,11 @@
+## 1. Spec & planning
+- [x] Add OpenSpec delta requirements for extracting MCP deploy_apply tool implementation
+- [x] Run `openspec validate refactor-mcp-deploy-apply-tool-module --strict --no-interactive`
+
+## 2. Implementation
+- [x] Extract the `deploy_apply` MCP tool handler into `src/mcp/tools/deploy_apply.rs`
+- [x] Keep `src/mcp/tools.rs` behavior unchanged (including confirm token enforcement and errors/envelope)
+
+## 3. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Instant;
 
 use anyhow::Context as _;
 use rmcp::{
@@ -13,6 +12,7 @@ use super::confirm::{CONFIRM_TOKEN_TTL, ConfirmTokenBinding};
 use super::{AgentpackMcp, confirm};
 
 mod deploy;
+mod deploy_apply;
 mod doctor;
 mod evolve_propose;
 mod evolve_restore;
@@ -322,105 +322,6 @@ async fn deploy_plan_envelope_in_process(args: CommonArgs) -> anyhow::Result<ser
     .context("mcp deploy handler task join")?
 }
 
-async fn call_deploy_apply_in_process(
-    args: DeployApplyArgs,
-) -> anyhow::Result<(String, serde_json::Value)> {
-    tokio::task::spawn_blocking(move || {
-        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
-        let profile = args.common.profile.as_deref().unwrap_or("default");
-        let target = args.common.target.as_deref().unwrap_or("all");
-        let machine_override = args.common.machine.as_deref();
-
-        let result = (|| -> anyhow::Result<(String, serde_json::Value)> {
-            let engine = crate::engine::Engine::load(repo_override.as_deref(), machine_override)?;
-            let crate::handlers::read_only::ReadOnlyContext {
-                targets,
-                desired,
-                plan,
-                warnings,
-                roots,
-            } = crate::handlers::read_only::read_only_context_in(&engine, profile, target)?;
-
-            let will_apply = !args.common.dry_run.unwrap_or(false);
-            if !will_apply {
-                let data =
-                    crate::app::deploy_json::deploy_json_data_dry_run(profile, targets, plan);
-                let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
-                envelope.warnings = warnings;
-
-                let text = serde_json::to_string_pretty(&envelope)?;
-                let envelope = serde_json::to_value(&envelope)?;
-                return Ok((text, envelope));
-            }
-
-            let adopt = args.adopt.unwrap_or(false);
-            let outcome = crate::handlers::deploy::deploy_apply_in(
-                &engine,
-                &plan,
-                &desired,
-                &roots,
-                adopt,
-                args.yes,
-                crate::handlers::deploy::ConfirmationStyle::JsonYes {
-                    command_id: "deploy --apply",
-                },
-            )?;
-
-            match outcome {
-                crate::handlers::deploy::DeployApplyOutcome::NoChanges => {
-                    let data = crate::app::deploy_json::deploy_json_data_no_changes(
-                        profile, targets, plan,
-                    );
-                    let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
-                    envelope.warnings = warnings;
-
-                    let text = serde_json::to_string_pretty(&envelope)?;
-                    let envelope = serde_json::to_value(&envelope)?;
-                    Ok((text, envelope))
-                }
-                crate::handlers::deploy::DeployApplyOutcome::Applied { snapshot_id } => {
-                    let data = crate::app::deploy_json::deploy_json_data_applied(
-                        profile,
-                        targets,
-                        plan,
-                        snapshot_id,
-                    );
-                    let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
-                    envelope.warnings = warnings;
-
-                    let text = serde_json::to_string_pretty(&envelope)?;
-                    let envelope = serde_json::to_value(&envelope)?;
-                    Ok((text, envelope))
-                }
-                crate::handlers::deploy::DeployApplyOutcome::NeedsConfirmation => {
-                    anyhow::bail!(
-                        "deploy apply requires confirmation, but confirmation was not provided"
-                    )
-                }
-            }
-        })();
-
-        match result {
-            Ok(v) => Ok(v),
-            Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = envelope_error("deploy", &code, &message, details);
-                let text = serde_json::to_string_pretty(&envelope)?;
-                Ok((text, envelope))
-            }
-        }
-    })
-    .await
-    .context("mcp deploy_apply handler task join")?
-}
-
 fn tool_result_from_envelope(text: String, envelope: serde_json::Value) -> CallToolResult {
     let ok = envelope
         .get("ok")
@@ -618,108 +519,7 @@ pub(super) async fn call_tool(
         }
         "deploy_apply" => {
             let args = deserialize_args::<DeployApplyArgs>(request.arguments)?;
-            if !args.yes || args.common.dry_run.unwrap_or(false) {
-                match call_deploy_apply_in_process(args).await {
-                    Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                    Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                        "deploy",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    ))),
-                }
-            } else {
-                let Some(token) = args
-                    .confirm_token
-                    .as_deref()
-                    .filter(|t| !t.is_empty())
-                    .map(ToOwned::to_owned)
-                else {
-                    return Ok(tool_result_from_user_error(
-                        "deploy",
-                        UserError::confirm_token_required(),
-                    ));
-                };
-
-                let binding = ConfirmTokenBinding::from(&args.common);
-                let now = Instant::now();
-                let stored_plan_hash = {
-                    let mut store = server
-                        .confirm_tokens
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner());
-                    match confirm::validate_token(&mut store, token.as_str(), &binding, now) {
-                        Ok(v) => v,
-                        Err(err) => return Ok(tool_result_from_user_error("deploy", err)),
-                    }
-                };
-
-                let plan_env = match deploy_plan_envelope_in_process(CommonArgs {
-                    repo: args.common.repo.clone(),
-                    profile: args.common.profile.clone(),
-                    target: args.common.target.clone(),
-                    machine: args.common.machine.clone(),
-                    dry_run: args.common.dry_run,
-                })
-                .await
-                {
-                    Ok(v) => v,
-                    Err(err) => {
-                        return Ok(CallToolResult::structured_error(envelope_error(
-                            "deploy",
-                            "E_UNEXPECTED",
-                            &err.to_string(),
-                            None,
-                        )));
-                    }
-                };
-                let current_plan_hash =
-                    match confirm::compute_confirm_plan_hash(&binding, &plan_env) {
-                        Ok(v) => v,
-                        Err(err) => {
-                            return Ok(CallToolResult::structured_error(envelope_error(
-                                "deploy",
-                                "E_UNEXPECTED",
-                                &err.to_string(),
-                                None,
-                            )));
-                        }
-                    };
-
-                if current_plan_hash != stored_plan_hash {
-                    return Ok(tool_result_from_user_error(
-                        "deploy",
-                        UserError::confirm_token_mismatch().with_details(serde_json::json!({
-                            "hint": "Re-run the deploy tool and ensure the apply uses the matching confirm_token.",
-                            "confirm_plan_hash": current_plan_hash,
-                            "expected_confirm_plan_hash": stored_plan_hash,
-                        })),
-                    ));
-                }
-
-                match call_deploy_apply_in_process(args).await {
-                    Ok((text, envelope)) => {
-                        if envelope
-                            .get("ok")
-                            .and_then(serde_json::Value::as_bool)
-                            .unwrap_or(false)
-                        {
-                            let mut store = server
-                                .confirm_tokens
-                                .lock()
-                                .unwrap_or_else(|e| e.into_inner());
-                            confirm::consume_token(&mut store, &token);
-                        }
-                        Ok(tool_result_from_envelope(text, envelope))
-                    }
-                    Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                        "deploy",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    ))),
-                }
-            }
+            Ok(deploy_apply::call_deploy_apply_tool(server, args).await)
         }
         "rollback" => {
             let args = deserialize_args::<RollbackArgs>(request.arguments)?;

--- a/src/mcp/tools/deploy_apply.rs
+++ b/src/mcp/tools/deploy_apply.rs
@@ -1,0 +1,213 @@
+use std::time::Instant;
+
+use anyhow::Context as _;
+use rmcp::model::CallToolResult;
+
+use crate::user_error::UserError;
+
+pub(super) async fn call_deploy_apply_tool(
+    server: &super::AgentpackMcp,
+    args: super::DeployApplyArgs,
+) -> CallToolResult {
+    if !args.yes || args.common.dry_run.unwrap_or(false) {
+        match call_deploy_apply_in_process(args).await {
+            Ok((text, envelope)) => super::tool_result_from_envelope(text, envelope),
+            Err(err) => CallToolResult::structured_error(super::envelope_error(
+                "deploy",
+                "E_UNEXPECTED",
+                &err.to_string(),
+                None,
+            )),
+        }
+    } else {
+        let Some(token) = args
+            .confirm_token
+            .as_deref()
+            .filter(|t| !t.is_empty())
+            .map(ToOwned::to_owned)
+        else {
+            return super::tool_result_from_user_error(
+                "deploy",
+                UserError::confirm_token_required(),
+            );
+        };
+
+        let binding = super::ConfirmTokenBinding::from(&args.common);
+        let now = Instant::now();
+        let stored_plan_hash = {
+            let mut store = server
+                .confirm_tokens
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            match super::confirm::validate_token(&mut store, token.as_str(), &binding, now) {
+                Ok(v) => v,
+                Err(err) => return super::tool_result_from_user_error("deploy", err),
+            }
+        };
+
+        let plan_env = match super::deploy_plan_envelope_in_process(super::CommonArgs {
+            repo: args.common.repo.clone(),
+            profile: args.common.profile.clone(),
+            target: args.common.target.clone(),
+            machine: args.common.machine.clone(),
+            dry_run: args.common.dry_run,
+        })
+        .await
+        {
+            Ok(v) => v,
+            Err(err) => {
+                return CallToolResult::structured_error(super::envelope_error(
+                    "deploy",
+                    "E_UNEXPECTED",
+                    &err.to_string(),
+                    None,
+                ));
+            }
+        };
+        let current_plan_hash = match super::confirm::compute_confirm_plan_hash(&binding, &plan_env)
+        {
+            Ok(v) => v,
+            Err(err) => {
+                return CallToolResult::structured_error(super::envelope_error(
+                    "deploy",
+                    "E_UNEXPECTED",
+                    &err.to_string(),
+                    None,
+                ));
+            }
+        };
+
+        if current_plan_hash != stored_plan_hash {
+            return super::tool_result_from_user_error(
+                "deploy",
+                UserError::confirm_token_mismatch().with_details(serde_json::json!({
+                    "hint": "Re-run the deploy tool and ensure the apply uses the matching confirm_token.",
+                    "confirm_plan_hash": current_plan_hash,
+                    "expected_confirm_plan_hash": stored_plan_hash,
+                })),
+            );
+        }
+
+        match call_deploy_apply_in_process(args).await {
+            Ok((text, envelope)) => {
+                if envelope
+                    .get("ok")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    let mut store = server
+                        .confirm_tokens
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    super::confirm::consume_token(&mut store, &token);
+                }
+                super::tool_result_from_envelope(text, envelope)
+            }
+            Err(err) => CallToolResult::structured_error(super::envelope_error(
+                "deploy",
+                "E_UNEXPECTED",
+                &err.to_string(),
+                None,
+            )),
+        }
+    }
+}
+
+async fn call_deploy_apply_in_process(
+    args: super::DeployApplyArgs,
+) -> anyhow::Result<(String, serde_json::Value)> {
+    tokio::task::spawn_blocking(move || {
+        let repo_override = args.common.repo.as_ref().map(std::path::PathBuf::from);
+        let profile = args.common.profile.as_deref().unwrap_or("default");
+        let target = args.common.target.as_deref().unwrap_or("all");
+        let machine_override = args.common.machine.as_deref();
+
+        let result = (|| -> anyhow::Result<(String, serde_json::Value)> {
+            let engine = crate::engine::Engine::load(repo_override.as_deref(), machine_override)?;
+            let crate::handlers::read_only::ReadOnlyContext {
+                targets,
+                desired,
+                plan,
+                warnings,
+                roots,
+            } = crate::handlers::read_only::read_only_context_in(&engine, profile, target)?;
+
+            let will_apply = !args.common.dry_run.unwrap_or(false);
+            if !will_apply {
+                let data =
+                    crate::app::deploy_json::deploy_json_data_dry_run(profile, targets, plan);
+                let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
+                envelope.warnings = warnings;
+
+                let text = serde_json::to_string_pretty(&envelope)?;
+                let envelope = serde_json::to_value(&envelope)?;
+                return Ok((text, envelope));
+            }
+
+            let adopt = args.adopt.unwrap_or(false);
+            let outcome = crate::handlers::deploy::deploy_apply_in(
+                &engine,
+                &plan,
+                &desired,
+                &roots,
+                adopt,
+                args.yes,
+                crate::handlers::deploy::ConfirmationStyle::JsonYes {
+                    command_id: "deploy --apply",
+                },
+            )?;
+
+            match outcome {
+                crate::handlers::deploy::DeployApplyOutcome::NoChanges => {
+                    let data = crate::app::deploy_json::deploy_json_data_no_changes(
+                        profile, targets, plan,
+                    );
+                    let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
+                    envelope.warnings = warnings;
+
+                    let text = serde_json::to_string_pretty(&envelope)?;
+                    let envelope = serde_json::to_value(&envelope)?;
+                    Ok((text, envelope))
+                }
+                crate::handlers::deploy::DeployApplyOutcome::Applied { snapshot_id } => {
+                    let data = crate::app::deploy_json::deploy_json_data_applied(
+                        profile,
+                        targets,
+                        plan,
+                        snapshot_id,
+                    );
+                    let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
+                    envelope.warnings = warnings;
+
+                    let text = serde_json::to_string_pretty(&envelope)?;
+                    let envelope = serde_json::to_value(&envelope)?;
+                    Ok((text, envelope))
+                }
+                crate::handlers::deploy::DeployApplyOutcome::NeedsConfirmation => {
+                    anyhow::bail!(
+                        "deploy apply requires confirmation, but confirmation was not provided"
+                    )
+                }
+            }
+        })();
+
+        match result {
+            Ok(v) => Ok(v),
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error("deploy", &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                Ok((text, envelope))
+            }
+        }
+    })
+    .await
+    .context("mcp deploy_apply handler task join")?
+}


### PR DESCRIPTION
Closes #698

OpenSpec
- `openspec/changes/refactor-mcp-deploy-apply-tool-module/`

What
- Extracts the MCP `deploy_apply` tool handler from `src/mcp/tools.rs` into `src/mcp/tools/deploy_apply.rs`.
- Keeps the external MCP behavior + Agentpack JSON envelope semantics unchanged.

Tests
- `openspec validate refactor-mcp-deploy-apply-tool-module --strict --no-interactive`
- `cargo fmt --all`
- `just check`
