### PR TITLE
feat(json): add E_GIT_REPO_REQUIRED when config repo lacks git

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -554,6 +554,7 @@ Notes:
 Behavior:
 - wraps a recommended multi-machine sync flow with git commands (`pull --rebase` + `push`)
 - does not resolve conflicts automatically; on conflict it fails and asks the user to handle it
+- requires the config repo to be a git repository (in `--json`, returns `E_GIT_REPO_REQUIRED` if not)
 - requires a clean working tree in the config repo (in `--json`, returns `E_GIT_WORKTREE_DIRTY` if dirty)
 
 ### 4.12 `record` / `score`
@@ -579,6 +580,7 @@ Event conventions (v0.2):
 
 Notes:
 - In `--json` mode it requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
+- Requires the config repo to be a git repository (in `--json`, returns `E_GIT_REPO_REQUIRED` if not).
 - Requires a clean working tree in the config repo; it creates a branch and attempts to commit (in `--json`, returns `E_GIT_WORKTREE_DIRTY` if dirty).
   - If git identity is missing and commit fails, agentpack prints guidance and keeps the branch and changes.
 - Current behavior is conservative: only generate proposals for drift that can be safely attributed to a single module.

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -25,6 +25,13 @@ Retryable: yes.
 Recommended action: commit or stash your changes, then retry.
 Details: includes `{command, repo, repo_posix, hint}`.
 
+### E_GIT_REPO_REQUIRED
+Meaning: the command requires the config repo to be a git repository, but `.git` was not found.
+Typical cases: `sync`, `evolve propose`.
+Retryable: yes.
+Recommended action: initialize git in the config repo (e.g. `agentpack init --git`), then retry.
+Details: includes `{command, repo, repo_posix, hint}`.
+
 ### E_CONFIRM_TOKEN_REQUIRED
 Meaning: in MCP mode (`agentpack mcp serve`), `deploy_apply` was called with `yes=true` but without a `confirm_token` from the `deploy` tool.
 Retryable: yes.

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -8,10 +8,7 @@ pub(crate) fn run(ctx: &Ctx<'_>, rebase: bool, remote: &str) -> anyhow::Result<(
 
     let repo_dir = ctx.repo.repo_dir.as_path();
     if !repo_dir.join(".git").exists() {
-        anyhow::bail!(
-            "config repo is not a git repository: {}",
-            repo_dir.display()
-        );
+        return Err(UserError::git_repo_required("sync", repo_dir));
     }
 
     let status = crate::git::git_in(repo_dir, &["status", "--porcelain"])?;

--- a/src/handlers/evolve.rs
+++ b/src/handlers/evolve.rs
@@ -643,10 +643,7 @@ pub(crate) fn evolve_propose_in(
 
     let repo_dir = engine.repo.repo_dir.as_path();
     if !repo_dir.join(".git").exists() {
-        anyhow::bail!(
-            "config repo is not a git repository: {}",
-            repo_dir.display()
-        );
+        return Err(UserError::git_repo_required("evolve propose", repo_dir));
     }
 
     let status = crate::git::git_in(repo_dir, &["status", "--porcelain"])?;

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -27,6 +27,28 @@ impl UserError {
         self
     }
 
+    pub fn git_repo_required(
+        command: impl Into<String>,
+        repo_dir: &std::path::Path,
+    ) -> anyhow::Error {
+        let command = command.into();
+        anyhow::Error::new(
+            Self::new(
+                "E_GIT_REPO_REQUIRED",
+                format!(
+                    "config repo is not a git repository (required for '{command}'): {}",
+                    repo_dir.display()
+                ),
+            )
+            .with_details(serde_json::json!({
+                "command": command,
+                "repo": repo_dir.display().to_string(),
+                "repo_posix": crate::paths::path_to_posix_string(repo_dir),
+                "hint": "Initialize git in the config repo (agentpack init --git), or run the command in a git-backed config repo.",
+            })),
+        )
+    }
+
     pub fn git_worktree_dirty(
         command: impl Into<String>,
         repo_dir: &std::path::Path,

--- a/tests/cli_evolve_propose_git_repo_required.rs
+++ b/tests/cli_evolve_propose_git_repo_required.rs
@@ -1,0 +1,92 @@
+mod journeys;
+
+use journeys::common::{TestEnv, run_json_fail, run_json_ok, run_ok, write_file};
+
+#[test]
+fn evolve_propose_returns_stable_error_code_when_config_repo_is_not_git() {
+    let env = TestEnv::new();
+    run_ok(&env, &["--json", "--yes", "init"]);
+
+    let repo_dir = env.repo_dir();
+    assert!(
+        !repo_dir.join(".git").exists(),
+        "expected config repo to not be a git repository"
+    );
+
+    let codex_home = env.home().join("codex_home");
+    std::fs::create_dir_all(&codex_home).expect("create codex_home");
+
+    let module_dir = repo_dir.join("modules/prompt/one");
+    std::fs::create_dir_all(&module_dir).expect("create prompt module dir");
+    write_file(&module_dir.join("prompt.md"), "# prompt\n");
+
+    let manifest = format!(
+        r#"version: 1
+
+profiles:
+  default:
+    include_tags: []
+    include_modules: ["prompt:one"]
+    exclude_modules: []
+
+targets:
+  codex:
+    mode: files
+    scope: user
+    options:
+      codex_home: '{}'
+      write_agents_global: false
+      write_agents_repo_root: false
+      write_user_prompts: true
+      write_user_skills: false
+      write_repo_skills: false
+
+modules:
+  - id: "prompt:one"
+    type: prompt
+    enabled: true
+    tags: []
+    targets: ["codex"]
+    source:
+      local_path:
+        path: "modules/prompt/one"
+"#,
+        codex_home.display()
+    );
+    write_file(&repo_dir.join("agentpack.yaml"), &manifest);
+
+    // Deploy once so drift exists under the target root.
+    let deploy = run_json_ok(
+        &env,
+        &["--target", "codex", "deploy", "--apply", "--json", "--yes"],
+    );
+    assert_eq!(deploy["ok"], true);
+
+    let prompt_path = codex_home.join("prompts").join("prompt.md");
+    assert!(prompt_path.is_file(), "expected prompt to be deployed");
+
+    // Create proposable drift (single-module output).
+    write_file(&prompt_path, "# prompt edited\n");
+
+    let v = run_json_fail(
+        &env,
+        &[
+            "--target",
+            "codex",
+            "evolve",
+            "propose",
+            "--scope",
+            "global",
+            "--module-id",
+            "prompt:one",
+            "--json",
+            "--yes",
+        ],
+    );
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_GIT_REPO_REQUIRED");
+    assert_eq!(v["errors"][0]["details"]["command"], "evolve propose");
+    assert!(v["errors"][0]["details"]["repo"].is_string());
+    assert!(v["errors"][0]["details"]["repo_posix"].is_string());
+    assert!(v["errors"][0]["details"]["hint"].is_string());
+}

--- a/tests/cli_sync_git_repo_required.rs
+++ b/tests/cli_sync_git_repo_required.rs
@@ -1,0 +1,24 @@
+mod journeys;
+
+use journeys::common::{TestEnv, run_json_fail, run_ok};
+
+#[test]
+fn sync_returns_stable_error_code_when_config_repo_is_not_git() {
+    let env = TestEnv::new();
+    run_ok(&env, &["--json", "--yes", "init"]);
+
+    let repo_dir = env.repo_dir();
+    assert!(
+        !repo_dir.join(".git").exists(),
+        "expected config repo to not be a git repository"
+    );
+
+    let v = run_json_fail(&env, &["sync", "--rebase", "--json", "--yes"]);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "sync");
+    assert_eq!(v["errors"][0]["code"], "E_GIT_REPO_REQUIRED");
+    assert_eq!(v["errors"][0]["details"]["command"], "sync");
+    assert!(v["errors"][0]["details"]["repo"].is_string());
+    assert!(v["errors"][0]["details"]["repo_posix"].is_string());
+    assert!(v["errors"][0]["details"]["hint"].is_string());
+}


### PR DESCRIPTION
Closes #760.

## Summary
- Adds a new stable `--json` error code: `E_GIT_REPO_REQUIRED`.
- Emits it (instead of `E_UNEXPECTED`) when the config repo is not a git repository for:
  - `agentpack sync`
  - `agentpack evolve propose`
- Updates docs:
  - `docs/reference/error-codes.md`
  - `docs/SPEC.md`
- Adds tests covering both paths.

## Testing
- `cargo test --locked --test cli_sync_git_repo_required --test cli_evolve_propose_git_repo_required`
- `cargo test --locked --test cli_error_codes_doc_sync`
