### PR TITLE
feat(json): add command_id/command_path to --json envelope

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -815,6 +815,8 @@ All `--json` outputs must include:
 - `schema_version: number`
 - `ok: boolean`
 - `command: string`
+- `command_id: string` (stable command id; aligns with `agentpack help --json` ids)
+- `command_path: [string]` (tokenized `command_id`)
 - `version: string` (agentpack version)
 - `data: object` (empty object on failure)
 - `warnings: [string]`

--- a/docs/reference/json-api.md
+++ b/docs/reference/json-api.md
@@ -20,6 +20,8 @@ All `--json` outputs include:
 - `schema_version`: number
 - `ok`: boolean
 - `command`: string
+- `command_id`: string
+- `command_path`: string[]
 - `version`: string (agentpack version)
 - `data`: object (success payload; empty object on failure)
 - `warnings`: string[]
@@ -31,6 +33,8 @@ Failure example:
   "schema_version": 1,
   "ok": false,
   "command": "deploy",
+  "command_id": "deploy --apply",
+  "command_path": ["deploy", "--apply"],
   "version": "0.8.0",
   "data": {},
   "warnings": [],

--- a/openspec/changes/add-json-command-metadata/proposal.md
+++ b/openspec/changes/add-json-command-metadata/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add `command_id` and `command_path` to the `--json` envelope
+
+## Why
+Automation needs to reliably identify the invoked command, including subcommands and mutating variants like `deploy --apply` / `doctor --fix`.
+
+Today the envelope’s `command` field is not sufficient for this:
+- Many success envelopes use dotted leaf names (e.g. `overlay.path`, `remote.set`).
+- The error envelope currently only includes the top-level command (e.g. `overlay`, `remote`, `evolve`), losing subcommand specificity.
+
+Adding explicit command metadata fields makes `--json` outputs easier to orchestrate without breaking existing parsers.
+
+## What Changes
+- Add two new top-level fields to the `schema_version=1` envelope:
+  - `command_id: string` (stable, space-separated command id aligned with `help --json` ids and mutating guardrails, e.g. `remote set`, `deploy --apply`)
+  - `command_path: string[]` (tokenized `command_id`)
+- Populate these fields for both success and error envelopes.
+- Update `agentpack schema --json`, `docs/SPEC.md`, and `docs/reference/json-api.md`.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Affects stable API output in `--json` mode; requires updating golden snapshots and docs.
+
+## Acceptance
+- All `--json` outputs include `command_id` and `command_path`.
+- For subcommands, `command_id` reflects the full leaf id (e.g. `remote set`), even on failure.
+- For mutating variants, `command_id` reflects the variant id used by guardrails (e.g. `deploy --apply`, `doctor --fix`, `import --apply`).

--- a/openspec/changes/add-json-command-metadata/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-json-command-metadata/specs/agentpack-cli/spec.md
@@ -1,0 +1,20 @@
+# agentpack-cli (delta)
+
+## ADDED Requirements
+
+### Requirement: JSON envelope includes command metadata
+When invoked with `--json`, the system SHALL include `command_id` and `command_path` as top-level envelope fields:
+- `command_id`: stable command id (space-separated), aligned with `help --json` command ids and mutating guardrails
+- `command_path`: tokenized command id (array of strings)
+
+#### Scenario: error envelope includes subcommand id
+- **WHEN** the user runs `agentpack remote set https://example.invalid/repo.git --json` without `--yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `command_id == "remote set"`
+- **AND** `command_path == ["remote", "set"]`
+
+#### Scenario: error envelope includes mutating variant id
+- **WHEN** the user runs `agentpack doctor --fix --json` without `--yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `command_id == "doctor --fix"`
+- **AND** `command_path == ["doctor", "--fix"]`

--- a/openspec/changes/add-json-command-metadata/tasks.md
+++ b/openspec/changes/add-json-command-metadata/tasks.md
@@ -1,0 +1,22 @@
+## 1. Implementation
+
+### 1.1 CLI command identification
+- [ ] Add `Cli::command_id()` and `Cli::command_path()` helpers.
+- [ ] Ensure mutating variants are represented as stable ids (`deploy --apply`, `doctor --fix`, `import --apply`).
+
+### 1.2 JSON envelope fields
+- [ ] Add `command_id` and `command_path` to `JsonEnvelope` (additive).
+- [ ] Populate these fields for all success envelopes.
+- [ ] Populate these fields for the error envelope (`print_anyhow_error`).
+
+### 1.3 Docs and schema
+- [ ] Update `agentpack schema --json` envelope field list.
+- [ ] Update `docs/SPEC.md` and `docs/reference/json-api.md`.
+
+### 1.4 Tests
+- [ ] Update golden snapshot `tests/golden/schema_json_data.json`.
+- [ ] Add an integration test asserting `command_id`/`command_path` on an error path for a subcommand (e.g. `remote set --json` without `--yes`).
+
+### 1.5 Validation
+- [ ] Run `openspec validate add-json-command-metadata --strict --no-interactive`.
+- [ ] Run `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all --locked`.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -403,6 +403,81 @@ pub enum EvolveCommands {
 }
 
 impl Cli {
+    pub(crate) fn command_path(&self) -> Vec<String> {
+        match &self.command {
+            Commands::Init { .. } => vec!["init".to_string()],
+            Commands::Import { apply, .. } => {
+                let mut out = vec!["import".to_string()];
+                if *apply && !self.dry_run {
+                    out.push("--apply".to_string());
+                }
+                out
+            }
+            Commands::Help { .. } => vec!["help".to_string()],
+            Commands::Schema => vec!["schema".to_string()],
+            Commands::Update { .. } => vec!["update".to_string()],
+            Commands::Add { .. } => vec!["add".to_string()],
+            Commands::Remove { .. } => vec!["remove".to_string()],
+            Commands::Lock => vec!["lock".to_string()],
+            Commands::Fetch => vec!["fetch".to_string()],
+            Commands::Preview { .. } => vec!["preview".to_string()],
+            Commands::Plan => vec!["plan".to_string()],
+            Commands::Diff => vec!["diff".to_string()],
+            Commands::Deploy { apply, .. } => {
+                let mut out = vec!["deploy".to_string()];
+                if *apply && !self.dry_run {
+                    out.push("--apply".to_string());
+                }
+                out
+            }
+            Commands::Status { .. } => vec!["status".to_string()],
+            #[cfg(feature = "tui")]
+            Commands::Tui { .. } => vec!["tui".to_string()],
+            Commands::Mcp { command } => match command {
+                McpCommands::Serve => vec!["mcp".to_string(), "serve".to_string()],
+            },
+            Commands::Policy { command } => match command {
+                PolicyCommands::Lint => vec!["policy".to_string(), "lint".to_string()],
+                PolicyCommands::Audit => vec!["policy".to_string(), "audit".to_string()],
+                PolicyCommands::Lock => vec!["policy".to_string(), "lock".to_string()],
+            },
+            Commands::Doctor { fix } => {
+                let mut out = vec!["doctor".to_string()];
+                if *fix {
+                    out.push("--fix".to_string());
+                }
+                out
+            }
+            Commands::Remote { command } => match command {
+                RemoteCommands::Set { .. } => vec!["remote".to_string(), "set".to_string()],
+            },
+            Commands::Sync { .. } => vec!["sync".to_string()],
+            Commands::Record => vec!["record".to_string()],
+            Commands::Score => vec!["score".to_string()],
+            Commands::Explain { command } => match command {
+                ExplainCommands::Plan => vec!["explain".to_string(), "plan".to_string()],
+                ExplainCommands::Diff => vec!["explain".to_string(), "diff".to_string()],
+                ExplainCommands::Status => vec!["explain".to_string(), "status".to_string()],
+            },
+            Commands::Evolve { command } => match command {
+                EvolveCommands::Propose { .. } => vec!["evolve".to_string(), "propose".to_string()],
+                EvolveCommands::Restore { .. } => vec!["evolve".to_string(), "restore".to_string()],
+            },
+            Commands::Completions { .. } => vec!["completions".to_string()],
+            Commands::Rollback { .. } => vec!["rollback".to_string()],
+            Commands::Bootstrap { .. } => vec!["bootstrap".to_string()],
+            Commands::Overlay { command } => match command {
+                OverlayCommands::Edit { .. } => vec!["overlay".to_string(), "edit".to_string()],
+                OverlayCommands::Rebase { .. } => vec!["overlay".to_string(), "rebase".to_string()],
+                OverlayCommands::Path { .. } => vec!["overlay".to_string(), "path".to_string()],
+            },
+        }
+    }
+
+    pub(crate) fn command_id(&self) -> String {
+        self.command_path().join(" ")
+    }
+
     pub(crate) fn command_name(&self) -> String {
         match &self.command {
             Commands::Init { .. } => "init",

--- a/src/cli/commands/add.rs
+++ b/src/cli/commands/add.rs
@@ -44,7 +44,8 @@ pub(crate) fn run(
                 "manifest": ctx.repo.manifest_path.clone(),
                 "manifest_posix": crate::paths::path_to_posix_string(&ctx.repo.manifest_path),
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!("Added module {module_id}");

--- a/src/cli/commands/bootstrap.rs
+++ b/src/cli/commands/bootstrap.rs
@@ -397,7 +397,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, scope: BootstrapScope) -> anyhow::Result<()> {
                     "changes": plan.changes,
                     "summary": plan.summary,
                 }),
-            );
+            )
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
             print_json(&envelope)?;
         }
         return Ok(());
@@ -415,7 +416,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, scope: BootstrapScope) -> anyhow::Result<()> {
                     "changes": plan.changes,
                     "summary": plan.summary,
                 }),
-            );
+            )
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
             print_json(&envelope)?;
         } else {
             println!("No changes");
@@ -445,7 +447,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, scope: BootstrapScope) -> anyhow::Result<()> {
                 "changes": plan.changes,
                 "summary": plan.summary,
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!("Bootstrapped. Snapshot: {}", snapshot.id);

--- a/src/cli/commands/deploy.rs
+++ b/src/cli/commands/deploy.rs
@@ -34,7 +34,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, apply: bool, adopt: bool) -> anyhow::Result<()>
     if !will_apply {
         if ctx.cli.json {
             let data = deploy_json_data_dry_run(ctx.cli.profile.as_str(), targets, plan);
-            let mut envelope = JsonEnvelope::ok("deploy", data);
+            let mut envelope = JsonEnvelope::ok("deploy", data)
+                .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
             envelope.warnings = warnings;
             print_json(&envelope)?;
         }
@@ -77,7 +78,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, apply: bool, adopt: bool) -> anyhow::Result<()>
         DeployApplyOutcome::NoChanges => {
             if ctx.cli.json {
                 let data = deploy_json_data_no_changes(ctx.cli.profile.as_str(), targets, plan);
-                let mut envelope = JsonEnvelope::ok("deploy", data);
+                let mut envelope = JsonEnvelope::ok("deploy", data)
+                    .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
                 envelope.warnings = warnings;
                 print_json(&envelope)?;
             } else {
@@ -89,7 +91,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, apply: bool, adopt: bool) -> anyhow::Result<()>
             if ctx.cli.json {
                 let data =
                     deploy_json_data_applied(ctx.cli.profile.as_str(), targets, plan, snapshot_id);
-                let mut envelope = JsonEnvelope::ok("deploy", data);
+                let mut envelope = JsonEnvelope::ok("deploy", data)
+                    .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
                 envelope.warnings = warnings;
                 print_json(&envelope)?;
             } else {

--- a/src/cli/commands/diff.rs
+++ b/src/cli/commands/diff.rs
@@ -20,7 +20,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
 
     if ctx.cli.json {
         let data = plan_json_data(ctx.cli.profile.as_str(), targets, plan);
-        let mut envelope = JsonEnvelope::ok("diff", data);
+        let mut envelope = JsonEnvelope::ok("diff", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
         return Ok(());

--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -28,7 +28,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, fix: bool) -> anyhow::Result<()> {
 
     if ctx.cli.json {
         let data = doctor_json_data(machine_id, checks, gitignore_fixes, &next_actions.json)?;
-        let mut envelope = JsonEnvelope::ok("doctor", data);
+        let mut envelope = JsonEnvelope::ok("doctor", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
     } else {

--- a/src/cli/commands/evolve.rs
+++ b/src/cli/commands/evolve.rs
@@ -87,7 +87,8 @@ fn evolve_propose(
             if cli.json {
                 let data =
                     evolve_propose_json_data_noop(report.reason, report.summary, report.skipped);
-                let mut envelope = JsonEnvelope::ok("evolve.propose", data);
+                let mut envelope = JsonEnvelope::ok("evolve.propose", data)
+                    .with_command_meta(cli.command_id(), cli.command_path());
                 envelope.warnings = report.warnings;
                 print_json(&envelope)?;
             } else {
@@ -139,7 +140,8 @@ fn evolve_propose(
                     report.skipped,
                     report.summary,
                 );
-                let mut envelope = JsonEnvelope::ok("evolve.propose", data);
+                let mut envelope = JsonEnvelope::ok("evolve.propose", data)
+                    .with_command_meta(cli.command_id(), cli.command_path());
                 envelope.warnings = report.warnings;
                 print_json(&envelope)?;
             } else {
@@ -196,7 +198,8 @@ fn evolve_propose(
                     report.files_posix,
                     report.committed,
                 );
-                let envelope = JsonEnvelope::ok("evolve.propose", data);
+                let envelope = JsonEnvelope::ok("evolve.propose", data)
+                    .with_command_meta(cli.command_id(), cli.command_path());
                 print_json(&envelope)?;
             } else {
                 println!("Created proposal branch: {}", report.branch);
@@ -255,7 +258,8 @@ fn evolve_restore(
 
     if cli.json {
         let data = evolve_restore_json_data(report.restored, report.summary, report.reason);
-        let mut envelope = JsonEnvelope::ok("evolve.restore", data);
+        let mut envelope = JsonEnvelope::ok("evolve.restore", data)
+            .with_command_meta(cli.command_id(), cli.command_path());
         envelope.warnings = report.warnings;
         print_json(&envelope)?;
     } else {

--- a/src/cli/commands/explain.rs
+++ b/src/cli/commands/explain.rs
@@ -102,7 +102,8 @@ fn explain_plan(cli: &super::super::args::Cli, engine: &Engine) -> anyhow::Resul
 
     if cli.json {
         let data = explain_plan_json_data(&cli.profile, targets, explained);
-        let mut envelope = JsonEnvelope::ok("explain.plan", data);
+        let mut envelope = JsonEnvelope::ok("explain.plan", data)
+            .with_command_meta(cli.command_id(), cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
     } else {
@@ -232,7 +233,8 @@ fn explain_status(cli: &super::super::args::Cli, engine: &Engine) -> anyhow::Res
 
     if cli.json {
         let data = explain_status_json_data(&cli.profile, targets, drift);
-        let mut envelope = JsonEnvelope::ok("explain.status", data);
+        let mut envelope = JsonEnvelope::ok("explain.status", data)
+            .with_command_meta(cli.command_id(), cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
     } else {

--- a/src/cli/commands/fetch.rs
+++ b/src/cli/commands/fetch.rs
@@ -47,7 +47,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                 "store_posix": crate::paths::path_to_posix_string(&ctx.home.cache_dir),
                 "git_modules_fetched": fetched,
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!(

--- a/src/cli/commands/help.rs
+++ b/src/cli/commands/help.rs
@@ -47,7 +47,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, markdown: bool) -> anyhow::Result<()> {
                     "in --json mode, mutating commands require --yes"
                 ]
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else if markdown {
         print!("{}", crate::docs::render_cli_reference_markdown());

--- a/src/cli/commands/import.rs
+++ b/src/cli/commands/import.rs
@@ -189,7 +189,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, apply: bool, home_root: Option<&PathBuf>) -> an
                 );
         }
 
-        let mut envelope = JsonEnvelope::ok("import", data);
+        let mut envelope = JsonEnvelope::ok("import", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
         return Ok(());

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -456,7 +456,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, guided: bool, git: bool, bootstrap: bool) -> an
                     .insert("bootstrap".to_string(), bootstrap_result);
             }
 
-            let mut envelope = JsonEnvelope::ok("init", data);
+            let mut envelope = JsonEnvelope::ok("init", data)
+                .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
             envelope.warnings.append(&mut guided_warnings);
             print_json(&envelope)?;
         } else {
@@ -573,7 +574,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, guided: bool, git: bool, bootstrap: bool) -> an
                 .insert("bootstrap".to_string(), bootstrap_result);
         }
 
-        let envelope = JsonEnvelope::ok("init", data);
+        let envelope = JsonEnvelope::ok("init", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!(

--- a/src/cli/commands/lock.rs
+++ b/src/cli/commands/lock.rs
@@ -24,7 +24,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                 "lockfile_posix": crate::paths::path_to_posix_string(&ctx.repo.lockfile_path),
                 "modules": lock.modules.len(),
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!(

--- a/src/cli/commands/overlay.rs
+++ b/src/cli/commands/overlay.rs
@@ -138,7 +138,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &OverlayCommands) -> anyhow::Result<()
                         "machine_id": if matches!(effective_scope, OverlayScope::Machine) { Some(engine.machine_id.clone()) } else { None },
                         "project_id": if matches!(effective_scope, OverlayScope::Project) { Some(engine.project.project_id.clone()) } else { None },
                     }),
-                );
+                )
+                .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
                 envelope.warnings = warnings;
                 print_json(&envelope)?;
             } else {
@@ -227,7 +228,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &OverlayCommands) -> anyhow::Result<()
                         "sparsify": sparsify,
                         "report": report,
                     }),
-                );
+                )
+                .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
                 print_json(&envelope)?;
             } else {
                 let verb = if ctx.cli.dry_run {
@@ -261,7 +263,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &OverlayCommands) -> anyhow::Result<()
                         "overlay_dir": overlay_dir,
                         "overlay_dir_posix": crate::paths::path_to_posix_string(&overlay_dir),
                     }),
-                );
+                )
+                .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
                 print_json(&envelope)?;
             } else {
                 println!("{}", overlay_dir.display());

--- a/src/cli/commands/plan.rs
+++ b/src/cli/commands/plan.rs
@@ -19,7 +19,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
 
     if ctx.cli.json {
         let data = plan_json_data(ctx.cli.profile.as_str(), targets, plan);
-        let mut envelope = JsonEnvelope::ok("plan", data);
+        let mut envelope = JsonEnvelope::ok("plan", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
     } else {

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -21,7 +21,8 @@ fn lint(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     if ctx.cli.json {
         if violations == 0 {
             let data = serde_json::to_value(&report).context("serialize policy lint report")?;
-            let envelope = JsonEnvelope::ok("policy.lint", data);
+            let envelope = JsonEnvelope::ok("policy.lint", data)
+                .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
             print_json(&envelope)?;
             return Ok(());
         }
@@ -58,7 +59,8 @@ fn audit(ctx: &Ctx<'_>) -> anyhow::Result<()> {
     if ctx.cli.json {
         let data =
             serde_json::to_value(&outcome.report).context("serialize policy audit report")?;
-        let mut envelope = JsonEnvelope::ok("policy.audit", data);
+        let mut envelope = JsonEnvelope::ok("policy.audit", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         envelope.warnings = outcome.warnings;
         print_json(&envelope)?;
         return Ok(());
@@ -126,7 +128,8 @@ fn lock(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                 "sha256": report.sha256,
                 "files": report.files,
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
         return Ok(());
     }

--- a/src/cli/commands/preview.rs
+++ b/src/cli/commands/preview.rs
@@ -29,7 +29,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, diff: bool) -> anyhow::Result<()> {
             &mut warnings,
         )?;
 
-        let mut envelope = JsonEnvelope::ok("preview", data);
+        let mut envelope = JsonEnvelope::ok("preview", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
     } else {

--- a/src/cli/commands/record.rs
+++ b/src/cli/commands/record.rs
@@ -19,7 +19,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                 "recorded_at": record.recorded_at,
                 "machine_id": record.machine_id,
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!("Recorded event to {}", path.display());

--- a/src/cli/commands/remote.rs
+++ b/src/cli/commands/remote.rs
@@ -33,7 +33,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &RemoteCommands) -> anyhow::Result<()>
                         "remote": name,
                         "url": url,
                     }),
-                );
+                )
+                .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
                 print_json(&envelope)?;
             } else {
                 println!("Set remote {name} -> {url}");

--- a/src/cli/commands/remove.rs
+++ b/src/cli/commands/remove.rs
@@ -26,7 +26,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, module_id: &str) -> anyhow::Result<()> {
                 "manifest": ctx.repo.manifest_path.clone(),
                 "manifest_posix": crate::paths::path_to_posix_string(&ctx.repo.manifest_path),
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!("Removed module {module_id}");

--- a/src/cli/commands/rollback.rs
+++ b/src/cli/commands/rollback.rs
@@ -8,7 +8,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, snapshot_id: &str) -> anyhow::Result<()> {
     let event = rollback(ctx.home, snapshot_id, ctx.cli.json, ctx.cli.yes)?;
     if ctx.cli.json {
         let data = rollback_json_data(snapshot_id, &event.id);
-        let envelope = JsonEnvelope::ok("rollback", data);
+        let envelope = JsonEnvelope::ok("rollback", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!("Rolled back to snapshot {snapshot_id}. Event: {}", event.id);

--- a/src/cli/commands/schema.rs
+++ b/src/cli/commands/schema.rs
@@ -13,6 +13,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                         "schema_version": "number",
                         "ok": "boolean",
                         "command": "string",
+                        "command_id": "string",
+                        "command_path": "array[string]",
                         "version": "string",
                         "data": "object",
                         "warnings": "array[string]",
@@ -37,11 +39,14 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                     "posix": "many payloads also include *_posix companion fields using forward slashes"
                 }
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!("JSON envelope schema_version=1");
-        println!("- keys: schema_version, ok, command, version, data, warnings, errors");
+        println!(
+            "- keys: schema_version, ok, command, command_id, command_path, version, data, warnings, errors"
+        );
         println!("- key commands: plan/diff/preview/status (use --json to inspect)");
     }
 

--- a/src/cli/commands/score.rs
+++ b/src/cli/commands/score.rs
@@ -84,7 +84,8 @@ pub(crate) fn run(ctx: &Ctx<'_>) -> anyhow::Result<()> {
                 "modules": out,
                 "read_stats": stats,
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
     } else if out.is_empty() {

--- a/src/cli/commands/status.rs
+++ b/src/cli/commands/status.rs
@@ -98,7 +98,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, only: &[crate::cli::args::StatusOnly]) -> anyho
             summary_total_opt,
             &next_actions.json,
         )?;
-        let mut envelope = JsonEnvelope::ok("status", data);
+        let mut envelope = JsonEnvelope::ok("status", data)
+            .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         envelope.warnings = warnings;
         print_json(&envelope)?;
     } else if drift.is_empty() {

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -51,7 +51,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, rebase: bool, remote: &str) -> anyhow::Result<(
                 "rebase": rebase,
                 "commands": ran,
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else {
         println!("Synced {} ({} {})", repo_dir.display(), remote, branch);

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -128,7 +128,8 @@ pub(crate) fn run(
                 "steps": steps,
                 "git_modules_fetched": fetched,
             }),
-        );
+        )
+        .with_command_meta(ctx.cli.command_id(), ctx.cli.command_path());
         print_json(&envelope)?;
     } else if steps.is_empty() {
         println!("No steps to run");

--- a/src/cli/json.rs
+++ b/src/cli/json.rs
@@ -4,7 +4,8 @@ use super::args::Cli;
 
 pub(crate) fn print_anyhow_error(cli: &Cli, err: &anyhow::Error) {
     let (code, message, details) = crate::user_error::anyhow_error_parts_for_envelope(err);
-    let mut envelope = JsonEnvelope::ok(cli.command_name(), serde_json::json!({}));
+    let mut envelope = JsonEnvelope::ok(cli.command_name(), serde_json::json!({}))
+        .with_command_meta(cli.command_id(), cli.command_path());
     envelope.ok = false;
     envelope.errors = vec![JsonError {
         code: code.to_string(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -18,6 +18,10 @@ where
     pub schema_version: u32,
     pub ok: bool,
     pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command_path: Option<Vec<String>>,
     pub version: String,
     pub data: T,
     pub warnings: Vec<String>,
@@ -33,6 +37,8 @@ where
             schema_version: JSON_SCHEMA_VERSION,
             ok: true,
             command: command.into(),
+            command_id: None,
+            command_path: None,
             version: env!("CARGO_PKG_VERSION").to_string(),
             data,
             warnings: Vec::new(),
@@ -48,11 +54,19 @@ where
             schema_version: JSON_SCHEMA_VERSION,
             ok: false,
             command: command.into(),
+            command_id: None,
+            command_path: None,
             version: env!("CARGO_PKG_VERSION").to_string(),
             data: T::default(),
             warnings: Vec::new(),
             errors,
         }
+    }
+
+    pub fn with_command_meta(mut self, command_id: String, command_path: Vec<String>) -> Self {
+        self.command_id = Some(command_id);
+        self.command_path = Some(command_path);
+        self
     }
 }
 

--- a/tests/cli_json_command_metadata.rs
+++ b/tests/cli_json_command_metadata.rs
@@ -1,0 +1,59 @@
+use std::process::Command;
+
+fn run_agentpack(args: &[&str]) -> std::process::Output {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .args(args)
+        .env("AGENTPACK_HOME", tmp.path())
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+#[test]
+fn json_success_includes_command_id_and_command_path() {
+    let output = run_agentpack(&["schema", "--json"]);
+    assert!(output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["command"], "schema");
+    assert_eq!(v["command_id"], "schema");
+    assert_eq!(v["command_path"], serde_json::json!(["schema"]));
+}
+
+#[test]
+fn json_error_includes_command_id_and_command_path_for_subcommand() {
+    let output = run_agentpack(&[
+        "remote",
+        "set",
+        "https://example.invalid/repo.git",
+        "--json",
+    ]);
+    assert!(!output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "remote");
+    assert_eq!(v["command_id"], "remote set");
+    assert_eq!(v["command_path"], serde_json::json!(["remote", "set"]));
+    assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+}
+
+#[test]
+fn json_error_includes_command_id_and_command_path_for_mutating_flag_variant() {
+    let output = run_agentpack(&["doctor", "--fix", "--json"]);
+    assert!(!output.status.success());
+
+    let v = parse_stdout_json(&output);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["command"], "doctor");
+    assert_eq!(v["command_id"], "doctor --fix");
+    assert_eq!(v["command_path"], serde_json::json!(["doctor", "--fix"]));
+    assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+}

--- a/tests/golden/schema_json_data.json
+++ b/tests/golden/schema_json_data.json
@@ -68,6 +68,8 @@
     },
     "fields": {
       "command": "string",
+      "command_id": "string",
+      "command_path": "array[string]",
       "data": "object",
       "errors": "array[{code,message,details?}]",
       "ok": "boolean",


### PR DESCRIPTION
Closes #770.\n\nWhat\n- Add additive envelope fields: command_id (stable id) and command_path (tokenized id).\n- Populate fields for both success and error envelopes.\n- Update schema output + docs (SPEC + reference/json-api) + golden snapshot.\n- Add focused integration tests for success + subcommand refusal + mutating flag variant.\n\nWhy\n- The existing command field is not sufficient for reliably identifying subcommands and mutating variants in automation, especially on error paths.\n\nTests\n- cargo fmt --all\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test --all --locked\n\nOpenSpec\n- openspec/changes/add-json-command-metadata