### PR TITLE
refactor(mcp): extract envelope helpers module

### DIFF
--- a/openspec/changes/refactor-mcp-envelope-helper-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-envelope-helper-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-envelope-helper-module/README.md
+++ b/openspec/changes/refactor-mcp-envelope-helper-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-envelope-helper-module
+
+Refactor: extract MCP envelope/tool-result helpers into a dedicated module

--- a/openspec/changes/refactor-mcp-envelope-helper-module/proposal.md
+++ b/openspec/changes/refactor-mcp-envelope-helper-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP envelope helpers into a dedicated module
+
+## Why
+`src/mcp/tools.rs` still contains shared MCP envelope and tool-result helpers used across multiple tool implementations. Moving these helpers into a dedicated module keeps `tools.rs` focused on routing and schemas and makes future refactors easier to review.
+
+## What Changes
+- Move MCP envelope/tool-result helpers (`envelope_error`, `tool_result_from_envelope`, `tool_result_from_user_error`) out of `src/mcp/tools.rs` into `src/mcp/tools/envelope.rs`.
+- Keep MCP tool behavior and JSON envelopes identical (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/envelope.rs` (new)

--- a/openspec/changes/refactor-mcp-envelope-helper-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-envelope-helper-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP envelope helpers are modularized
+The system SHALL keep MCP envelope and tool-result helper functions implemented in a dedicated module file so `src/mcp/tools.rs` stays focused on routing and schemas while preserving MCP tool behavior and JSON envelopes.
+
+#### Scenario: MCP tool envelopes remain unchanged after helper refactor
+- **GIVEN** MCP tool implementations that reuse shared envelope helper functions
+- **WHEN** the helpers are refactored into a dedicated module for maintainability
+- **THEN** tool results still reuse the Agentpack JSON envelope unchanged

--- a/openspec/changes/refactor-mcp-envelope-helper-module/tasks.md
+++ b/openspec/changes/refactor-mcp-envelope-helper-module/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [x] Extract MCP envelope/tool-result helpers into `src/mcp/tools/envelope.rs`
+- [x] Keep MCP tool behavior and JSON envelopes unchanged
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/envelope.rs
+++ b/src/mcp/tools/envelope.rs
@@ -1,0 +1,74 @@
+use rmcp::model::{CallToolResult, Content};
+
+use crate::user_error::UserError;
+
+pub(super) fn envelope_error(
+    command: &str,
+    code: &str,
+    message: &str,
+    details: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut err = serde_json::Map::from_iter([
+        (
+            "code".to_string(),
+            serde_json::Value::String(code.to_string()),
+        ),
+        (
+            "message".to_string(),
+            serde_json::Value::String(message.to_string()),
+        ),
+    ]);
+    if let Some(details) = details {
+        err.insert("details".to_string(), details);
+    }
+
+    serde_json::Value::Object(serde_json::Map::from_iter([
+        (
+            "schema_version".to_string(),
+            serde_json::Value::Number(1.into()),
+        ),
+        ("ok".to_string(), serde_json::Value::Bool(false)),
+        (
+            "command".to_string(),
+            serde_json::Value::String(command.to_string()),
+        ),
+        (
+            "version".to_string(),
+            serde_json::Value::String(env!("CARGO_PKG_VERSION").to_string()),
+        ),
+        (
+            "data".to_string(),
+            serde_json::Value::Object(serde_json::Map::new()),
+        ),
+        ("warnings".to_string(), serde_json::Value::Array(Vec::new())),
+        (
+            "errors".to_string(),
+            serde_json::Value::Array(vec![serde_json::Value::Object(err)]),
+        ),
+    ]))
+}
+
+pub(super) fn tool_result_from_envelope(
+    text: String,
+    envelope: serde_json::Value,
+) -> CallToolResult {
+    let ok = envelope
+        .get("ok")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    CallToolResult {
+        content: vec![Content::text(text)],
+        structured_content: Some(envelope),
+        is_error: Some(!ok),
+        meta: None,
+    }
+}
+
+pub(super) fn tool_result_from_user_error(command: &str, err: UserError) -> CallToolResult {
+    CallToolResult::structured_error(envelope_error(
+        command,
+        &err.code,
+        &err.message,
+        err.details,
+    ))
+}


### PR DESCRIPTION
Closes #704.

Summary:
- Extracted MCP envelope/tool-result helpers into `src/mcp/tools/envelope.rs`.
- Kept MCP tool routing and JSON envelopes unchanged (pure refactor).

OpenSpec:
- Change: `refactor-mcp-envelope-helper-module`
- `openspec validate refactor-mcp-envelope-helper-module --strict --no-interactive`

Tests:
- `just check`
