### PR TITLE
feat(json): add E_GIT_NOT_FOUND when git is missing

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -558,6 +558,7 @@ Behavior:
 - requires a clean working tree in the config repo (in `--json`, returns `E_GIT_WORKTREE_DIRTY` if dirty)
 - refuses to sync on detached HEAD (in `--json`, returns `E_GIT_DETACHED_HEAD`)
 - requires the configured remote to exist in the config repo (in `--json`, returns `E_GIT_REMOTE_MISSING` if not)
+- requires `git` to be installed and available on PATH (in `--json`, returns `E_GIT_NOT_FOUND` if not)
 
 ### 4.12 `record` / `score`
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -46,6 +46,13 @@ Retryable: yes.
 Recommended action: set the remote via `agentpack remote set <url> --name <remote>` (or `git remote add <remote> <url>`), then retry.
 Details: includes `{command, repo, repo_posix, remote, hint}`.
 
+### E_GIT_NOT_FOUND
+Meaning: `git` executable was not found (not installed or not on PATH), but the command requires git operations.
+Typical cases: any command that shells out to `git` (e.g. `sync`, `evolve propose`, git-sourced module workflows).
+Retryable: yes.
+Recommended action: install git and ensure `git` is available on PATH, then retry.
+Details: includes `{cwd, cwd_posix, args, hint}`.
+
 ### E_CONFIRM_TOKEN_REQUIRED
 Meaning: in MCP mode (`agentpack mcp serve`), `deploy_apply` was called with `yes=true` but without a `confirm_token` from the `deploy` tool.
 Retryable: yes.

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -89,6 +89,21 @@ impl UserError {
         )
     }
 
+    pub fn git_not_found(cwd: &std::path::Path, args: &[&str]) -> anyhow::Error {
+        anyhow::Error::new(
+            Self::new(
+                "E_GIT_NOT_FOUND",
+                "git executable not found (is git installed and on PATH?)",
+            )
+            .with_details(serde_json::json!({
+                "cwd": cwd.display().to_string(),
+                "cwd_posix": crate::paths::path_to_posix_string(cwd),
+                "args": args.iter().map(|s| s.to_string()).collect::<Vec<String>>(),
+                "hint": "Install git and ensure `git` is available on PATH, then retry.",
+            })),
+        )
+    }
+
     pub fn git_worktree_dirty(
         command: impl Into<String>,
         repo_dir: &std::path::Path,

--- a/tests/cli_git_not_found.rs
+++ b/tests/cli_git_not_found.rs
@@ -1,0 +1,26 @@
+mod journeys;
+
+use journeys::common::{TestEnv, parse_stdout_json, run_ok};
+
+#[test]
+fn stable_error_code_when_git_executable_missing() {
+    let env = TestEnv::new();
+
+    run_ok(&env, &["--json", "--yes", "init", "--git"]);
+
+    let mut cmd = env.agentpack();
+    cmd.env("PATH", "");
+    cmd.args(["sync", "--rebase", "--json", "--yes"]);
+
+    let out = cmd.output().expect("run agentpack");
+    assert!(!out.status.success(), "expected command to fail");
+
+    let v = parse_stdout_json(&out);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "sync");
+    assert_eq!(v["errors"][0]["code"], "E_GIT_NOT_FOUND");
+    assert!(v["errors"][0]["details"]["cwd"].is_string());
+    assert!(v["errors"][0]["details"]["cwd_posix"].is_string());
+    assert!(v["errors"][0]["details"]["args"].is_array());
+    assert!(v["errors"][0]["details"]["hint"].is_string());
+}


### PR DESCRIPTION
Closes #768.

## What
- Emits a stable `--json` error code (`E_GIT_NOT_FOUND`) when spawning `git` fails with `ErrorKind::NotFound`.

## Why
- Avoids `E_UNEXPECTED` for a common precondition failure in automation.

## Tests
- `cargo test --locked --test cli_git_not_found`
- `cargo test --locked --test cli_error_codes_doc_sync`