### PR TITLE
refactor(mcp): centralize unexpected tool errors

### DIFF
--- a/openspec/changes/refactor-mcp-unexpected-tool-error-helper/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-unexpected-tool-error-helper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-unexpected-tool-error-helper/README.md
+++ b/openspec/changes/refactor-mcp-unexpected-tool-error-helper/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-unexpected-tool-error-helper
+
+Centralize MCP tool `E_UNEXPECTED` structured error creation

--- a/openspec/changes/refactor-mcp-unexpected-tool-error-helper/proposal.md
+++ b/openspec/changes/refactor-mcp-unexpected-tool-error-helper/proposal.md
@@ -1,0 +1,19 @@
+# Change: Centralize MCP tool `E_UNEXPECTED` structured error creation
+
+## Why
+Several MCP tool implementations repeat the same pattern for converting unexpected errors into an Agentpack JSON envelope (`ok=false`, `errors[0].code=E_UNEXPECTED`) wrapped as an MCP `CallToolResult`.
+
+This duplication makes it harder to keep behavior consistent and adds noise to otherwise straightforward control-flow in tool handlers.
+
+## What Changes
+- Introduce a shared helper for constructing `E_UNEXPECTED` MCP tool errors (based on `envelope_error`).
+- Replace repeated `CallToolResult::structured_error(envelope_error(...))` call-sites with the helper.
+- Keep MCP tool behavior, input schemas, and JSON envelopes unchanged (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools/envelope.rs`
+  - `src/mcp/tools/router.rs`
+  - `src/mcp/tools/deploy.rs`
+  - `src/mcp/tools/deploy_apply.rs`

--- a/openspec/changes/refactor-mcp-unexpected-tool-error-helper/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-unexpected-tool-error-helper/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: MCP tool unexpected-error envelopes are constructed via a shared helper
+The system SHALL centralize construction of MCP tool `E_UNEXPECTED` structured errors so tool implementations remain readable while preserving MCP behavior and schemas.
+
+#### Scenario: MCP tool behavior remains unchanged after centralizing unexpected errors
+- **GIVEN** the MCP server exposes tools with stable behavior and input schemas
+- **WHEN** `E_UNEXPECTED` tool error mapping is refactored into a shared helper
+- **THEN** the tools continue to behave the same and advertise the same `inputSchema` values

--- a/openspec/changes/refactor-mcp-unexpected-tool-error-helper/tasks.md
+++ b/openspec/changes/refactor-mcp-unexpected-tool-error-helper/tasks.md
@@ -1,0 +1,8 @@
+---
+## 1. Implementation
+- [x] Add a shared helper for MCP tool `E_UNEXPECTED` structured errors (based on `envelope_error`)
+- [x] Refactor MCP tools to use the helper (no behavior change)
+
+## 2. Verification
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -29,7 +29,9 @@ pub(super) use args::{
 };
 
 use deploy_plan::deploy_plan_envelope_in_process;
-use envelope::{envelope_error, tool_result_from_envelope, tool_result_from_user_error};
+use envelope::{
+    envelope_error, tool_result_from_envelope, tool_result_from_user_error, tool_result_unexpected,
+};
 use tool_schema::{tool, tool_input_schema};
 
 pub(super) const TOOLS_INSTRUCTIONS: &str = "Agentpack MCP server (stdio). Tools: plan, diff, preview, status, doctor, deploy, deploy_apply, rollback, evolve_propose, evolve_restore, explain.";

--- a/src/mcp/tools/deploy.rs
+++ b/src/mcp/tools/deploy.rs
@@ -12,24 +12,14 @@ pub(super) async fn call_deploy_tool(
             let plan_hash = match super::confirm::compute_confirm_plan_hash(&binding, &envelope) {
                 Ok(v) => v,
                 Err(err) => {
-                    return CallToolResult::structured_error(super::envelope_error(
-                        "deploy",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    ));
+                    return super::tool_result_unexpected("deploy", &err);
                 }
             };
 
             let token = match super::confirm::generate_confirm_token() {
                 Ok(v) => v,
                 Err(err) => {
-                    return CallToolResult::structured_error(super::envelope_error(
-                        "deploy",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    ));
+                    return super::tool_result_unexpected("deploy", &err);
                 }
             };
 
@@ -56,22 +46,15 @@ pub(super) async fn call_deploy_tool(
                 match expires_at_utc.format(&time::format_description::well_known::Rfc3339) {
                     Ok(v) => v,
                     Err(err) => {
-                        return CallToolResult::structured_error(super::envelope_error(
-                            "deploy",
-                            "E_UNEXPECTED",
-                            &err.to_string(),
-                            None,
-                        ));
+                        return super::tool_result_unexpected("deploy", &err);
                     }
                 };
 
             let Some(data) = envelope.get_mut("data").and_then(|v| v.as_object_mut()) else {
-                return CallToolResult::structured_error(super::envelope_error(
+                return super::tool_result_unexpected(
                     "deploy",
-                    "E_UNEXPECTED",
                     "agentpack deploy envelope missing data object",
-                    None,
-                ));
+                );
             };
             data.insert(
                 "confirm_token".to_string(),
@@ -89,21 +72,11 @@ pub(super) async fn call_deploy_tool(
             let text = match serde_json::to_string_pretty(&envelope) {
                 Ok(v) => v,
                 Err(err) => {
-                    return CallToolResult::structured_error(super::envelope_error(
-                        "deploy",
-                        "E_UNEXPECTED",
-                        &err.to_string(),
-                        None,
-                    ));
+                    return super::tool_result_unexpected("deploy", &err);
                 }
             };
             super::tool_result_from_envelope(text, envelope)
         }
-        Err(err) => CallToolResult::structured_error(super::envelope_error(
-            "deploy",
-            "E_UNEXPECTED",
-            &err.to_string(),
-            None,
-        )),
+        Err(err) => super::tool_result_unexpected("deploy", &err),
     }
 }

--- a/src/mcp/tools/deploy_apply.rs
+++ b/src/mcp/tools/deploy_apply.rs
@@ -12,12 +12,7 @@ pub(super) async fn call_deploy_apply_tool(
     if !args.yes || args.common.dry_run.unwrap_or(false) {
         match call_deploy_apply_in_process(args).await {
             Ok((text, envelope)) => super::tool_result_from_envelope(text, envelope),
-            Err(err) => CallToolResult::structured_error(super::envelope_error(
-                "deploy",
-                "E_UNEXPECTED",
-                &err.to_string(),
-                None,
-            )),
+            Err(err) => super::tool_result_unexpected("deploy", &err),
         }
     } else {
         let Some(token) = args
@@ -56,24 +51,14 @@ pub(super) async fn call_deploy_apply_tool(
         {
             Ok(v) => v,
             Err(err) => {
-                return CallToolResult::structured_error(super::envelope_error(
-                    "deploy",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ));
+                return super::tool_result_unexpected("deploy", &err);
             }
         };
         let current_plan_hash = match super::confirm::compute_confirm_plan_hash(&binding, &plan_env)
         {
             Ok(v) => v,
             Err(err) => {
-                return CallToolResult::structured_error(super::envelope_error(
-                    "deploy",
-                    "E_UNEXPECTED",
-                    &err.to_string(),
-                    None,
-                ));
+                return super::tool_result_unexpected("deploy", &err);
             }
         };
 
@@ -103,12 +88,7 @@ pub(super) async fn call_deploy_apply_tool(
                 }
                 super::tool_result_from_envelope(text, envelope)
             }
-            Err(err) => CallToolResult::structured_error(super::envelope_error(
-                "deploy",
-                "E_UNEXPECTED",
-                &err.to_string(),
-                None,
-            )),
+            Err(err) => super::tool_result_unexpected("deploy", &err),
         }
     }
 }

--- a/src/mcp/tools/envelope.rs
+++ b/src/mcp/tools/envelope.rs
@@ -2,6 +2,14 @@ use rmcp::model::{CallToolResult, Content};
 
 use crate::user_error::UserError;
 
+pub(super) fn tool_result_unexpected(
+    command: &str,
+    message: impl std::fmt::Display,
+) -> CallToolResult {
+    let message = message.to_string();
+    CallToolResult::structured_error(envelope_error(command, "E_UNEXPECTED", &message, None))
+}
+
 pub(super) fn envelope_error(
     command: &str,
     code: &str,

--- a/src/mcp/tools/router.rs
+++ b/src/mcp/tools/router.rs
@@ -3,17 +3,8 @@ use rmcp::{
     model::{CallToolRequestParam, CallToolResult, Content},
 };
 
-use super::envelope::{envelope_error, tool_result_from_envelope};
 use super::tool_schema::deserialize_args;
-
-fn unexpected(tool_id: &str, err: &anyhow::Error) -> CallToolResult {
-    CallToolResult::structured_error(envelope_error(
-        tool_id,
-        "E_UNEXPECTED",
-        &err.to_string(),
-        None,
-    ))
-}
+use super::{tool_result_from_envelope, tool_result_unexpected};
 
 pub(super) async fn call_tool(
     server: &super::AgentpackMcp,
@@ -26,7 +17,7 @@ pub(super) async fn call_tool(
                 match super::read_only::call_read_only_in_process("plan", args).await {
                     Ok(v) => v,
                     Err(err) => {
-                        return Ok(unexpected("plan", &err));
+                        return Ok(tool_result_unexpected("plan", &err));
                     }
                 };
             Ok(tool_result_from_envelope(text, envelope))
@@ -37,7 +28,7 @@ pub(super) async fn call_tool(
                 match super::read_only::call_read_only_in_process("diff", args).await {
                     Ok(v) => v,
                     Err(err) => {
-                        return Ok(unexpected("diff", &err));
+                        return Ok(tool_result_unexpected("diff", &err));
                     }
                 };
             Ok(tool_result_from_envelope(text, envelope))
@@ -46,14 +37,14 @@ pub(super) async fn call_tool(
             let args = deserialize_args::<super::PreviewArgs>(request.arguments)?;
             match super::preview::call_preview_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(unexpected("preview", &err)),
+                Err(err) => Ok(tool_result_unexpected("preview", &err)),
             }
         }
         "status" => {
             let args = deserialize_args::<super::StatusArgs>(request.arguments)?;
             match super::status::call_status_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(unexpected("status", &err)),
+                Err(err) => Ok(tool_result_unexpected("status", &err)),
             }
         }
         "doctor" => {
@@ -61,7 +52,7 @@ pub(super) async fn call_tool(
             let (text, envelope) = match super::doctor::call_doctor_in_process(args).await {
                 Ok(v) => v,
                 Err(err) => {
-                    return Ok(unexpected("doctor", &err));
+                    return Ok(tool_result_unexpected("doctor", &err));
                 }
             };
             Ok(tool_result_from_envelope(text, envelope))
@@ -78,28 +69,28 @@ pub(super) async fn call_tool(
             let args = deserialize_args::<super::RollbackArgs>(request.arguments)?;
             match super::rollback::call_rollback_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(unexpected("rollback", &err)),
+                Err(err) => Ok(tool_result_unexpected("rollback", &err)),
             }
         }
         "evolve_propose" => {
             let args = deserialize_args::<super::EvolveProposeArgs>(request.arguments)?;
             match super::evolve_propose::call_evolve_propose_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(unexpected("evolve.propose", &err)),
+                Err(err) => Ok(tool_result_unexpected("evolve.propose", &err)),
             }
         }
         "evolve_restore" => {
             let args = deserialize_args::<super::EvolveRestoreArgs>(request.arguments)?;
             match super::evolve_restore::call_evolve_restore_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(unexpected("evolve.restore", &err)),
+                Err(err) => Ok(tool_result_unexpected("evolve.restore", &err)),
             }
         }
         "explain" => {
             let args = deserialize_args::<super::ExplainArgs>(request.arguments)?;
             match super::explain::call_explain_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(unexpected("explain", &err)),
+                Err(err) => Ok(tool_result_unexpected("explain", &err)),
             }
         }
         other => Ok(CallToolResult {


### PR DESCRIPTION
Closes #725.

## Summary
- Adds a shared MCP helper for constructing `E_UNEXPECTED` tool errors.
- Refactors MCP router + deploy tools to use it.
- Pure refactor: no behavior / schema changes intended.

## OpenSpec
- `openspec/changes/refactor-mcp-unexpected-tool-error-helper/`

## Testing
- `openspec validate refactor-mcp-unexpected-tool-error-helper --strict --no-interactive`
- `cargo fmt --all`
- `just check`
