### PR TITLE
refactor(mcp): extract read-only helper module

### DIFF
--- a/openspec/changes/refactor-mcp-read-only-helper-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-read-only-helper-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-read-only-helper-module/README.md
+++ b/openspec/changes/refactor-mcp-read-only-helper-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-read-only-helper-module
+
+Extract MCP read-only helper into a dedicated module

--- a/openspec/changes/refactor-mcp-read-only-helper-module/proposal.md
+++ b/openspec/changes/refactor-mcp-read-only-helper-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP read-only helper into a dedicated module
+
+## Why
+`src/mcp/tools.rs` still contains the generic “read-only in-process” helper used by multiple MCP tools. Moving it into a dedicated module keeps `tools.rs` focused on routing and makes future refactors easier to review.
+
+## What Changes
+- Move the MCP read-only helper (`call_read_only_in_process`) out of `src/mcp/tools.rs` into `src/mcp/tools/read_only.rs`.
+- Keep MCP tool behavior and JSON envelopes identical (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/read_only.rs` (new)

--- a/openspec/changes/refactor-mcp-read-only-helper-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-read-only-helper-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP read-only helper is modularized
+The system SHALL keep the MCP read-only in-process helper implemented in a dedicated module file so `src/mcp/tools.rs` stays focused on routing while preserving MCP tool behavior and JSON envelopes.
+
+#### Scenario: MCP plan/diff envelopes remain unchanged after helper refactor
+- **GIVEN** the MCP server exposes read-only tools that return Agentpack JSON envelopes
+- **WHEN** the read-only helper code is refactored into a dedicated module
+- **THEN** the tools return the same JSON envelope structure and `ok`/error semantics as before

--- a/openspec/changes/refactor-mcp-read-only-helper-module/tasks.md
+++ b/openspec/changes/refactor-mcp-read-only-helper-module/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [x] Extract MCP read-only helper into `src/mcp/tools/read_only.rs`
+- [x] Keep MCP tool behavior and JSON envelopes unchanged
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/read_only.rs
+++ b/src/mcp/tools/read_only.rs
@@ -1,0 +1,55 @@
+use anyhow::Context as _;
+
+use crate::user_error::UserError;
+
+pub(super) async fn call_read_only_in_process(
+    command: &'static str,
+    args: super::CommonArgs,
+) -> anyhow::Result<(String, serde_json::Value)> {
+    tokio::task::spawn_blocking(move || {
+        let repo_override = args.repo.as_ref().map(std::path::PathBuf::from);
+        let profile = args.profile.as_deref().unwrap_or("default");
+        let target = args.target.as_deref().unwrap_or("all");
+        let machine_override = args.machine.as_deref();
+
+        let result = crate::handlers::read_only::read_only_context(
+            repo_override.as_deref(),
+            machine_override,
+            profile,
+            target,
+        );
+
+        let (text, envelope) = match result {
+            Ok(crate::handlers::read_only::ReadOnlyContext {
+                targets,
+                plan,
+                warnings,
+                ..
+            }) => {
+                let data = crate::app::plan_json::plan_json_data(profile, targets, plan);
+                let mut envelope = crate::output::JsonEnvelope::ok(command, data);
+                envelope.warnings = warnings;
+                let text = serde_json::to_string_pretty(&envelope)?;
+                let envelope = serde_json::to_value(&envelope)?;
+                (text, envelope)
+            }
+            Err(err) => {
+                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+                let code = user_err
+                    .map(|e| e.code.clone())
+                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
+                let message = user_err
+                    .map(|e| e.message.clone())
+                    .unwrap_or_else(|| err.to_string());
+                let details = user_err.and_then(|e| e.details.clone());
+                let envelope = super::envelope_error(command, &code, &message, details);
+                let text = serde_json::to_string_pretty(&envelope)?;
+                (text, envelope)
+            }
+        };
+
+        Ok((text, envelope))
+    })
+    .await
+    .context("mcp read-only handler task join")?
+}


### PR DESCRIPTION
Closes #710.

## Summary
- Moves the generic MCP read-only in-process helper out of `src/mcp/tools.rs` into `src/mcp/tools/read_only.rs`.
- Behavior-preserving refactor: MCP tool behavior and JSON envelopes remain unchanged.

## Testing
- `cargo fmt --all`
- `just check`
