### PR TITLE
refactor(mcp): centralize anyhow envelope mapping

### DIFF
--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper/README.md
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-anyhow-envelope-helper
+
+Centralize mapping from `anyhow::Error` to MCP tool error envelopes

--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper/proposal.md
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper/proposal.md
@@ -1,0 +1,25 @@
+# Change: Centralize mapping from `anyhow::Error` to MCP tool error envelopes
+
+## Why
+Several MCP tools repeat the same logic to:
+1) Scan an `anyhow::Error` chain for `UserError`
+2) Choose `code`/`message`/`details` accordingly
+3) Build an Agentpack JSON error envelope via `envelope_error(...)`
+
+This duplication is noisy, easy to drift, and makes otherwise-straightforward handlers harder to read.
+
+## What Changes
+- Add a shared helper (based on `envelope_error`) for converting an `anyhow::Error` into the standard MCP tool error envelope.
+- Refactor a first batch of read-only MCP tool handlers to use the helper.
+- No behavior / schema changes intended (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools/envelope.rs`
+  - `src/mcp/tools/read_only.rs`
+  - `src/mcp/tools/preview.rs`
+  - `src/mcp/tools/status.rs`
+  - `src/mcp/tools/doctor.rs`
+  - `src/mcp/tools/rollback.rs`
+  - `src/mcp/tools/explain.rs`

--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: MCP tool error envelopes reuse a shared helper for `anyhow::Error` chains
+The system SHALL centralize the mapping from `anyhow::Error` chains (including embedded `UserError`) to MCP tool error envelopes so tool handlers stay readable while preserving behavior and schemas.
+
+#### Scenario: MCP tool behavior remains unchanged after centralizing anyhow error mapping
+- **GIVEN** the MCP server exposes tools with stable behavior and input schemas
+- **WHEN** `anyhow::Error` -> envelope mapping is refactored into a shared helper
+- **THEN** the tools continue to behave the same and advertise the same `inputSchema` values

--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper/tasks.md
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper/tasks.md
@@ -1,0 +1,9 @@
+---
+## 1. Implementation
+- [x] Add a shared helper to convert `anyhow::Error` -> Agentpack MCP error envelope (preserving `UserError` details)
+- [x] Refactor selected read-only MCP tool handlers to use the helper (no behavior change)
+
+## 2. Verification
+- [x] `openspec validate refactor-mcp-anyhow-envelope-helper --strict --no-interactive`
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -30,7 +30,8 @@ pub(super) use args::{
 
 use deploy_plan::deploy_plan_envelope_in_process;
 use envelope::{
-    envelope_error, tool_result_from_envelope, tool_result_from_user_error, tool_result_unexpected,
+    envelope_error, envelope_from_anyhow_error, tool_result_from_envelope,
+    tool_result_from_user_error, tool_result_unexpected,
 };
 use tool_schema::{tool, tool_input_schema};
 

--- a/src/mcp/tools/doctor.rs
+++ b/src/mcp/tools/doctor.rs
@@ -2,7 +2,6 @@ use anyhow::Context as _;
 
 use crate::app::doctor_json::doctor_json_data;
 use crate::app::doctor_next_actions::doctor_next_actions;
-use crate::user_error::UserError;
 
 fn action_prefix(repo: Option<&str>, target: &str) -> String {
     let mut out = String::from("agentpack");
@@ -25,15 +24,7 @@ pub(super) async fn call_doctor_in_process(
         let engine = match crate::engine::Engine::load(repo_override.as_deref(), None) {
             Ok(v) => v,
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("doctor", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("doctor", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 return Ok((text, envelope));
             }
@@ -43,15 +34,7 @@ pub(super) async fn call_doctor_in_process(
         let report = match report {
             Ok(v) => v,
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("doctor", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("doctor", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 return Ok((text, envelope));
             }

--- a/src/mcp/tools/explain.rs
+++ b/src/mcp/tools/explain.rs
@@ -1,7 +1,5 @@
 use anyhow::Context as _;
 
-use crate::user_error::UserError;
-
 pub(super) async fn call_explain_in_process(
     args: super::ExplainArgs,
 ) -> anyhow::Result<(String, serde_json::Value)> {
@@ -252,15 +250,7 @@ pub(super) async fn call_explain_in_process(
         match result {
             Ok(v) => Ok(v),
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error(command, &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error(command, &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 Ok((text, envelope))
             }

--- a/src/mcp/tools/preview.rs
+++ b/src/mcp/tools/preview.rs
@@ -1,7 +1,5 @@
 use anyhow::Context as _;
 
-use crate::user_error::UserError;
-
 pub(super) async fn call_preview_in_process(
     args: super::PreviewArgs,
 ) -> anyhow::Result<(String, serde_json::Value)> {
@@ -44,15 +42,7 @@ pub(super) async fn call_preview_in_process(
                 (text, envelope)
             }
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("preview", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("preview", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }

--- a/src/mcp/tools/read_only.rs
+++ b/src/mcp/tools/read_only.rs
@@ -1,7 +1,5 @@
 use anyhow::Context as _;
 
-use crate::user_error::UserError;
-
 pub(super) async fn call_read_only_in_process(
     command: &'static str,
     args: super::CommonArgs,
@@ -34,15 +32,7 @@ pub(super) async fn call_read_only_in_process(
                 (text, envelope)
             }
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error(command, &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error(command, &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }

--- a/src/mcp/tools/rollback.rs
+++ b/src/mcp/tools/rollback.rs
@@ -1,7 +1,5 @@
 use anyhow::Context as _;
 
-use crate::user_error::UserError;
-
 pub(super) async fn call_rollback_in_process(
     args: super::RollbackArgs,
 ) -> anyhow::Result<(String, serde_json::Value)> {
@@ -24,15 +22,7 @@ pub(super) async fn call_rollback_in_process(
                 (text, envelope)
             }
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("rollback", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("rollback", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }

--- a/src/mcp/tools/status.rs
+++ b/src/mcp/tools/status.rs
@@ -8,7 +8,6 @@ use crate::app::operator_assets::{
 use crate::app::status_drift::{drift_summary_by_root, filter_drift_by_kind};
 use crate::app::status_json::status_json_data;
 use crate::app::status_next_actions::status_next_actions;
-use crate::user_error::UserError;
 
 fn action_prefix_common(common: &super::CommonArgs) -> String {
     let mut out = String::from("agentpack");
@@ -151,15 +150,7 @@ pub(super) async fn call_status_in_process(
         match result {
             Ok(v) => Ok(v),
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("status", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("status", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 Ok((text, envelope))
             }


### PR DESCRIPTION
Closes #728.

## Summary
- Adds `envelope_from_anyhow_error()` to centralize mapping from `anyhow::Error` (including embedded `UserError`) into the standard MCP tool error envelope.
- Refactors a first batch of read-only MCP tool handlers to use the helper.
- Pure refactor: no behavior / schema changes intended.

## OpenSpec
- `openspec/changes/refactor-mcp-anyhow-envelope-helper/`

## Testing
- `openspec validate refactor-mcp-anyhow-envelope-helper --strict --no-interactive`
- `cargo fmt --all`
- `just check`
