### PR TITLE
docs(demo): add Windows demo_5min.ps1

### DIFF
--- a/docs/tutorials/demo-5min.md
+++ b/docs/tutorials/demo-5min.md
@@ -12,6 +12,12 @@ From the repo root:
 ./scripts/demo_5min.sh
 ```
 
+On Windows (PowerShell):
+
+```powershell
+pwsh -NoProfile -File .\\scripts\\demo_5min.ps1
+```
+
 The script prefers (in order):
 - `AGENTPACK_BIN` (if you set it to a path)
 - `agentpack` on your PATH

--- a/docs/zh-CN/tutorials/demo-5min.md
+++ b/docs/zh-CN/tutorials/demo-5min.md
@@ -12,6 +12,12 @@
 ./scripts/demo_5min.sh
 ```
 
+Windows（PowerShell）下：
+
+```powershell
+pwsh -NoProfile -File .\\scripts\\demo_5min.ps1
+```
+
 脚本会按优先级选择运行方式：
 - 如果设置了 `AGENTPACK_BIN`（一个可执行文件路径），优先用它
 - 否则用 PATH 里的 `agentpack`

--- a/scripts/demo_5min.ps1
+++ b/scripts/demo_5min.ps1
@@ -1,0 +1,76 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+$scriptDir = $PSScriptRoot
+$projectRoot = (Resolve-Path (Join-Path $scriptDir "..")).Path
+
+$exampleRepoSrc = Join-Path $projectRoot "docs/examples/minimal_repo"
+if (-not (Test-Path -Path $exampleRepoSrc -PathType Container)) {
+  [Console]::Error.WriteLine("error: example repo not found: $exampleRepoSrc")
+  exit 1
+}
+
+function Invoke-Agentpack {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$Args
+  )
+
+  if ($env:AGENTPACK_BIN -and (Test-Path -Path $env:AGENTPACK_BIN -PathType Leaf)) {
+    & $env:AGENTPACK_BIN @Args
+    exit $LASTEXITCODE
+  }
+
+  $agentpackCmd = Get-Command agentpack -ErrorAction SilentlyContinue
+  if ($agentpackCmd) {
+    & $agentpackCmd.Source @Args
+    exit $LASTEXITCODE
+  }
+
+  $cargoCmd = Get-Command cargo -ErrorAction SilentlyContinue
+  if ($cargoCmd) {
+    $cargoToml = Join-Path $projectRoot "Cargo.toml"
+    & $cargoCmd.Source run --quiet --manifest-path $cargoToml -- @Args
+    exit $LASTEXITCODE
+  }
+
+  [Console]::Error.WriteLine("error: agentpack not found (set AGENTPACK_BIN, install agentpack, or run with Rust/cargo)")
+  exit 1
+}
+
+$tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("agentpack-demo-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $tmpRoot | Out-Null
+
+try {
+  $demoHome = Join-Path $tmpRoot "home"
+  $demoAgentpackHome = Join-Path $tmpRoot "agentpack_home"
+  $demoWorkspace = Join-Path $tmpRoot "workspace"
+  $demoRepo = Join-Path $tmpRoot "repo"
+
+  foreach ($p in @($demoHome, $demoAgentpackHome, $demoWorkspace, $demoRepo)) {
+    New-Item -ItemType Directory -Force -Path $p | Out-Null
+  }
+
+  Copy-Item -Recurse -Force (Join-Path $exampleRepoSrc "*") $demoRepo
+
+  # Avoid touching real user state on Windows.
+  $env:HOME = $demoHome
+  $env:USERPROFILE = $demoHome
+  $env:AGENTPACK_HOME = $demoAgentpackHome
+
+  [Console]::Error.WriteLine("[demo] HOME=$($env:HOME)")
+  [Console]::Error.WriteLine("[demo] USERPROFILE=$($env:USERPROFILE)")
+  [Console]::Error.WriteLine("[demo] AGENTPACK_HOME=$($env:AGENTPACK_HOME)")
+  [Console]::Error.WriteLine("[demo] repo=$demoRepo")
+  [Console]::Error.WriteLine("[demo] workspace=$demoWorkspace")
+
+  Set-Location $demoWorkspace
+
+  [Console]::Error.WriteLine("[demo] agentpack doctor --json")
+  Invoke-Agentpack @("--repo", $demoRepo, "doctor", "--json")
+
+  [Console]::Error.WriteLine("[demo] agentpack preview --diff --json")
+  Invoke-Agentpack @("--repo", $demoRepo, "preview", "--diff", "--json")
+} finally {
+  Remove-Item -Recurse -Force $tmpRoot -ErrorAction SilentlyContinue
+}

--- a/scripts/demo_5min.ps1
+++ b/scripts/demo_5min.ps1
@@ -18,20 +18,23 @@ function Invoke-Agentpack {
 
   if ($env:AGENTPACK_BIN -and (Test-Path -Path $env:AGENTPACK_BIN -PathType Leaf)) {
     & $env:AGENTPACK_BIN @Args
-    exit $LASTEXITCODE
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    return
   }
 
   $agentpackCmd = Get-Command agentpack -ErrorAction SilentlyContinue
   if ($agentpackCmd) {
     & $agentpackCmd.Source @Args
-    exit $LASTEXITCODE
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    return
   }
 
   $cargoCmd = Get-Command cargo -ErrorAction SilentlyContinue
   if ($cargoCmd) {
     $cargoToml = Join-Path $projectRoot "Cargo.toml"
     & $cargoCmd.Source run --quiet --manifest-path $cargoToml -- @Args
-    exit $LASTEXITCODE
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    return
   }
 
   [Console]::Error.WriteLine("error: agentpack not found (set AGENTPACK_BIN, install agentpack, or run with Rust/cargo)")

--- a/tests/cli_demo_5min_script.rs
+++ b/tests/cli_demo_5min_script.rs
@@ -20,6 +20,10 @@ fn demo_5min_script_succeeds_on_unix() {
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("agentpack doctor --json"));
+    assert!(stderr.contains("agentpack preview --diff --json"));
 }
 
 #[test]
@@ -50,4 +54,8 @@ fn demo_5min_script_succeeds_on_windows() {
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("agentpack doctor --json"));
+    assert!(stderr.contains("agentpack preview --diff --json"));
 }

--- a/tests/cli_demo_5min_script.rs
+++ b/tests/cli_demo_5min_script.rs
@@ -1,12 +1,9 @@
-#[cfg(not(windows))]
 use std::path::Path;
-
-#[cfg(not(windows))]
 use std::process::Command;
 
 #[test]
 #[cfg(not(windows))]
-fn demo_5min_script_succeeds() {
+fn demo_5min_script_succeeds_on_unix() {
     let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/demo_5min.sh");
     assert!(script.exists(), "missing script: {}", script.display());
 
@@ -20,6 +17,36 @@ fn demo_5min_script_succeeds() {
     assert!(
         out.status.success(),
         "demo_5min.sh failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+#[cfg(windows)]
+fn demo_5min_script_succeeds_on_windows() {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/demo_5min.ps1");
+    assert!(script.exists(), "missing script: {}", script.display());
+
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+
+    let out = Command::new("pwsh")
+        .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+        .arg(&script)
+        .env("AGENTPACK_BIN", bin)
+        .output()
+        .or_else(|_| {
+            Command::new("powershell")
+                .args(["-NoProfile", "-ExecutionPolicy", "Bypass", "-File"])
+                .arg(&script)
+                .env("AGENTPACK_BIN", bin)
+                .output()
+        })
+        .expect("run demo_5min.ps1");
+
+    assert!(
+        out.status.success(),
+        "demo_5min.ps1 failed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );


### PR DESCRIPTION
Closes #746.

## Summary
Adds a Windows-friendly `scripts/demo_5min.ps1` (PowerShell) that mirrors `scripts/demo_5min.sh`, and updates the demo docs + CI test to cover Windows.

## Notes
- The script sets both `HOME` and `USERPROFILE` (plus `AGENTPACK_HOME`) to ensure the demo does not touch real user state on Windows.

## Tests
- `cargo test --test cli_demo_5min_script`
- `cargo test --test docs_markdown_links`
