### PR TITLE
refactor(mcp): dedupe router unexpected error mapping

### DIFF
--- a/openspec/changes/refactor-mcp-router-error-helper/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-router-error-helper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-router-error-helper/README.md
+++ b/openspec/changes/refactor-mcp-router-error-helper/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-router-error-helper
+
+Deduplicate unexpected-error handling in MCP tool router

--- a/openspec/changes/refactor-mcp-router-error-helper/proposal.md
+++ b/openspec/changes/refactor-mcp-router-error-helper/proposal.md
@@ -1,0 +1,13 @@
+# Change: Deduplicate unexpected-error handling in MCP tool router
+
+## Why
+`src/mcp/tools/router.rs` repeats the same "unexpected error" mapping pattern for many tools (build `E_UNEXPECTED` structured errors via `envelope_error`). This makes the router harder to scan and increases the chance of inconsistency when adding new tools.
+
+## What Changes
+- Introduce a small helper in `src/mcp/tools/router.rs` for the repeated `E_UNEXPECTED` error mapping.
+- Keep MCP tool behavior, input schemas, and JSON envelopes unchanged (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools/router.rs`

--- a/openspec/changes/refactor-mcp-router-error-helper/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-router-error-helper/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: MCP router unexpected-error handling is centralized
+The system SHALL centralize repeated unexpected-error handling in the MCP tool router so routing logic stays readable while preserving MCP tool behavior and schemas.
+
+#### Scenario: MCP tool behavior remains unchanged after router error refactor
+- **GIVEN** the MCP server exposes tools with stable behavior and input schemas
+- **WHEN** unexpected-error mapping is refactored into a shared helper
+- **THEN** the tools continue to behave the same and advertise the same `inputSchema` values

--- a/openspec/changes/refactor-mcp-router-error-helper/tasks.md
+++ b/openspec/changes/refactor-mcp-router-error-helper/tasks.md
@@ -1,0 +1,8 @@
+---
+## 1. Implementation
+- [x] Add helper for repeated `E_UNEXPECTED` structured errors in `src/mcp/tools/router.rs`
+- [x] Keep MCP tool schemas and JSON envelopes unchanged
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/router.rs
+++ b/src/mcp/tools/router.rs
@@ -6,6 +6,15 @@ use rmcp::{
 use super::envelope::{envelope_error, tool_result_from_envelope};
 use super::tool_schema::deserialize_args;
 
+fn unexpected(tool_id: &str, err: &anyhow::Error) -> CallToolResult {
+    CallToolResult::structured_error(envelope_error(
+        tool_id,
+        "E_UNEXPECTED",
+        &err.to_string(),
+        None,
+    ))
+}
+
 pub(super) async fn call_tool(
     server: &super::AgentpackMcp,
     request: CallToolRequestParam,
@@ -17,12 +26,7 @@ pub(super) async fn call_tool(
                 match super::read_only::call_read_only_in_process("plan", args).await {
                     Ok(v) => v,
                     Err(err) => {
-                        return Ok(CallToolResult::structured_error(envelope_error(
-                            "plan",
-                            "E_UNEXPECTED",
-                            &err.to_string(),
-                            None,
-                        )));
+                        return Ok(unexpected("plan", &err));
                     }
                 };
             Ok(tool_result_from_envelope(text, envelope))
@@ -33,12 +37,7 @@ pub(super) async fn call_tool(
                 match super::read_only::call_read_only_in_process("diff", args).await {
                     Ok(v) => v,
                     Err(err) => {
-                        return Ok(CallToolResult::structured_error(envelope_error(
-                            "diff",
-                            "E_UNEXPECTED",
-                            &err.to_string(),
-                            None,
-                        )));
+                        return Ok(unexpected("diff", &err));
                     }
                 };
             Ok(tool_result_from_envelope(text, envelope))
@@ -47,24 +46,14 @@ pub(super) async fn call_tool(
             let args = deserialize_args::<super::PreviewArgs>(request.arguments)?;
             match super::preview::call_preview_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "preview",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
+                Err(err) => Ok(unexpected("preview", &err)),
             }
         }
         "status" => {
             let args = deserialize_args::<super::StatusArgs>(request.arguments)?;
             match super::status::call_status_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "status",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
+                Err(err) => Ok(unexpected("status", &err)),
             }
         }
         "doctor" => {
@@ -72,12 +61,7 @@ pub(super) async fn call_tool(
             let (text, envelope) = match super::doctor::call_doctor_in_process(args).await {
                 Ok(v) => v,
                 Err(err) => {
-                    return Ok(CallToolResult::structured_error(envelope_error(
-                        "doctor",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    )));
+                    return Ok(unexpected("doctor", &err));
                 }
             };
             Ok(tool_result_from_envelope(text, envelope))
@@ -94,48 +78,28 @@ pub(super) async fn call_tool(
             let args = deserialize_args::<super::RollbackArgs>(request.arguments)?;
             match super::rollback::call_rollback_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "rollback",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
+                Err(err) => Ok(unexpected("rollback", &err)),
             }
         }
         "evolve_propose" => {
             let args = deserialize_args::<super::EvolveProposeArgs>(request.arguments)?;
             match super::evolve_propose::call_evolve_propose_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "evolve.propose",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
+                Err(err) => Ok(unexpected("evolve.propose", &err)),
             }
         }
         "evolve_restore" => {
             let args = deserialize_args::<super::EvolveRestoreArgs>(request.arguments)?;
             match super::evolve_restore::call_evolve_restore_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "evolve.restore",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
+                Err(err) => Ok(unexpected("evolve.restore", &err)),
             }
         }
         "explain" => {
             let args = deserialize_args::<super::ExplainArgs>(request.arguments)?;
             match super::explain::call_explain_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(CallToolResult::structured_error(envelope_error(
-                    "explain",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ))),
+                Err(err) => Ok(unexpected("explain", &err)),
             }
         }
         other => Ok(CallToolResult {


### PR DESCRIPTION
Closes #722.

Deduplicates repeated `E_UNEXPECTED` structured-error mapping in `src/mcp/tools/router.rs`.

- OpenSpec: `refactor-mcp-router-error-helper`
- Behavior: no changes (schemas/envelopes preserved)

## Test
- `cargo fmt --all`
- `just check`
