### PR TITLE
feat(mcp): include command_id/command_path in tool envelopes

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -30,8 +30,8 @@ pub(super) use args::{
 
 use deploy_plan::deploy_plan_envelope_in_process;
 use envelope::{
-    envelope_from_anyhow_error, tool_result_from_envelope, tool_result_from_user_error,
-    tool_result_unexpected,
+    CommandMeta, envelope_from_anyhow_error, tool_result_from_envelope,
+    tool_result_from_user_error, tool_result_unexpected,
 };
 use tool_schema::{tool, tool_input_schema};
 

--- a/src/mcp/tools/deploy_plan.rs
+++ b/src/mcp/tools/deploy_plan.rs
@@ -4,6 +4,13 @@ pub(super) async fn deploy_plan_envelope_in_process(
     args: super::CommonArgs,
 ) -> anyhow::Result<serde_json::Value> {
     tokio::task::spawn_blocking(move || {
+        let command_path = ["deploy"];
+        let meta = super::CommandMeta {
+            command: "deploy",
+            command_id: "deploy",
+            command_path: &command_path,
+        };
+
         let repo_override = args.repo.as_ref().map(std::path::PathBuf::from);
         let profile = args.profile.as_deref().unwrap_or("default");
         let target = args.target.as_deref().unwrap_or("all");
@@ -25,11 +32,12 @@ pub(super) async fn deploy_plan_envelope_in_process(
             }) => {
                 let data =
                     crate::app::deploy_json::deploy_json_data_dry_run(profile, targets, plan);
-                let mut envelope = crate::output::JsonEnvelope::ok("deploy", data);
+                let mut envelope = crate::output::JsonEnvelope::ok(meta.command, data)
+                    .with_command_meta(meta.command_id_string(), meta.command_path_vec());
                 envelope.warnings = warnings;
                 serde_json::to_value(&envelope).context("serialize deploy envelope")
             }
-            Err(err) => Ok(super::envelope_from_anyhow_error("deploy", &err)),
+            Err(err) => Ok(super::envelope_from_anyhow_error(meta, &err)),
         }
     })
     .await

--- a/src/mcp/tools/read_only.rs
+++ b/src/mcp/tools/read_only.rs
@@ -5,6 +5,13 @@ pub(super) async fn call_read_only_in_process(
     args: super::CommonArgs,
 ) -> anyhow::Result<(String, serde_json::Value)> {
     tokio::task::spawn_blocking(move || {
+        let command_path = [command];
+        let meta = super::CommandMeta {
+            command,
+            command_id: command,
+            command_path: &command_path,
+        };
+
         let repo_override = args.repo.as_ref().map(std::path::PathBuf::from);
         let profile = args.profile.as_deref().unwrap_or("default");
         let target = args.target.as_deref().unwrap_or("all");
@@ -25,14 +32,15 @@ pub(super) async fn call_read_only_in_process(
                 ..
             }) => {
                 let data = crate::app::plan_json::plan_json_data(profile, targets, plan);
-                let mut envelope = crate::output::JsonEnvelope::ok(command, data);
+                let mut envelope = crate::output::JsonEnvelope::ok(meta.command, data)
+                    .with_command_meta(meta.command_id_string(), meta.command_path_vec());
                 envelope.warnings = warnings;
                 let text = serde_json::to_string_pretty(&envelope)?;
                 let envelope = serde_json::to_value(&envelope)?;
                 (text, envelope)
             }
             Err(err) => {
-                let envelope = super::envelope_from_anyhow_error(command, &err);
+                let envelope = super::envelope_from_anyhow_error(meta, &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }

--- a/src/mcp/tools/rollback.rs
+++ b/src/mcp/tools/rollback.rs
@@ -4,6 +4,13 @@ pub(super) async fn call_rollback_in_process(
     args: super::RollbackArgs,
 ) -> anyhow::Result<(String, serde_json::Value)> {
     tokio::task::spawn_blocking(move || {
+        let command_path = ["rollback"];
+        let meta = super::CommandMeta {
+            command: "rollback",
+            command_id: "rollback",
+            command_path: &command_path,
+        };
+
         let home = crate::paths::AgentpackHome::resolve().context("resolve agentpack home")?;
 
         let super::RollbackArgs {
@@ -16,13 +23,14 @@ pub(super) async fn call_rollback_in_process(
         let (text, envelope) = match result {
             Ok(event) => {
                 let data = crate::app::rollback_json::rollback_json_data(&snapshot_id, &event.id);
-                let envelope = crate::output::JsonEnvelope::ok("rollback", data);
+                let envelope = crate::output::JsonEnvelope::ok(meta.command, data)
+                    .with_command_meta(meta.command_id_string(), meta.command_path_vec());
                 let text = serde_json::to_string_pretty(&envelope)?;
                 let envelope = serde_json::to_value(&envelope)?;
                 (text, envelope)
             }
             Err(err) => {
-                let envelope = super::envelope_from_anyhow_error("rollback", &err);
+                let envelope = super::envelope_from_anyhow_error(meta, &err);
                 let text = serde_json::to_string_pretty(&envelope)?;
                 (text, envelope)
             }

--- a/src/mcp/tools/router.rs
+++ b/src/mcp/tools/router.rs
@@ -12,47 +12,77 @@ pub(super) async fn call_tool(
 ) -> Result<CallToolResult, McpError> {
     match request.name.as_ref() {
         "plan" => {
+            let command_path = ["plan"];
+            let meta = super::CommandMeta {
+                command: "plan",
+                command_id: "plan",
+                command_path: &command_path,
+            };
             let args = deserialize_args::<super::CommonArgs>(request.arguments)?;
             let (text, envelope) =
                 match super::read_only::call_read_only_in_process("plan", args).await {
                     Ok(v) => v,
                     Err(err) => {
-                        return Ok(tool_result_unexpected("plan", &err));
+                        return Ok(tool_result_unexpected(meta, &err));
                     }
                 };
             Ok(tool_result_from_envelope(text, envelope))
         }
         "diff" => {
+            let command_path = ["diff"];
+            let meta = super::CommandMeta {
+                command: "diff",
+                command_id: "diff",
+                command_path: &command_path,
+            };
             let args = deserialize_args::<super::CommonArgs>(request.arguments)?;
             let (text, envelope) =
                 match super::read_only::call_read_only_in_process("diff", args).await {
                     Ok(v) => v,
                     Err(err) => {
-                        return Ok(tool_result_unexpected("diff", &err));
+                        return Ok(tool_result_unexpected(meta, &err));
                     }
                 };
             Ok(tool_result_from_envelope(text, envelope))
         }
         "preview" => {
+            let command_path = ["preview"];
+            let meta = super::CommandMeta {
+                command: "preview",
+                command_id: "preview",
+                command_path: &command_path,
+            };
             let args = deserialize_args::<super::PreviewArgs>(request.arguments)?;
             match super::preview::call_preview_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(tool_result_unexpected("preview", &err)),
+                Err(err) => Ok(tool_result_unexpected(meta, &err)),
             }
         }
         "status" => {
+            let command_path = ["status"];
+            let meta = super::CommandMeta {
+                command: "status",
+                command_id: "status",
+                command_path: &command_path,
+            };
             let args = deserialize_args::<super::StatusArgs>(request.arguments)?;
             match super::status::call_status_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(tool_result_unexpected("status", &err)),
+                Err(err) => Ok(tool_result_unexpected(meta, &err)),
             }
         }
         "doctor" => {
+            let command_path = ["doctor"];
+            let meta = super::CommandMeta {
+                command: "doctor",
+                command_id: "doctor",
+                command_path: &command_path,
+            };
             let args = deserialize_args::<super::DoctorArgs>(request.arguments)?;
             let (text, envelope) = match super::doctor::call_doctor_in_process(args).await {
                 Ok(v) => v,
                 Err(err) => {
-                    return Ok(tool_result_unexpected("doctor", &err));
+                    return Ok(tool_result_unexpected(meta, &err));
                 }
             };
             Ok(tool_result_from_envelope(text, envelope))
@@ -66,31 +96,65 @@ pub(super) async fn call_tool(
             Ok(super::deploy_apply::call_deploy_apply_tool(server, args).await)
         }
         "rollback" => {
+            let command_path = ["rollback"];
+            let meta = super::CommandMeta {
+                command: "rollback",
+                command_id: "rollback",
+                command_path: &command_path,
+            };
             let args = deserialize_args::<super::RollbackArgs>(request.arguments)?;
             match super::rollback::call_rollback_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(tool_result_unexpected("rollback", &err)),
+                Err(err) => Ok(tool_result_unexpected(meta, &err)),
             }
         }
         "evolve_propose" => {
+            let command_path = ["evolve", "propose"];
+            let meta = super::CommandMeta {
+                command: "evolve.propose",
+                command_id: "evolve propose",
+                command_path: &command_path,
+            };
             let args = deserialize_args::<super::EvolveProposeArgs>(request.arguments)?;
             match super::evolve_propose::call_evolve_propose_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(tool_result_unexpected("evolve.propose", &err)),
+                Err(err) => Ok(tool_result_unexpected(meta, &err)),
             }
         }
         "evolve_restore" => {
+            let command_path = ["evolve", "restore"];
+            let meta = super::CommandMeta {
+                command: "evolve.restore",
+                command_id: "evolve restore",
+                command_path: &command_path,
+            };
             let args = deserialize_args::<super::EvolveRestoreArgs>(request.arguments)?;
             match super::evolve_restore::call_evolve_restore_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(tool_result_unexpected("evolve.restore", &err)),
+                Err(err) => Ok(tool_result_unexpected(meta, &err)),
             }
         }
         "explain" => {
             let args = deserialize_args::<super::ExplainArgs>(request.arguments)?;
+            let (command, command_id, command_path) = match args.kind {
+                super::ExplainKindArg::Plan => {
+                    ("explain.plan", "explain plan", ["explain", "plan"])
+                }
+                super::ExplainKindArg::Diff => {
+                    ("explain.plan", "explain diff", ["explain", "diff"])
+                }
+                super::ExplainKindArg::Status => {
+                    ("explain.status", "explain status", ["explain", "status"])
+                }
+            };
+            let meta = super::CommandMeta {
+                command,
+                command_id,
+                command_path: &command_path,
+            };
             match super::explain::call_explain_in_process(args).await {
                 Ok((text, envelope)) => Ok(tool_result_from_envelope(text, envelope)),
-                Err(err) => Ok(tool_result_unexpected("explain", &err)),
+                Err(err) => Ok(tool_result_unexpected(meta, &err)),
             }
         }
         other => Ok(CallToolResult {

--- a/tests/mcp_server_stdio.rs
+++ b/tests/mcp_server_stdio.rs
@@ -109,14 +109,51 @@ modules: []
         assert!(names.contains(&required), "missing tool: {required}");
     }
 
-    for (idx, (tool, args, expected_command)) in [
-        ("plan", "{}", "plan"),
-        ("diff", "{}", "diff"),
-        ("preview", "{}", "preview"),
-        ("status", "{}", "status"),
-        ("doctor", "{}", "doctor"),
-        ("deploy", "{}", "deploy"),
-        ("explain", r#"{"kind":"plan"}"#, "explain.plan"),
+    for (idx, (tool, args, expected_command, expected_command_id, expected_command_path)) in [
+        ("plan", "{}", "plan", "plan", serde_json::json!(["plan"])),
+        ("diff", "{}", "diff", "diff", serde_json::json!(["diff"])),
+        (
+            "preview",
+            "{}",
+            "preview",
+            "preview",
+            serde_json::json!(["preview"]),
+        ),
+        (
+            "status",
+            "{}",
+            "status",
+            "status",
+            serde_json::json!(["status"]),
+        ),
+        (
+            "doctor",
+            "{}",
+            "doctor",
+            "doctor",
+            serde_json::json!(["doctor"]),
+        ),
+        (
+            "deploy",
+            "{}",
+            "deploy",
+            "deploy",
+            serde_json::json!(["deploy"]),
+        ),
+        (
+            "explain",
+            r#"{"kind":"plan"}"#,
+            "explain.plan",
+            "explain plan",
+            serde_json::json!(["explain", "plan"]),
+        ),
+        (
+            "explain",
+            r#"{"kind":"diff"}"#,
+            "explain.plan",
+            "explain diff",
+            serde_json::json!(["explain", "diff"]),
+        ),
     ]
     .iter()
     .enumerate()
@@ -139,6 +176,8 @@ modules: []
             .expect("content text");
         let envelope: serde_json::Value = serde_json::from_str(text).expect("envelope json");
         assert_eq!(envelope["command"], *expected_command);
+        assert_eq!(envelope["command_id"], *expected_command_id);
+        assert_eq!(envelope["command_path"], *expected_command_path);
         assert!(envelope["ok"].as_bool().unwrap_or(false));
     }
 

--- a/tests/mcp_server_stdio_mutating.rs
+++ b/tests/mcp_server_stdio_mutating.rs
@@ -100,6 +100,11 @@ modules:
         .expect("content text");
     let deploy_plan_env: serde_json::Value =
         serde_json::from_str(deploy_plan_text).expect("envelope json");
+    assert_eq!(deploy_plan_env["command_id"], "deploy");
+    assert_eq!(
+        deploy_plan_env["command_path"],
+        serde_json::json!(["deploy"])
+    );
     let confirm_token = deploy_plan_env["data"]["confirm_token"]
         .as_str()
         .expect("confirm_token string")
@@ -123,6 +128,11 @@ modules:
     let deploy_no_env: serde_json::Value =
         serde_json::from_str(deploy_no_text).expect("envelope json");
     assert_eq!(deploy_no_env["command"], "deploy");
+    assert_eq!(deploy_no_env["command_id"], "deploy --apply");
+    assert_eq!(
+        deploy_no_env["command_path"],
+        serde_json::json!(["deploy", "--apply"])
+    );
     assert_eq!(deploy_no_env["errors"][0]["code"], "E_CONFIRM_REQUIRED");
 
     assert!(
@@ -152,6 +162,11 @@ modules:
     let deploy_missing_token_env: serde_json::Value =
         serde_json::from_str(deploy_missing_token_text).expect("envelope json");
     assert_eq!(deploy_missing_token_env["command"], "deploy");
+    assert_eq!(deploy_missing_token_env["command_id"], "deploy --apply");
+    assert_eq!(
+        deploy_missing_token_env["command_path"],
+        serde_json::json!(["deploy", "--apply"])
+    );
     assert_eq!(
         deploy_missing_token_env["errors"][0]["code"],
         "E_CONFIRM_TOKEN_REQUIRED"
@@ -184,6 +199,11 @@ modules:
     let deploy_bad_token_env: serde_json::Value =
         serde_json::from_str(deploy_bad_token_text).expect("envelope json");
     assert_eq!(deploy_bad_token_env["command"], "deploy");
+    assert_eq!(deploy_bad_token_env["command_id"], "deploy --apply");
+    assert_eq!(
+        deploy_bad_token_env["command_path"],
+        serde_json::json!(["deploy", "--apply"])
+    );
     assert_eq!(
         deploy_bad_token_env["errors"][0]["code"],
         "E_CONFIRM_TOKEN_MISMATCH"
@@ -208,6 +228,11 @@ modules:
     let deploy_ok_env: serde_json::Value =
         serde_json::from_str(deploy_ok_text).expect("envelope json");
     assert_eq!(deploy_ok_env["command"], "deploy");
+    assert_eq!(deploy_ok_env["command_id"], "deploy --apply");
+    assert_eq!(
+        deploy_ok_env["command_path"],
+        serde_json::json!(["deploy", "--apply"])
+    );
     assert!(deploy_ok_env["ok"].as_bool().unwrap_or(false));
     let snapshot_id = deploy_ok_env["data"]["snapshot_id"]
         .as_str()
@@ -237,6 +262,11 @@ modules:
     let rollback_no_env: serde_json::Value =
         serde_json::from_str(rollback_no_text).expect("envelope json");
     assert_eq!(rollback_no_env["command"], "rollback");
+    assert_eq!(rollback_no_env["command_id"], "rollback");
+    assert_eq!(
+        rollback_no_env["command_path"],
+        serde_json::json!(["rollback"])
+    );
     assert_eq!(rollback_no_env["errors"][0]["code"], "E_CONFIRM_REQUIRED");
 
     // rollback with approval
@@ -258,6 +288,11 @@ modules:
     let rollback_ok_env: serde_json::Value =
         serde_json::from_str(rollback_ok_text).expect("envelope json");
     assert_eq!(rollback_ok_env["command"], "rollback");
+    assert_eq!(rollback_ok_env["command_id"], "rollback");
+    assert_eq!(
+        rollback_ok_env["command_path"],
+        serde_json::json!(["rollback"])
+    );
     assert!(rollback_ok_env["ok"].as_bool().unwrap_or(false));
 
     let _ = child.kill();


### PR DESCRIPTION
Closes #773.

## Summary
- MCP tool envelopes now include top-level `command_id` and `command_path` fields (success + error), matching the Agentpack JSON envelope contract.
- Keeps MCP `command` values unchanged, but maps metadata to the corresponding CLI command:
  - `deploy_apply`: `command="deploy"`, `command_id="deploy --apply"`, `command_path=["deploy","--apply"]`
  - `explain` kind=diff: `command="explain.plan"`, `command_id="explain diff"`, `command_path=["explain","diff"]`

## Tests
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
