### PR TITLE
refactor(mcp): extract tool router module

### DIFF
--- a/openspec/changes/refactor-mcp-tool-router-module/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-tool-router-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-tool-router-module/README.md
+++ b/openspec/changes/refactor-mcp-tool-router-module/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-tool-router-module
+
+Extract MCP tool routing into a dedicated module

--- a/openspec/changes/refactor-mcp-tool-router-module/proposal.md
+++ b/openspec/changes/refactor-mcp-tool-router-module/proposal.md
@@ -1,0 +1,14 @@
+# Change: Extract MCP tool routing into a dedicated module
+
+## Why
+`src/mcp/tools.rs` currently contains the full `call_tool` routing match, which makes the file longer and increases review surface for unrelated changes. Moving the routing logic into a dedicated module keeps `tools.rs` focused on module wiring and exports while preserving MCP behavior.
+
+## What Changes
+- Move MCP tool routing logic (`call_tool`) out of `src/mcp/tools.rs` into `src/mcp/tools/router.rs`.
+- Keep MCP tool behavior, input schemas, and JSON envelopes unchanged (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools.rs`
+  - `src/mcp/tools/router.rs` (new)

--- a/openspec/changes/refactor-mcp-tool-router-module/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-tool-router-module/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: MCP tool routing is modularized
+The system SHALL keep MCP tool routing implemented in a dedicated module file so `src/mcp/tools.rs` stays focused on wiring and exports while preserving MCP tool behavior and schemas.
+
+#### Scenario: MCP tool behavior remains unchanged after routing refactor
+- **GIVEN** the MCP server exposes tools with stable behavior and input schemas
+- **WHEN** tool routing is refactored into a dedicated module
+- **THEN** the tools continue to behave the same and advertise the same `inputSchema` values

--- a/openspec/changes/refactor-mcp-tool-router-module/tasks.md
+++ b/openspec/changes/refactor-mcp-tool-router-module/tasks.md
@@ -1,0 +1,8 @@
+---
+## 1. Implementation
+- [x] Extract MCP tool routing into `src/mcp/tools/router.rs`
+- [x] Keep MCP tool schemas and JSON envelopes unchanged
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,6 +1,6 @@
 use rmcp::{
     ErrorData as McpError,
-    model::{CallToolRequestParam, CallToolResult, Content, Tool},
+    model::{CallToolRequestParam, CallToolResult, Tool},
 };
 
 use super::confirm::{CONFIRM_TOKEN_TTL, ConfirmTokenBinding};
@@ -18,6 +18,7 @@ mod explain;
 mod preview;
 mod read_only;
 mod rollback;
+mod router;
 mod status;
 mod tool_registry;
 mod tool_schema;
@@ -29,43 +30,9 @@ pub(super) use args::{
 
 use deploy_plan::deploy_plan_envelope_in_process;
 use envelope::{envelope_error, tool_result_from_envelope, tool_result_from_user_error};
-use tool_schema::{deserialize_args, tool, tool_input_schema};
+use tool_schema::{tool, tool_input_schema};
 
 pub(super) const TOOLS_INSTRUCTIONS: &str = "Agentpack MCP server (stdio). Tools: plan, diff, preview, status, doctor, deploy, deploy_apply, rollback, evolve_propose, evolve_restore, explain.";
-
-async fn call_doctor_in_process(args: DoctorArgs) -> anyhow::Result<(String, serde_json::Value)> {
-    doctor::call_doctor_in_process(args).await
-}
-
-async fn call_status_in_process(args: StatusArgs) -> anyhow::Result<(String, serde_json::Value)> {
-    status::call_status_in_process(args).await
-}
-
-async fn call_explain_in_process(args: ExplainArgs) -> anyhow::Result<(String, serde_json::Value)> {
-    explain::call_explain_in_process(args).await
-}
-
-async fn call_rollback_in_process(
-    args: RollbackArgs,
-) -> anyhow::Result<(String, serde_json::Value)> {
-    rollback::call_rollback_in_process(args).await
-}
-
-async fn call_evolve_restore_in_process(
-    args: EvolveRestoreArgs,
-) -> anyhow::Result<(String, serde_json::Value)> {
-    evolve_restore::call_evolve_restore_in_process(args).await
-}
-
-async fn call_evolve_propose_in_process(
-    args: EvolveProposeArgs,
-) -> anyhow::Result<(String, serde_json::Value)> {
-    evolve_propose::call_evolve_propose_in_process(args).await
-}
-
-async fn call_preview_in_process(args: PreviewArgs) -> anyhow::Result<(String, serde_json::Value)> {
-    preview::call_preview_in_process(args).await
-}
 
 pub(super) fn tools() -> Vec<Tool> {
     tool_registry::tools()
@@ -75,137 +42,5 @@ pub(super) async fn call_tool(
     server: &AgentpackMcp,
     request: CallToolRequestParam,
 ) -> Result<CallToolResult, McpError> {
-    match request.name.as_ref() {
-        "plan" => {
-            let args = deserialize_args::<CommonArgs>(request.arguments)?;
-            let (text, envelope) = match read_only::call_read_only_in_process("plan", args).await {
-                Ok(v) => v,
-                Err(err) => {
-                    return Ok(CallToolResult::structured_error(envelope_error(
-                        "plan",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    )));
-                }
-            };
-            Ok(tool_result_from_envelope(text, envelope))
-        }
-        "diff" => {
-            let args = deserialize_args::<CommonArgs>(request.arguments)?;
-            let (text, envelope) = match read_only::call_read_only_in_process("diff", args).await {
-                Ok(v) => v,
-                Err(err) => {
-                    return Ok(CallToolResult::structured_error(envelope_error(
-                        "diff",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    )));
-                }
-            };
-            Ok(tool_result_from_envelope(text, envelope))
-        }
-        "preview" => {
-            let args = deserialize_args::<PreviewArgs>(request.arguments)?;
-            match call_preview_in_process(args).await {
-                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "preview",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
-            }
-        }
-        "status" => {
-            let args = deserialize_args::<StatusArgs>(request.arguments)?;
-            match call_status_in_process(args).await {
-                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "status",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
-            }
-        }
-        "doctor" => {
-            let args = deserialize_args::<DoctorArgs>(request.arguments)?;
-            let (text, envelope) = match call_doctor_in_process(args).await {
-                Ok(v) => v,
-                Err(err) => {
-                    return Ok(CallToolResult::structured_error(envelope_error(
-                        "doctor",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    )));
-                }
-            };
-            Ok(tool_result_from_envelope(text, envelope))
-        }
-        "deploy" => {
-            let args = deserialize_args::<CommonArgs>(request.arguments)?;
-            Ok(deploy::call_deploy_tool(server, args).await)
-        }
-        "deploy_apply" => {
-            let args = deserialize_args::<DeployApplyArgs>(request.arguments)?;
-            Ok(deploy_apply::call_deploy_apply_tool(server, args).await)
-        }
-        "rollback" => {
-            let args = deserialize_args::<RollbackArgs>(request.arguments)?;
-            match call_rollback_in_process(args).await {
-                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "rollback",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
-            }
-        }
-        "evolve_propose" => {
-            let args = deserialize_args::<EvolveProposeArgs>(request.arguments)?;
-            match call_evolve_propose_in_process(args).await {
-                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "evolve.propose",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
-            }
-        }
-        "evolve_restore" => {
-            let args = deserialize_args::<EvolveRestoreArgs>(request.arguments)?;
-            match call_evolve_restore_in_process(args).await {
-                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "evolve.restore",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
-            }
-        }
-        "explain" => {
-            let args = deserialize_args::<ExplainArgs>(request.arguments)?;
-            match call_explain_in_process(args).await {
-                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "explain",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
-            }
-        }
-        other => Ok(CallToolResult {
-            content: vec![Content::text(format!("unknown tool: {other}"))],
-            structured_content: None,
-            is_error: Some(true),
-            meta: None,
-        }),
-    }
+    router::call_tool(server, request).await
 }

--- a/src/mcp/tools/router.rs
+++ b/src/mcp/tools/router.rs
@@ -1,0 +1,148 @@
+use rmcp::{
+    ErrorData as McpError,
+    model::{CallToolRequestParam, CallToolResult, Content},
+};
+
+use super::envelope::{envelope_error, tool_result_from_envelope};
+use super::tool_schema::deserialize_args;
+
+pub(super) async fn call_tool(
+    server: &super::AgentpackMcp,
+    request: CallToolRequestParam,
+) -> Result<CallToolResult, McpError> {
+    match request.name.as_ref() {
+        "plan" => {
+            let args = deserialize_args::<super::CommonArgs>(request.arguments)?;
+            let (text, envelope) =
+                match super::read_only::call_read_only_in_process("plan", args).await {
+                    Ok(v) => v,
+                    Err(err) => {
+                        return Ok(CallToolResult::structured_error(envelope_error(
+                            "plan",
+                            "E_UNEXPECTED",
+                            &err.to_string(),
+                            None,
+                        )));
+                    }
+                };
+            Ok(tool_result_from_envelope(text, envelope))
+        }
+        "diff" => {
+            let args = deserialize_args::<super::CommonArgs>(request.arguments)?;
+            let (text, envelope) =
+                match super::read_only::call_read_only_in_process("diff", args).await {
+                    Ok(v) => v,
+                    Err(err) => {
+                        return Ok(CallToolResult::structured_error(envelope_error(
+                            "diff",
+                            "E_UNEXPECTED",
+                            &err.to_string(),
+                            None,
+                        )));
+                    }
+                };
+            Ok(tool_result_from_envelope(text, envelope))
+        }
+        "preview" => {
+            let args = deserialize_args::<super::PreviewArgs>(request.arguments)?;
+            match super::preview::call_preview_in_process(args).await {
+                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
+                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
+                    "preview",
+                    "E_UNEXPECTED",
+                    &err.to_string(),
+                    None,
+                ))),
+            }
+        }
+        "status" => {
+            let args = deserialize_args::<super::StatusArgs>(request.arguments)?;
+            match super::status::call_status_in_process(args).await {
+                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
+                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
+                    "status",
+                    "E_UNEXPECTED",
+                    &err.to_string(),
+                    None,
+                ))),
+            }
+        }
+        "doctor" => {
+            let args = deserialize_args::<super::DoctorArgs>(request.arguments)?;
+            let (text, envelope) = match super::doctor::call_doctor_in_process(args).await {
+                Ok(v) => v,
+                Err(err) => {
+                    return Ok(CallToolResult::structured_error(envelope_error(
+                        "doctor",
+                        "E_UNEXPECTED",
+                        &err.to_string(),
+                        None,
+                    )));
+                }
+            };
+            Ok(tool_result_from_envelope(text, envelope))
+        }
+        "deploy" => {
+            let args = deserialize_args::<super::CommonArgs>(request.arguments)?;
+            Ok(super::deploy::call_deploy_tool(server, args).await)
+        }
+        "deploy_apply" => {
+            let args = deserialize_args::<super::DeployApplyArgs>(request.arguments)?;
+            Ok(super::deploy_apply::call_deploy_apply_tool(server, args).await)
+        }
+        "rollback" => {
+            let args = deserialize_args::<super::RollbackArgs>(request.arguments)?;
+            match super::rollback::call_rollback_in_process(args).await {
+                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
+                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
+                    "rollback",
+                    "E_UNEXPECTED",
+                    &err.to_string(),
+                    None,
+                ))),
+            }
+        }
+        "evolve_propose" => {
+            let args = deserialize_args::<super::EvolveProposeArgs>(request.arguments)?;
+            match super::evolve_propose::call_evolve_propose_in_process(args).await {
+                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
+                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
+                    "evolve.propose",
+                    "E_UNEXPECTED",
+                    &err.to_string(),
+                    None,
+                ))),
+            }
+        }
+        "evolve_restore" => {
+            let args = deserialize_args::<super::EvolveRestoreArgs>(request.arguments)?;
+            match super::evolve_restore::call_evolve_restore_in_process(args).await {
+                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
+                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
+                    "evolve.restore",
+                    "E_UNEXPECTED",
+                    &err.to_string(),
+                    None,
+                ))),
+            }
+        }
+        "explain" => {
+            let args = deserialize_args::<super::ExplainArgs>(request.arguments)?;
+            match super::explain::call_explain_in_process(args).await {
+                Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
+                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
+                    "explain",
+                    "E_UNEXPECTED",
+                    &err.to_string(),
+                    None,
+                ))),
+            }
+        }
+        other => Ok(CallToolResult {
+            content: vec![Content::text(format!("unknown tool: {other}"))],
+            structured_content: None,
+            is_error: Some(true),
+            meta: None,
+        }),
+    }
+}


### PR DESCRIPTION
Closes #719.

Moves MCP tool routing (`call_tool`) out of `src/mcp/tools.rs` into `src/mcp/tools/router.rs`.

- OpenSpec: `refactor-mcp-tool-router-module`
- Behavior: no changes (schemas/envelopes preserved)

## Test
- `cargo fmt --all`
- `just check`
