### PR TITLE
refactor(user-error): centralize UserError extraction helper

### DIFF
--- a/openspec/changes/refactor-anyhow-user-error-helper/.openspec.yaml
+++ b/openspec/changes/refactor-anyhow-user-error-helper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-anyhow-user-error-helper/README.md
+++ b/openspec/changes/refactor-anyhow-user-error-helper/README.md
@@ -1,0 +1,3 @@
+# refactor-anyhow-user-error-helper
+
+Centralize `UserError` extraction / mapping from `anyhow::Error` for CLI + MCP error envelopes.

--- a/openspec/changes/refactor-anyhow-user-error-helper/proposal.md
+++ b/openspec/changes/refactor-anyhow-user-error-helper/proposal.md
@@ -1,0 +1,20 @@
+# Change: Centralize `UserError` extraction for CLI + MCP error envelopes
+
+## Why
+Multiple surfaces (CLI JSON, CLI human/TUI formatting, MCP tool envelopes) currently duplicate the same `anyhow::Error` chain-walk to find an embedded `UserError`.
+
+Centralizing this logic reduces duplication and keeps error mapping behavior consistent across surfaces.
+
+## What Changes
+- Introduce a shared helper for extracting `UserError` from an `anyhow::Error`.
+- Refactor callers (CLI + MCP) to reuse the shared helper.
+- No behavior / schema changes intended (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/user_error.rs`
+  - `src/cli/json.rs`
+  - `src/cli/human.rs`
+  - `src/cli/commands/tui.rs`
+  - `src/mcp/tools/envelope.rs`

--- a/openspec/changes/refactor-anyhow-user-error-helper/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-anyhow-user-error-helper/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: CLI error formatting reuses shared UserError extraction helper
+The system SHALL refactor CLI error formatting paths to reuse a shared helper for extracting embedded `UserError` values from an `anyhow::Error` chain while preserving output behavior.
+
+#### Scenario: CLI error behavior remains unchanged after refactor
+- **GIVEN** the CLI emits stable `--json` envelopes and stable human/TUI error formatting
+- **WHEN** UserError extraction is centralized behind a shared helper
+- **THEN** CLI output remains unchanged for both `UserError` and non-`UserError` failures

--- a/openspec/changes/refactor-anyhow-user-error-helper/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-anyhow-user-error-helper/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: MCP tool error envelopes reuse shared UserError extraction helper
+The system SHALL refactor MCP tool error envelope construction to reuse a shared helper for extracting embedded `UserError` values from an `anyhow::Error` chain while preserving envelope payloads and schemas.
+
+#### Scenario: MCP tool error envelopes remain unchanged after refactor
+- **GIVEN** the MCP server exposes tools with stable behavior and stable `inputSchema` values
+- **WHEN** UserError extraction is centralized behind a shared helper
+- **THEN** MCP tool error envelopes remain identical at the payload level (`errors[0].code/message/details`)

--- a/openspec/changes/refactor-anyhow-user-error-helper/tasks.md
+++ b/openspec/changes/refactor-anyhow-user-error-helper/tasks.md
@@ -1,0 +1,9 @@
+---
+## 1. Implementation
+- [x] Add shared helper for extracting `UserError` from `anyhow::Error`
+- [x] Refactor CLI + MCP call sites to use the shared helper (no behavior change)
+
+## 2. Verification
+- [x] `openspec validate refactor-anyhow-user-error-helper --strict --no-interactive`
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/cli/commands/tui.rs
+++ b/src/cli/commands/tui.rs
@@ -290,7 +290,7 @@ fn refresh_views(app: &mut App) -> anyhow::Result<()> {
 }
 
 fn format_anyhow_error(err: &anyhow::Error) -> String {
-    let Some(user_err) = err.chain().find_map(|e| e.downcast_ref::<UserError>()) else {
+    let Some(user_err) = crate::user_error::find_user_error(err) else {
         return format!("{err:#}");
     };
 

--- a/src/cli/human.rs
+++ b/src/cli/human.rs
@@ -1,7 +1,7 @@
-use crate::user_error::UserError;
+use crate::user_error::find_user_error;
 
 pub(crate) fn print_user_error_human(err: &anyhow::Error) -> bool {
-    let Some(user_err) = err.chain().find_map(|e| e.downcast_ref::<UserError>()) else {
+    let Some(user_err) = find_user_error(err) else {
         return false;
     };
 

--- a/src/cli/json.rs
+++ b/src/cli/json.rs
@@ -1,10 +1,10 @@
 use crate::output::{JsonEnvelope, JsonError, print_json};
-use crate::user_error::UserError;
+use crate::user_error::find_user_error;
 
 use super::args::Cli;
 
 pub(crate) fn print_anyhow_error(cli: &Cli, err: &anyhow::Error) {
-    let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+    let user_err = find_user_error(err);
     let mut envelope = JsonEnvelope::ok(cli.command_name(), serde_json::json!({}));
     envelope.ok = false;
     envelope.errors = vec![JsonError {

--- a/src/mcp/tools/envelope.rs
+++ b/src/mcp/tools/envelope.rs
@@ -3,7 +3,7 @@ use rmcp::model::{CallToolResult, Content};
 use crate::user_error::UserError;
 
 pub(super) fn envelope_from_anyhow_error(command: &str, err: &anyhow::Error) -> serde_json::Value {
-    let user_err = err.chain().find_map(|e| e.downcast_ref::<UserError>());
+    let user_err = crate::user_error::find_user_error(err);
     let (code, message, details) = match user_err {
         Some(user_err) => (
             user_err.code.as_str(),

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -64,3 +64,7 @@ impl UserError {
         }))
     }
 }
+
+pub(crate) fn find_user_error(err: &anyhow::Error) -> Option<&UserError> {
+    err.chain().find_map(|e| e.downcast_ref::<UserError>())
+}


### PR DESCRIPTION
## Summary
Adds a shared helper (`find_user_error`) for extracting embedded `UserError` values from an `anyhow::Error` chain, and refactors CLI + MCP call sites to use it.

Closes #734.

## Spec / OpenSpec
- `openspec/changes/refactor-anyhow-user-error-helper/`

## Notes
- No behavior / schema changes intended (pure refactor).

## Tests
- `just check`
- `openspec validate refactor-anyhow-user-error-helper --strict --no-interactive`
