### PR TITLE
refactor(error): centralize anyhow envelope parts mapping

### DIFF
--- a/openspec/changes/refactor-anyhow-error-parts-helper/.openspec.yaml
+++ b/openspec/changes/refactor-anyhow-error-parts-helper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-23

--- a/openspec/changes/refactor-anyhow-error-parts-helper/README.md
+++ b/openspec/changes/refactor-anyhow-error-parts-helper/README.md
@@ -1,0 +1,3 @@
+# refactor-anyhow-error-parts-helper
+
+Centralize `anyhow::Error` -> `(code, message, details)` mapping for error envelopes.

--- a/openspec/changes/refactor-anyhow-error-parts-helper/proposal.md
+++ b/openspec/changes/refactor-anyhow-error-parts-helper/proposal.md
@@ -1,0 +1,18 @@
+# Change: Centralize `anyhow::Error` -> `(code, message, details)` mapping
+
+## Why
+Both the CLI JSON error envelope and MCP tool error envelope paths map an `anyhow::Error` into a `(code, message, details)` triple (prefer embedded `UserError`, otherwise `E_UNEXPECTED`).
+
+Today this mapping logic is duplicated across callers. Centralizing it reduces duplication and helps keep envelope behavior consistent.
+
+## What Changes
+- Add a shared helper that converts an `anyhow::Error` into `(code, message, details)` suitable for envelopes.
+- Refactor CLI JSON error printing and MCP tool envelope helpers to reuse the shared helper.
+- No behavior / schema changes intended (pure refactor).
+
+## Impact
+- Affected specs: `agentpack-cli`, `agentpack-mcp` (no behavioral change expected).
+- Affected code:
+  - `src/user_error.rs`
+  - `src/cli/json.rs`
+  - `src/mcp/tools/envelope.rs`

--- a/openspec/changes/refactor-anyhow-error-parts-helper/specs/agentpack-cli/spec.md
+++ b/openspec/changes/refactor-anyhow-error-parts-helper/specs/agentpack-cli/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: CLI JSON error envelopes reuse a shared anyhow error-parts helper
+The system SHALL refactor CLI JSON error envelope construction to reuse a shared helper for mapping an `anyhow::Error` into `(code, message, details)` while preserving envelope payloads and schemas.
+
+#### Scenario: CLI JSON error envelopes remain unchanged after refactor
+- **GIVEN** the CLI emits stable `--json` envelopes
+- **WHEN** the `anyhow::Error` -> `(code, message, details)` mapping is centralized behind a shared helper
+- **THEN** CLI JSON error envelopes remain identical at the payload level (`errors[0].code/message/details`)

--- a/openspec/changes/refactor-anyhow-error-parts-helper/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/refactor-anyhow-error-parts-helper/specs/agentpack-mcp/spec.md
@@ -1,0 +1,10 @@
+---
+## ADDED Requirements
+
+### Requirement: MCP tool error envelopes reuse a shared anyhow error-parts helper
+The system SHALL refactor MCP tool error envelope construction to reuse a shared helper for mapping an `anyhow::Error` into `(code, message, details)` while preserving envelope payloads and schemas.
+
+#### Scenario: MCP tool error envelopes remain unchanged after refactor
+- **GIVEN** the MCP server exposes tools with stable behavior and stable `inputSchema` values
+- **WHEN** the `anyhow::Error` -> `(code, message, details)` mapping is centralized behind a shared helper
+- **THEN** MCP tool error envelopes remain identical at the payload level (`errors[0].code/message/details`)

--- a/openspec/changes/refactor-anyhow-error-parts-helper/tasks.md
+++ b/openspec/changes/refactor-anyhow-error-parts-helper/tasks.md
@@ -1,0 +1,9 @@
+---
+## 1. Implementation
+- [x] Add shared helper for mapping `anyhow::Error` into `(code, message, details)` for envelopes
+- [x] Refactor CLI JSON + MCP tool envelope mapping to use the shared helper
+
+## 2. Verification
+- [x] `openspec validate refactor-anyhow-error-parts-helper --strict --no-interactive`
+- [x] `cargo fmt --all`
+- [x] `just check`

--- a/src/mcp/tools/envelope.rs
+++ b/src/mcp/tools/envelope.rs
@@ -3,19 +3,7 @@ use rmcp::model::{CallToolResult, Content};
 use crate::user_error::UserError;
 
 pub(super) fn envelope_from_anyhow_error(command: &str, err: &anyhow::Error) -> serde_json::Value {
-    let user_err = crate::user_error::find_user_error(err);
-    let (code, message, details) = match user_err {
-        Some(user_err) => (
-            user_err.code.as_str(),
-            std::borrow::Cow::Borrowed(user_err.message.as_str()),
-            user_err.details.clone(),
-        ),
-        None => (
-            "E_UNEXPECTED",
-            std::borrow::Cow::Owned(err.to_string()),
-            None,
-        ),
-    };
+    let (code, message, details) = crate::user_error::anyhow_error_parts_for_envelope(err);
 
     envelope_error(command, code, message.as_ref(), details)
 }

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -68,3 +68,25 @@ impl UserError {
 pub(crate) fn find_user_error(err: &anyhow::Error) -> Option<&UserError> {
     err.chain().find_map(|e| e.downcast_ref::<UserError>())
 }
+
+pub(crate) fn anyhow_error_parts_for_envelope(
+    err: &anyhow::Error,
+) -> (
+    &'_ str,
+    std::borrow::Cow<'_, str>,
+    Option<serde_json::Value>,
+) {
+    let user_err = find_user_error(err);
+    match user_err {
+        Some(user_err) => (
+            user_err.code.as_str(),
+            std::borrow::Cow::Borrowed(user_err.message.as_str()),
+            user_err.details.clone(),
+        ),
+        None => (
+            "E_UNEXPECTED",
+            std::borrow::Cow::Owned(err.to_string()),
+            None,
+        ),
+    }
+}


### PR DESCRIPTION
## Summary
Adds a shared helper for mapping `anyhow::Error` into `(code, message, details)` for envelopes, and refactors CLI JSON + MCP tool envelope mapping to reuse it.

Closes #737.

## Spec / OpenSpec
- `openspec/changes/refactor-anyhow-error-parts-helper/`

## Notes
- No behavior / schema changes intended (pure refactor).

## Tests
- `just check`
- `openspec validate refactor-anyhow-error-parts-helper --strict --no-interactive`
