### PR TITLE
refactor(mcp): extract tool schema helpers module

### DIFF
--- a/openspec/changes/refactor-mcp-tool-schema-helper-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tool-schema-helper-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-tool-schema-helper-module/README.md
+++ b/openspec/changes/refactor-mcp-tool-schema-helper-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tool-schema-helper-module
+
+Refactor: extract MCP tool schema/deserialization helpers into a dedicated module

--- a/openspec/changes/refactor-mcp-tool-schema-helper-module/proposal.md
+++ b/openspec/changes/refactor-mcp-tool-schema-helper-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP tool schema helpers into a dedicated module
+
+## Why
+`src/mcp/tools.rs` still contains generic MCP tooling helpers (tool schema construction and argument deserialization). Moving these helpers into a dedicated module keeps `tools.rs` focused on routing, improving readability and making future refactors safer.
+
+## What Changes
+- Move MCP tool schema/args helpers (`tool_input_schema`, `tool`, `deserialize_args`) out of `src/mcp/tools.rs` into `src/mcp/tools/tool_schema.rs`.
+- Keep MCP tool behavior and JSON envelopes identical (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/tool_schema.rs` (new)

--- a/openspec/changes/refactor-mcp-tool-schema-helper-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tool-schema-helper-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP tool schema helpers are modularized
+The system SHALL keep MCP tool schema construction and argument deserialization helper functions implemented in a dedicated module file so `src/mcp/tools.rs` stays focused on routing and schemas while preserving MCP tool behavior and JSON envelopes.
+
+#### Scenario: MCP tool schemas remain unchanged after helper refactor
+- **GIVEN** the MCP server exposes tools with stable input schemas
+- **WHEN** schema/argument helper code is refactored for maintainability
+- **THEN** the advertised tool `inputSchema` values remain unchanged

--- a/openspec/changes/refactor-mcp-tool-schema-helper-module/tasks.md
+++ b/openspec/changes/refactor-mcp-tool-schema-helper-module/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [x] Extract MCP tool schema/args helpers into `src/mcp/tools/tool_schema.rs`
+- [x] Keep MCP tool behavior and JSON envelopes unchanged
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/tool_schema.rs
+++ b/src/mcp/tools/tool_schema.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use rmcp::ErrorData as McpError;
+use rmcp::model::{JsonObject, Tool, ToolAnnotations};
+
+pub(super) fn tool_input_schema<T: schemars::JsonSchema + 'static>() -> Arc<JsonObject> {
+    rmcp::handler::server::tool::schema_for_type::<T>()
+}
+
+pub(super) fn tool(
+    name: &'static str,
+    description: &'static str,
+    input_schema: Arc<JsonObject>,
+    read_only: bool,
+) -> Tool {
+    Tool::new(name, description, input_schema).annotate(
+        ToolAnnotations::new()
+            .read_only(read_only)
+            .destructive(!read_only),
+    )
+}
+
+pub(super) fn deserialize_args<T: serde::de::DeserializeOwned>(
+    args: Option<JsonObject>,
+) -> Result<T, McpError> {
+    let value = serde_json::Value::Object(args.unwrap_or_default());
+    serde_json::from_value(value).map_err(|e| McpError::invalid_params(e.to_string(), None))
+}


### PR DESCRIPTION
Closes #707.

Summary:
- Extracted MCP tool schema construction + argument deserialization helpers into `src/mcp/tools/tool_schema.rs`.
- Kept MCP tool routing and JSON envelopes unchanged (pure refactor).

OpenSpec:
- Change: `refactor-mcp-tool-schema-helper-module`
- `openspec validate refactor-mcp-tool-schema-helper-module --strict --no-interactive`

Tests:
- `just check`
