### PR TITLE
feat(json): add E_GIT_WORKTREE_DIRTY for dirty git worktrees

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -554,6 +554,7 @@ Notes:
 Behavior:
 - wraps a recommended multi-machine sync flow with git commands (`pull --rebase` + `push`)
 - does not resolve conflicts automatically; on conflict it fails and asks the user to handle it
+- requires a clean working tree in the config repo (in `--json`, returns `E_GIT_WORKTREE_DIRTY` if dirty)
 
 ### 4.12 `record` / `score`
 
@@ -578,7 +579,7 @@ Event conventions (v0.2):
 
 Notes:
 - In `--json` mode it requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
-- Requires a clean working tree in the config repo; it creates a branch and attempts to commit.
+- Requires a clean working tree in the config repo; it creates a branch and attempts to commit (in `--json`, returns `E_GIT_WORKTREE_DIRTY` if dirty).
   - If git identity is missing and commit fails, agentpack prints guidance and keeps the branch and changes.
 - Current behavior is conservative: only generate proposals for drift that can be safely attributed to a single module.
   - By default it only processes outputs with `module_ids.len() == 1`.

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -18,6 +18,13 @@ Retryable: yes.
 Recommended action: confirm you intend to write, then retry with `--yes`, or drop `--json` and use interactive confirmation.
 Details: usually includes `{"command": "..."}`.
 
+### E_GIT_WORKTREE_DIRTY
+Meaning: the command requires a clean config repo git working tree, but uncommitted changes were detected.
+Typical cases: `sync`, `evolve propose`.
+Retryable: yes.
+Recommended action: commit or stash your changes, then retry.
+Details: includes `{command, repo, repo_posix, hint}`.
+
 ### E_CONFIRM_TOKEN_REQUIRED
 Meaning: in MCP mode (`agentpack mcp serve`), `deploy_apply` was called with `yes=true` but without a `confirm_token` from the `deploy` tool.
 Retryable: yes.

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -1,4 +1,5 @@
 use crate::output::{JsonEnvelope, print_json};
+use crate::user_error::UserError;
 
 use super::Ctx;
 
@@ -15,7 +16,7 @@ pub(crate) fn run(ctx: &Ctx<'_>, rebase: bool, remote: &str) -> anyhow::Result<(
 
     let status = crate::git::git_in(repo_dir, &["status", "--porcelain"])?;
     if !status.trim().is_empty() {
-        anyhow::bail!("refusing to sync with a dirty working tree (commit or stash first)");
+        return Err(UserError::git_worktree_dirty("sync", repo_dir));
     }
 
     let branch = crate::git::git_in(repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;

--- a/src/handlers/evolve.rs
+++ b/src/handlers/evolve.rs
@@ -651,7 +651,7 @@ pub(crate) fn evolve_propose_in(
 
     let status = crate::git::git_in(repo_dir, &["status", "--porcelain"])?;
     if !status.trim().is_empty() {
-        anyhow::bail!("refusing to propose with a dirty working tree (commit or stash first)");
+        return Err(UserError::git_worktree_dirty("evolve propose", repo_dir));
     }
 
     let original = crate::git::git_in(repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -27,6 +27,25 @@ impl UserError {
         self
     }
 
+    pub fn git_worktree_dirty(
+        command: impl Into<String>,
+        repo_dir: &std::path::Path,
+    ) -> anyhow::Error {
+        let command = command.into();
+        anyhow::Error::new(
+            Self::new(
+                "E_GIT_WORKTREE_DIRTY",
+                format!("refusing to run '{command}' with a dirty git working tree (commit or stash first)"),
+            )
+            .with_details(serde_json::json!({
+                "command": command,
+                "repo": repo_dir.display().to_string(),
+                "repo_posix": crate::paths::path_to_posix_string(repo_dir),
+                "hint": "Commit or stash your changes, then retry.",
+            })),
+        )
+    }
+
     pub fn confirm_required(command: impl Into<String>) -> anyhow::Error {
         let command = command.into();
         anyhow::Error::new(

--- a/tests/cli_evolve_propose_git_worktree_dirty.rs
+++ b/tests/cli_evolve_propose_git_worktree_dirty.rs
@@ -1,0 +1,97 @@
+mod journeys;
+
+use journeys::common::{
+    TestEnv, git_ok, git_stdout, run_json_fail, run_json_ok, run_ok, write_file,
+};
+
+#[test]
+fn evolve_propose_returns_stable_error_code_when_git_worktree_dirty() {
+    let env = TestEnv::new();
+
+    run_ok(&env, &["--json", "--yes", "init", "--git"]);
+
+    let repo_dir = env.repo_dir();
+    git_ok(&repo_dir, &["config", "user.email", "test@example.com"]);
+    git_ok(&repo_dir, &["config", "user.name", "Test User"]);
+
+    let codex_home = env.home().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let module_dir = repo_dir.join("modules/prompt/one");
+    std::fs::create_dir_all(&module_dir).expect("create prompt module dir");
+    write_file(&module_dir.join("prompt.md"), "# prompt\n");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["prompt:one"]
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: false
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: "prompt:one"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt/one"
+"#,
+        codex_home.display()
+    );
+    write_file(&repo_dir.join("agentpack.yaml"), &manifest);
+
+    git_ok(&repo_dir, &["add", "-A"]);
+    git_ok(&repo_dir, &["commit", "-m", "chore(test): seed repo"]);
+
+    let deploy = run_json_ok(
+        &env,
+        &["--target", "codex", "deploy", "--apply", "--json", "--yes"],
+    );
+    assert_eq!(deploy["ok"], true);
+
+    let prompt_path = codex_home.join("prompts").join("prompt.md");
+    assert!(prompt_path.is_file(), "expected prompt to be deployed");
+    write_file(&prompt_path, "# prompt edited\n");
+
+    write_file(&repo_dir.join("dirty.txt"), "dirty\n");
+    let status_dirty = git_stdout(&repo_dir, &["status", "--porcelain"]);
+    assert!(!status_dirty.trim().is_empty(), "expected dirty repo");
+
+    let v = run_json_fail(
+        &env,
+        &[
+            "--target",
+            "codex",
+            "evolve",
+            "propose",
+            "--scope",
+            "global",
+            "--module-id",
+            "prompt:one",
+            "--json",
+            "--yes",
+        ],
+    );
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_GIT_WORKTREE_DIRTY");
+    assert_eq!(v["errors"][0]["details"]["command"], "evolve propose");
+    assert!(v["errors"][0]["details"]["repo"].is_string());
+    assert!(v["errors"][0]["details"]["repo_posix"].is_string());
+    assert!(v["errors"][0]["details"]["hint"].is_string());
+}

--- a/tests/cli_sync_git_worktree_dirty.rs
+++ b/tests/cli_sync_git_worktree_dirty.rs
@@ -1,0 +1,32 @@
+mod journeys;
+
+use journeys::common::{TestEnv, git_ok, git_stdout, run_json_fail, run_ok, write_file};
+
+#[test]
+fn sync_returns_stable_error_code_when_git_worktree_dirty() {
+    let env = TestEnv::new();
+
+    run_ok(&env, &["--json", "--yes", "init", "--git"]);
+
+    let repo_dir = env.repo_dir();
+    git_ok(&repo_dir, &["config", "user.email", "test@example.com"]);
+    git_ok(&repo_dir, &["config", "user.name", "Test User"]);
+
+    write_file(&repo_dir.join("seed.txt"), "seed\n");
+    git_ok(&repo_dir, &["add", "-A"]);
+    git_ok(&repo_dir, &["commit", "-m", "chore(test): seed repo"]);
+
+    let status_clean = git_stdout(&repo_dir, &["status", "--porcelain"]);
+    assert!(status_clean.trim().is_empty(), "expected clean repo");
+
+    write_file(&repo_dir.join("dirty.txt"), "dirty\n");
+
+    let v = run_json_fail(&env, &["sync", "--rebase", "--json", "--yes"]);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "sync");
+    assert_eq!(v["errors"][0]["code"], "E_GIT_WORKTREE_DIRTY");
+    assert_eq!(v["errors"][0]["details"]["command"], "sync");
+    assert!(v["errors"][0]["details"]["repo"].is_string());
+    assert!(v["errors"][0]["details"]["repo_posix"].is_string());
+    assert!(v["errors"][0]["details"]["hint"].is_string());
+}


### PR DESCRIPTION
Closes #758.

## Summary
- Adds a new stable `--json` error code `E_GIT_WORKTREE_DIRTY` for commands that refuse to run when the config repo git working tree is dirty.
- Applies to:
  - `agentpack sync`
  - `agentpack evolve propose`
- Adds tests covering both paths.
- Updates docs:
  - `docs/reference/error-codes.md`
  - `docs/SPEC.md`

## Testing
- `cargo test --locked --test cli_sync_git_worktree_dirty --test cli_evolve_propose_git_worktree_dirty`
- `cargo test --locked --test cli_error_codes_doc_sync`
