### PR TITLE
feat(json): add E_GIT_REMOTE_MISSING for sync

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -557,6 +557,7 @@ Behavior:
 - requires the config repo to be a git repository (in `--json`, returns `E_GIT_REPO_REQUIRED` if not)
 - requires a clean working tree in the config repo (in `--json`, returns `E_GIT_WORKTREE_DIRTY` if dirty)
 - refuses to sync on detached HEAD (in `--json`, returns `E_GIT_DETACHED_HEAD`)
+- requires the configured remote to exist in the config repo (in `--json`, returns `E_GIT_REMOTE_MISSING` if not)
 
 ### 4.12 `record` / `score`
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -39,6 +39,13 @@ Retryable: yes.
 Recommended action: check out a branch (not detached HEAD), then retry.
 Details: includes `{command, repo, repo_posix, hint}`.
 
+### E_GIT_REMOTE_MISSING
+Meaning: the command requires a configured git remote in the config repo, but it was not found.
+Typical cases: `sync`.
+Retryable: yes.
+Recommended action: set the remote via `agentpack remote set <url> --name <remote>` (or `git remote add <remote> <url>`), then retry.
+Details: includes `{command, repo, repo_posix, remote, hint}`.
+
 ### E_CONFIRM_TOKEN_REQUIRED
 Meaning: in MCP mode (`agentpack mcp serve`), `deploy_apply` was called with `yes=true` but without a `confirm_token` from the `deploy` tool.
 Retryable: yes.

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -23,7 +23,10 @@ pub(crate) fn run(ctx: &Ctx<'_>, rebase: bool, remote: &str) -> anyhow::Result<(
     }
 
     // Ensure remote exists.
-    let _ = crate::git::git_in(repo_dir, &["remote", "get-url", remote])?;
+    let remotes = crate::git::git_in(repo_dir, &["remote"])?;
+    if !remotes.lines().any(|line| line.trim() == remote) {
+        return Err(UserError::git_remote_missing("sync", repo_dir, remote));
+    }
 
     let mut ran = Vec::new();
     if rebase {

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -68,6 +68,27 @@ impl UserError {
         )
     }
 
+    pub fn git_remote_missing(
+        command: impl Into<String>,
+        repo_dir: &std::path::Path,
+        remote: &str,
+    ) -> anyhow::Error {
+        let command = command.into();
+        anyhow::Error::new(
+            Self::new(
+                "E_GIT_REMOTE_MISSING",
+                format!("git remote '{remote}' not found (required for '{command}')"),
+            )
+            .with_details(serde_json::json!({
+                "command": command,
+                "repo": repo_dir.display().to_string(),
+                "repo_posix": crate::paths::path_to_posix_string(repo_dir),
+                "remote": remote,
+                "hint": format!("Set the remote via `agentpack remote set <url> --name {remote}` (or `git remote add {remote} <url>`), then retry."),
+            })),
+        )
+    }
+
     pub fn git_worktree_dirty(
         command: impl Into<String>,
         repo_dir: &std::path::Path,

--- a/tests/cli_sync_git_remote_missing.rs
+++ b/tests/cli_sync_git_remote_missing.rs
@@ -1,0 +1,40 @@
+mod journeys;
+
+use journeys::common::{TestEnv, git_ok, git_stdout, run_json_fail, run_ok};
+
+#[test]
+fn sync_returns_stable_error_code_when_remote_missing() {
+    let env = TestEnv::new();
+
+    run_ok(&env, &["--json", "--yes", "init", "--git"]);
+
+    let repo_dir = env.repo_dir();
+    git_ok(&repo_dir, &["config", "user.email", "test@example.com"]);
+    git_ok(&repo_dir, &["config", "user.name", "Test User"]);
+
+    git_ok(&repo_dir, &["add", "-A"]);
+    git_ok(&repo_dir, &["commit", "-m", "chore(test): seed repo"]);
+
+    let remotes = git_stdout(&repo_dir, &["remote"]);
+    if remotes.lines().any(|line| line.trim() == "origin") {
+        git_ok(&repo_dir, &["remote", "remove", "origin"]);
+    }
+    let remotes = git_stdout(&repo_dir, &["remote"]);
+    assert!(
+        !remotes.lines().any(|line| line.trim() == "origin"),
+        "expected origin remote to be missing"
+    );
+
+    let status_clean = git_stdout(&repo_dir, &["status", "--porcelain"]);
+    assert!(status_clean.trim().is_empty(), "expected clean repo");
+
+    let v = run_json_fail(&env, &["sync", "--rebase", "--json", "--yes"]);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "sync");
+    assert_eq!(v["errors"][0]["code"], "E_GIT_REMOTE_MISSING");
+    assert_eq!(v["errors"][0]["details"]["command"], "sync");
+    assert_eq!(v["errors"][0]["details"]["remote"], "origin");
+    assert!(v["errors"][0]["details"]["repo"].is_string());
+    assert!(v["errors"][0]["details"]["repo_posix"].is_string());
+    assert!(v["errors"][0]["details"]["hint"].is_string());
+}


### PR DESCRIPTION
Closes #764.

## What
- Emit stable `E_GIT_REMOTE_MISSING` when `agentpack sync` is run with a missing configured git remote.

## Why
- Missing remotes are a common precondition failure; scripts should not have to parse stderr / `E_UNEXPECTED`.

## Tests
- `cargo test --locked --test cli_sync_git_remote_missing`
- `cargo test --locked --test cli_error_codes_doc_sync`