### PR TITLE
refactor(mcp): extract tool args module

### DIFF
--- a/openspec/changes/refactor-mcp-tool-args-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tool-args-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-tool-args-module/README.md
+++ b/openspec/changes/refactor-mcp-tool-args-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tool-args-module
+
+Extract MCP tool argument types into a dedicated module

--- a/openspec/changes/refactor-mcp-tool-args-module/proposal.md
+++ b/openspec/changes/refactor-mcp-tool-args-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP tool argument types into a dedicated module
+
+## Why
+`src/mcp/tools.rs` still contains a large number of MCP tool argument structs/enums, which makes it harder to review routing logic changes. Moving these types into a dedicated module keeps `tools.rs` focused on routing while preserving MCP behavior.
+
+## What Changes
+- Move MCP tool argument structs/enums out of `src/mcp/tools.rs` into `src/mcp/tools/args.rs`.
+- Keep MCP tool behavior, input schemas, and JSON envelopes unchanged (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/args.rs` (new)

--- a/openspec/changes/refactor-mcp-tool-args-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tool-args-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,9 @@
+## ADDED Requirements
+
+### Requirement: MCP tool argument types are modularized
+The system SHALL keep MCP tool argument structs/enums implemented in a dedicated module file so `src/mcp/tools.rs` stays focused on routing while preserving MCP tool behavior and schemas.
+
+#### Scenario: MCP tool schemas remain unchanged after args refactor
+- **GIVEN** the MCP server exposes tools with stable input schemas
+- **WHEN** tool argument types are refactored into a dedicated module
+- **THEN** the advertised tool `inputSchema` values remain unchanged

--- a/openspec/changes/refactor-mcp-tool-args-module/tasks.md
+++ b/openspec/changes/refactor-mcp-tool-args-module/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [x] Extract MCP tool argument structs/enums into `src/mcp/tools/args.rs`
+- [x] Keep MCP tool schemas and JSON envelopes unchanged
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/args.rs
+++ b/src/mcp/tools/args.rs
@@ -1,0 +1,122 @@
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct CommonArgs {
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub profile: Option<String>,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub machine: Option<String>,
+    #[serde(default)]
+    pub dry_run: Option<bool>,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct StatusArgs {
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    #[serde(default)]
+    pub only: Option<Vec<StatusOnly>>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::mcp) enum StatusOnly {
+    Missing,
+    Modified,
+    Extra,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct DoctorArgs {
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub target: Option<String>,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct DeployApplyArgs {
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    #[serde(default)]
+    pub adopt: Option<bool>,
+    #[serde(default)]
+    pub confirm_token: Option<String>,
+    #[serde(default)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct RollbackArgs {
+    #[serde(default)]
+    pub repo: Option<String>,
+    pub to: String,
+    #[serde(default)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct PreviewArgs {
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    #[serde(default)]
+    pub diff: bool,
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::mcp) enum EvolveScopeArg {
+    Global,
+    Machine,
+    Project,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct EvolveProposeArgs {
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    #[serde(default)]
+    pub module_id: Option<String>,
+    #[serde(default)]
+    pub scope: Option<EvolveScopeArg>,
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Default, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct EvolveRestoreArgs {
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    #[serde(default)]
+    pub module_id: Option<String>,
+    #[serde(default)]
+    pub yes: bool,
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(in crate::mcp) enum ExplainKindArg {
+    Plan,
+    Diff,
+    Status,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(in crate::mcp) struct ExplainArgs {
+    #[serde(flatten)]
+    pub common: CommonArgs,
+    pub kind: ExplainKindArg,
+}


### PR DESCRIPTION
Closes #716.

## Summary
- Moves MCP tool argument structs/enums out of `src/mcp/tools.rs` into `src/mcp/tools/args.rs`.
- Keeps MCP tool behavior, input schemas, and JSON envelope semantics unchanged.

## Testing
- `cargo fmt --all`
- `just check`
