### PR TITLE
refactor(mcp): adopt anyhow envelope helper in remaining tools

### DIFF
--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/.openspec.yaml
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/README.md
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/README.md
@@ -1,0 +1,3 @@
+# refactor-mcp-anyhow-envelope-helper-remaining-tools
+
+Adopt `envelope_from_anyhow_error` across remaining MCP tools

--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/proposal.md
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/proposal.md
@@ -1,0 +1,18 @@
+# Change: Adopt `envelope_from_anyhow_error` across remaining MCP tools
+
+## Why
+`src/mcp/tools/envelope.rs` now provides `envelope_from_anyhow_error()` to map `anyhow::Error` (including embedded `UserError`) into the standard Agentpack MCP tool error envelope.
+
+A few MCP tools still inline the old `UserError`-extraction boilerplate. Converging on the shared helper reduces duplication and keeps error envelope behavior consistent.
+
+## What Changes
+- Refactor the remaining MCP tools that still inline `UserError` extraction to use `envelope_from_anyhow_error()`.
+- No behavior / schema changes intended (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/mcp/tools/deploy_plan.rs`
+  - `src/mcp/tools/deploy_apply.rs`
+  - `src/mcp/tools/evolve_propose.rs`
+  - `src/mcp/tools/evolve_restore.rs`

--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: Remaining MCP tools reuse the shared anyhow error envelope helper
+The system SHALL refactor remaining MCP tools that inline `UserError` extraction to use the shared `anyhow::Error` -> envelope helper while preserving tool behavior and schemas.
+
+#### Scenario: MCP tool behavior remains unchanged after adopting the shared helper
+- **GIVEN** the MCP server exposes tools with stable behavior and input schemas
+- **WHEN** remaining tool error mapping is refactored to use the shared helper
+- **THEN** the tools continue to behave the same and advertise the same `inputSchema` values

--- a/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/tasks.md
+++ b/openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/tasks.md
@@ -1,0 +1,8 @@
+---
+## 1. Implementation
+- [x] Refactor remaining MCP tools to use `envelope_from_anyhow_error()` for `anyhow::Error` -> envelope mapping
+
+## 2. Verification
+- [x] `openspec validate refactor-mcp-anyhow-envelope-helper-remaining-tools --strict --no-interactive`
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -30,8 +30,8 @@ pub(super) use args::{
 
 use deploy_plan::deploy_plan_envelope_in_process;
 use envelope::{
-    envelope_error, envelope_from_anyhow_error, tool_result_from_envelope,
-    tool_result_from_user_error, tool_result_unexpected,
+    envelope_from_anyhow_error, tool_result_from_envelope, tool_result_from_user_error,
+    tool_result_unexpected,
 };
 use tool_schema::{tool, tool_input_schema};
 

--- a/src/mcp/tools/deploy_apply.rs
+++ b/src/mcp/tools/deploy_apply.rs
@@ -174,15 +174,7 @@ async fn call_deploy_apply_in_process(
         match result {
             Ok(v) => Ok(v),
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("deploy", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("deploy", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 Ok((text, envelope))
             }

--- a/src/mcp/tools/evolve_propose.rs
+++ b/src/mcp/tools/evolve_propose.rs
@@ -38,15 +38,7 @@ pub(super) async fn call_evolve_propose_in_process(
         let engine = match crate::engine::Engine::load(repo_override.as_deref(), machine_override) {
             Ok(v) => v,
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("evolve.propose", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("evolve.propose", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 return Ok((text, envelope));
             }
@@ -107,28 +99,12 @@ pub(super) async fn call_evolve_propose_in_process(
             }
             Ok(crate::handlers::evolve::EvolveProposeOutcome::NeedsConfirmation) => {
                 let err = UserError::confirm_required("evolve propose");
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("evolve.propose", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("evolve.propose", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("evolve.propose", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("evolve.propose", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }

--- a/src/mcp/tools/evolve_restore.rs
+++ b/src/mcp/tools/evolve_restore.rs
@@ -15,15 +15,7 @@ pub(super) async fn call_evolve_restore_in_process(
         let engine = match crate::engine::Engine::load(repo_override.as_deref(), machine_override) {
             Ok(v) => v,
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("evolve.restore", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("evolve.restore", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 return Ok((text, envelope));
             }
@@ -54,28 +46,12 @@ pub(super) async fn call_evolve_restore_in_process(
             }
             Ok(crate::handlers::evolve::EvolveRestoreOutcome::NeedsConfirmation) => {
                 let err = UserError::confirm_required("evolve restore");
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("evolve.restore", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("evolve.restore", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }
             Err(err) => {
-                let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
-                let code = user_err
-                    .map(|e| e.code.clone())
-                    .unwrap_or_else(|| "E_UNEXPECTED".to_string());
-                let message = user_err
-                    .map(|e| e.message.clone())
-                    .unwrap_or_else(|| err.to_string());
-                let details = user_err.and_then(|e| e.details.clone());
-                let envelope = super::envelope_error("evolve.restore", &code, &message, details);
+                let envelope = super::envelope_from_anyhow_error("evolve.restore", &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }


### PR DESCRIPTION
## Summary
Refactors remaining MCP tool handlers that still inline UserError extraction to use the shared `envelope_from_anyhow_error()` helper.

Closes #731.

## Spec / OpenSpec
- `openspec/changes/refactor-mcp-anyhow-envelope-helper-remaining-tools/`

## Notes
- No behavior / schema changes intended; this is a refactor to reduce duplication and keep error envelopes consistent.

## Tests
- `just check`
- `openspec validate refactor-mcp-anyhow-envelope-helper-remaining-tools --strict --no-interactive`
