### PR TITLE
feat(json): add E_GIT_DETACHED_HEAD for sync detached HEAD

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -556,6 +556,7 @@ Behavior:
 - does not resolve conflicts automatically; on conflict it fails and asks the user to handle it
 - requires the config repo to be a git repository (in `--json`, returns `E_GIT_REPO_REQUIRED` if not)
 - requires a clean working tree in the config repo (in `--json`, returns `E_GIT_WORKTREE_DIRTY` if dirty)
+- refuses to sync on detached HEAD (in `--json`, returns `E_GIT_DETACHED_HEAD`)
 
 ### 4.12 `record` / `score`
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -32,6 +32,13 @@ Retryable: yes.
 Recommended action: initialize git in the config repo (e.g. `agentpack init --git`), then retry.
 Details: includes `{command, repo, repo_posix, hint}`.
 
+### E_GIT_DETACHED_HEAD
+Meaning: the command refused to run because the config repo is on a detached HEAD.
+Typical cases: `sync`.
+Retryable: yes.
+Recommended action: check out a branch (not detached HEAD), then retry.
+Details: includes `{command, repo, repo_posix, hint}`.
+
 ### E_CONFIRM_TOKEN_REQUIRED
 Meaning: in MCP mode (`agentpack mcp serve`), `deploy_apply` was called with `yes=true` but without a `confirm_token` from the `deploy` tool.
 Retryable: yes.

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -19,7 +19,7 @@ pub(crate) fn run(ctx: &Ctx<'_>, rebase: bool, remote: &str) -> anyhow::Result<(
     let branch = crate::git::git_in(repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;
     let branch = branch.trim();
     if branch == "HEAD" {
-        anyhow::bail!("refusing to sync on detached HEAD");
+        return Err(UserError::git_detached_head("sync", repo_dir));
     }
 
     // Ensure remote exists.

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -49,6 +49,25 @@ impl UserError {
         )
     }
 
+    pub fn git_detached_head(
+        command: impl Into<String>,
+        repo_dir: &std::path::Path,
+    ) -> anyhow::Error {
+        let command = command.into();
+        anyhow::Error::new(
+            Self::new(
+                "E_GIT_DETACHED_HEAD",
+                format!("refusing to run '{command}' on detached HEAD"),
+            )
+            .with_details(serde_json::json!({
+                "command": command,
+                "repo": repo_dir.display().to_string(),
+                "repo_posix": crate::paths::path_to_posix_string(repo_dir),
+                "hint": "Check out a branch (not detached HEAD), then retry.",
+            })),
+        )
+    }
+
     pub fn git_worktree_dirty(
         command: impl Into<String>,
         repo_dir: &std::path::Path,

--- a/tests/cli_sync_git_detached_head.rs
+++ b/tests/cli_sync_git_detached_head.rs
@@ -1,0 +1,39 @@
+mod journeys;
+
+use journeys::common::{TestEnv, git_ok, git_stdout, run_json_fail, run_ok, write_file};
+
+#[test]
+fn sync_returns_stable_error_code_when_on_detached_head() {
+    let env = TestEnv::new();
+
+    run_ok(&env, &["--json", "--yes", "init", "--git"]);
+
+    let repo_dir = env.repo_dir();
+    git_ok(&repo_dir, &["config", "user.email", "test@example.com"]);
+    git_ok(&repo_dir, &["config", "user.name", "Test User"]);
+
+    write_file(&repo_dir.join("seed.txt"), "seed\n");
+    git_ok(&repo_dir, &["add", "-A"]);
+    git_ok(&repo_dir, &["commit", "-m", "chore(test): seed repo"]);
+
+    let commit = git_stdout(&repo_dir, &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    assert!(!commit.is_empty());
+
+    git_ok(&repo_dir, &["checkout", commit.as_str()]);
+    let head = git_stdout(&repo_dir, &["rev-parse", "--abbrev-ref", "HEAD"]);
+    assert_eq!(head.trim(), "HEAD", "expected detached HEAD");
+
+    let status_clean = git_stdout(&repo_dir, &["status", "--porcelain"]);
+    assert!(status_clean.trim().is_empty(), "expected clean repo");
+
+    let v = run_json_fail(&env, &["sync", "--rebase", "--json", "--yes"]);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "sync");
+    assert_eq!(v["errors"][0]["code"], "E_GIT_DETACHED_HEAD");
+    assert_eq!(v["errors"][0]["details"]["command"], "sync");
+    assert!(v["errors"][0]["details"]["repo"].is_string());
+    assert!(v["errors"][0]["details"]["repo_posix"].is_string());
+    assert!(v["errors"][0]["details"]["hint"].is_string());
+}


### PR DESCRIPTION
Closes #762.

## Summary
- Adds a new stable `--json` error code: `E_GIT_DETACHED_HEAD`.
- Emits it for `agentpack sync` when the config repo is on a detached HEAD.
- Updates docs:
  - `docs/reference/error-codes.md`
  - `docs/SPEC.md`
- Adds an integration test that detaches HEAD and asserts the error code.

## Testing
- `cargo test --locked --test cli_sync_git_detached_head`
- `cargo test --locked --test cli_error_codes_doc_sync`
