### PR TITLE
refactor(mcp): extract tool registry module

### DIFF
--- a/openspec/changes/refactor-mcp-tool-registry-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tool-registry-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-tool-registry-module/README.md
+++ b/openspec/changes/refactor-mcp-tool-registry-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tool-registry-module
+
+Extract MCP tool registry/list into a dedicated module

--- a/openspec/changes/refactor-mcp-tool-registry-module/proposal.md
+++ b/openspec/changes/refactor-mcp-tool-registry-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP tool registry into a dedicated module
+
+## Why
+`src/mcp/tools.rs` still contains the MCP tool registry (the `tools()` list), mixing tool registration with routing logic. Moving the registry into a dedicated module keeps `tools.rs` focused on routing and makes future tool additions easier to review.
+
+## What Changes
+- Move the MCP tool registry (`tools()` list) out of `src/mcp/tools.rs` into `src/mcp/tools/tool_registry.rs`.
+- Keep the tool list, tool schemas, and JSON envelope behavior unchanged (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/tool_registry.rs` (new)

--- a/openspec/changes/refactor-mcp-tool-registry-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tool-registry-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP tool registry is modularized
+The system SHALL keep the MCP tool registry implemented in a dedicated module file so `src/mcp/tools.rs` stays focused on routing while preserving the advertised tool list and schemas.
+
+#### Scenario: MCP tool list and schemas remain unchanged after registry refactor
+- **GIVEN** the MCP server exposes a stable set of tools with stable input schemas
+- **WHEN** the registry/list code is refactored into a dedicated module
+- **THEN** the tool names and `inputSchema` values remain unchanged

--- a/openspec/changes/refactor-mcp-tool-registry-module/tasks.md
+++ b/openspec/changes/refactor-mcp-tool-registry-module/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [x] Extract the MCP tool registry into `src/mcp/tools/tool_registry.rs`
+- [x] Keep MCP tool list and schemas unchanged
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -18,6 +18,7 @@ mod preview;
 mod read_only;
 mod rollback;
 mod status;
+mod tool_registry;
 mod tool_schema;
 
 use deploy_plan::deploy_plan_envelope_in_process;
@@ -184,74 +185,7 @@ async fn call_preview_in_process(args: PreviewArgs) -> anyhow::Result<(String, s
 }
 
 pub(super) fn tools() -> Vec<Tool> {
-    vec![
-        tool(
-            "plan",
-            "Compute plan (returns Agentpack JSON envelope).",
-            tool_input_schema::<CommonArgs>(),
-            true,
-        ),
-        tool(
-            "diff",
-            "Compute diff (returns Agentpack JSON envelope).",
-            tool_input_schema::<CommonArgs>(),
-            true,
-        ),
-        tool(
-            "preview",
-            "Preview plan (optionally include diff; returns Agentpack JSON envelope).",
-            tool_input_schema::<PreviewArgs>(),
-            true,
-        ),
-        tool(
-            "status",
-            "Compute drift/status (returns Agentpack JSON envelope).",
-            tool_input_schema::<StatusArgs>(),
-            true,
-        ),
-        tool(
-            "doctor",
-            "Run doctor checks (returns Agentpack JSON envelope; read-only).",
-            tool_input_schema::<DoctorArgs>(),
-            true,
-        ),
-        tool(
-            "deploy",
-            "Plan+diff (read-only; returns Agentpack JSON envelope).",
-            tool_input_schema::<CommonArgs>(),
-            true,
-        ),
-        tool(
-            "deploy_apply",
-            "Deploy with apply (requires yes=true).",
-            tool_input_schema::<DeployApplyArgs>(),
-            false,
-        ),
-        tool(
-            "rollback",
-            "Rollback to a snapshot id (requires yes=true).",
-            tool_input_schema::<RollbackArgs>(),
-            false,
-        ),
-        tool(
-            "evolve_propose",
-            "Propose overlay updates by capturing drifted outputs (requires yes=true when not dry_run).",
-            tool_input_schema::<EvolveProposeArgs>(),
-            false,
-        ),
-        tool(
-            "evolve_restore",
-            "Restore missing desired outputs (requires yes=true when not dry_run).",
-            tool_input_schema::<EvolveRestoreArgs>(),
-            false,
-        ),
-        tool(
-            "explain",
-            "Explain plan/diff/status provenance (returns Agentpack JSON envelope).",
-            tool_input_schema::<ExplainArgs>(),
-            true,
-        ),
-    ]
+    tool_registry::tools()
 }
 
 pub(super) async fn call_tool(

--- a/src/mcp/tools/tool_registry.rs
+++ b/src/mcp/tools/tool_registry.rs
@@ -1,0 +1,77 @@
+use rmcp::model::Tool;
+
+use super::{
+    CommonArgs, DeployApplyArgs, DoctorArgs, EvolveProposeArgs, EvolveRestoreArgs, ExplainArgs,
+    PreviewArgs, RollbackArgs, StatusArgs, tool, tool_input_schema,
+};
+
+pub(super) fn tools() -> Vec<Tool> {
+    vec![
+        tool(
+            "plan",
+            "Compute plan (returns Agentpack JSON envelope).",
+            tool_input_schema::<CommonArgs>(),
+            true,
+        ),
+        tool(
+            "diff",
+            "Compute diff (returns Agentpack JSON envelope).",
+            tool_input_schema::<CommonArgs>(),
+            true,
+        ),
+        tool(
+            "preview",
+            "Preview plan (optionally include diff; returns Agentpack JSON envelope).",
+            tool_input_schema::<PreviewArgs>(),
+            true,
+        ),
+        tool(
+            "status",
+            "Compute drift/status (returns Agentpack JSON envelope).",
+            tool_input_schema::<StatusArgs>(),
+            true,
+        ),
+        tool(
+            "doctor",
+            "Run doctor checks (returns Agentpack JSON envelope; read-only).",
+            tool_input_schema::<DoctorArgs>(),
+            true,
+        ),
+        tool(
+            "deploy",
+            "Plan+diff (read-only; returns Agentpack JSON envelope).",
+            tool_input_schema::<CommonArgs>(),
+            true,
+        ),
+        tool(
+            "deploy_apply",
+            "Deploy with apply (requires yes=true).",
+            tool_input_schema::<DeployApplyArgs>(),
+            false,
+        ),
+        tool(
+            "rollback",
+            "Rollback to a snapshot id (requires yes=true).",
+            tool_input_schema::<RollbackArgs>(),
+            false,
+        ),
+        tool(
+            "evolve_propose",
+            "Propose overlay updates by capturing drifted outputs (requires yes=true when not dry_run).",
+            tool_input_schema::<EvolveProposeArgs>(),
+            false,
+        ),
+        tool(
+            "evolve_restore",
+            "Restore missing desired outputs (requires yes=true when not dry_run).",
+            tool_input_schema::<EvolveRestoreArgs>(),
+            false,
+        ),
+        tool(
+            "explain",
+            "Explain plan/diff/status provenance (returns Agentpack JSON envelope).",
+            tool_input_schema::<ExplainArgs>(),
+            true,
+        ),
+    ]
+}


### PR DESCRIPTION
Closes #713.

## Summary
- Moves the MCP tool registry (`tools()` list) out of `src/mcp/tools.rs` into `src/mcp/tools/tool_registry.rs`.
- No behavior changes: tool names, `inputSchema`, and JSON envelopes stay identical.

## Testing
- `cargo fmt --all`
- `just check`
