### PR TITLE
refactor(mcp): extract deploy plan helper module

### DIFF
--- a/openspec/changes/refactor-mcp-deploy-plan-helper-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-deploy-plan-helper-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-22

--- a/openspec/changes/refactor-mcp-deploy-plan-helper-module/README.md
+++ b/openspec/changes/refactor-mcp-deploy-plan-helper-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-deploy-plan-helper-module
+
+Refactor: extract MCP deploy-plan helper into a dedicated module

--- a/openspec/changes/refactor-mcp-deploy-plan-helper-module/proposal.md
+++ b/openspec/changes/refactor-mcp-deploy-plan-helper-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP deploy-plan helper into a dedicated module
+
+## Why
+`src/mcp/tools.rs` still contains shared logic used by multiple tools. Moving the deploy planning helper into its own module keeps `tools.rs` focused on routing, schemas, and shared envelopes, making the code easier to navigate and safer to refactor further.
+
+## What Changes
+- Move the shared MCP helper `deploy_plan_envelope_in_process` out of `src/mcp/tools.rs` into a dedicated module file.
+- Keep behavior and JSON envelopes identical (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/deploy_plan.rs` (new)

--- a/openspec/changes/refactor-mcp-deploy-plan-helper-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-deploy-plan-helper-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: MCP deploy planning helper is modularized
+The system SHALL keep the MCP deploy planning helper (`deploy_plan_envelope_in_process`) implemented in a dedicated module file so `src/mcp/tools.rs` stays focused on routing and schemas while preserving MCP tool behavior and JSON envelopes.
+
+#### Scenario: deploy and deploy_apply reuse the same deploy planning implementation
+- **GIVEN** MCP tools `deploy` and `deploy_apply` that both require the same plan computation
+- **WHEN** the implementation is refactored for maintainability
+- **THEN** both tools still reuse the same deploy planning implementation
+- **AND** the returned Agentpack JSON envelope for `command="deploy"` remains unchanged

--- a/openspec/changes/refactor-mcp-deploy-plan-helper-module/tasks.md
+++ b/openspec/changes/refactor-mcp-deploy-plan-helper-module/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [x] Extract `deploy_plan_envelope_in_process` into `src/mcp/tools/deploy_plan.rs`
+- [x] Keep MCP tool behavior and JSON envelopes unchanged
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/deploy_plan.rs
+++ b/src/mcp/tools/deploy_plan.rs
@@ -1,0 +1,49 @@
+use anyhow::Context as _;
+
+use crate::user_error::UserError;
+
+pub(super) async fn deploy_plan_envelope_in_process(
+    args: super::CommonArgs,
+) -> anyhow::Result<serde_json::Value> {
+    tokio::task::spawn_blocking(move || {
+        let repo_override = args.repo.as_ref().map(std::path::PathBuf::from);
+        let profile = args.profile.as_deref().unwrap_or("default");
+        let target = args.target.as_deref().unwrap_or("all");
+        let machine_override = args.machine.as_deref();
+
+        let result = crate::handlers::read_only::read_only_context(
+            repo_override.as_deref(),
+            machine_override,
+            profile,
+            target,
+        );
+
+        match result {
+            Ok(crate::handlers::read_only::ReadOnlyContext {
+                targets,
+                plan,
+                warnings,
+                ..
+            }) => {
+                let data =
+                    crate::app::deploy_json::deploy_json_data_dry_run(profile, targets, plan);
+                let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
+                envelope.warnings = warnings;
+                serde_json::to_value(&envelope).context("serialize deploy envelope")
+            }
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                Ok(super::envelope_error("deploy", &code, &message, details))
+            }
+        }
+    })
+    .await
+    .context("mcp deploy handler task join")?
+}


### PR DESCRIPTION
Closes #701.

Summary:
- Extracted the shared MCP deploy planning helper (`deploy_plan_envelope_in_process`) into `src/mcp/tools/deploy_plan.rs`.
- Kept MCP tool routing, confirm-token behavior, and JSON envelopes unchanged.

OpenSpec:
- Change: `refactor-mcp-deploy-plan-helper-module`
- `openspec validate refactor-mcp-deploy-plan-helper-module --strict --no-interactive`

Tests:
- `just check`
