### PR TITLE
feat(json): add reason_code/next_actions to confirm refusals

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -393,6 +393,10 @@ Global flags:
 Safety guardrails:
 - In `--json` mode, commands that write to disk and/or mutate git require `--yes` (avoid accidental writes in scripts/LLMs).
 - If `--yes` is missing: exit code is non-zero, stdout is still valid JSON (`ok=false`), and a stable error code `E_CONFIRM_REQUIRED` is returned in `errors[0].code`.
+  - `errors[0].details` MUST include additive, machine-actionable fields:
+    - `command` (the command id, e.g. `deploy --apply`)
+    - `reason_code` (currently: `confirm_required`)
+    - `next_actions` (currently: `["retry_with_yes"]`)
 
 ### 4.1 `init`
 
@@ -667,6 +671,7 @@ Two-stage deploy confirmation:
 - `deploy_apply` requires `yes=true` and a matching `confirm_token` from the prior `deploy` call.
   - Missing `yes=true` returns `E_CONFIRM_REQUIRED`.
   - Missing/expired/mismatched token returns `E_CONFIRM_TOKEN_REQUIRED` / `E_CONFIRM_TOKEN_EXPIRED` / `E_CONFIRM_TOKEN_MISMATCH`.
+    - These token errors MUST include additive `errors[0].details.reason_code` and `errors[0].details.next_actions`.
 
 Tool results:
 - Tool results reuse Agentpack’s `--json` envelope as the canonical payload, returned as structured content and as serialized JSON text.

--- a/docs/reference/json-api.md
+++ b/docs/reference/json-api.md
@@ -42,7 +42,11 @@ Failure example:
     {
       "code": "E_CONFIRM_REQUIRED",
       "message": "refusing to run 'deploy --apply' in --json mode without --yes",
-      "details": {"command": "deploy --apply"}
+      "details": {
+        "command": "deploy --apply",
+        "reason_code": "confirm_required",
+        "next_actions": ["retry_with_yes"]
+      }
     }
   ]
 }
@@ -54,6 +58,10 @@ In `--json` mode, mutating commands require explicit `--yes`, otherwise they ret
 
 You can use:
 - `agentpack help --json` to obtain the command list, the mutating command set, and the compiled target set (`data.targets[]`)
+
+Confirm-related refusals MAY include additional, machine-actionable detail fields (additive), such as:
+- `errors[0].details.reason_code`
+- `errors[0].details.next_actions`
 
 Common mutating commands (not exhaustive):
 - `deploy --apply`, `update`, `lock`, `fetch`, `add/remove`, `bootstrap`, `rollback`

--- a/openspec/changes/add-confirm-refusal-next-actions/proposal.md
+++ b/openspec/changes/add-confirm-refusal-next-actions/proposal.md
@@ -1,0 +1,27 @@
+# Change: Add `reason_code` and `next_actions` to confirm-related refusal errors
+
+## Why
+Automation (and MCP hosts) can reliably branch on stable error codes like `E_CONFIRM_REQUIRED`, but often still need structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, confirm-related refusal errors primarily include a message and (sometimes) a free-form `hint`, but do not consistently provide stable `reason_code` + `next_actions` fields.
+
+## What Changes
+- Add additive fields under `errors[0].details` for confirm-related refusals:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Cover these errors first (small initial slice):
+  - `E_CONFIRM_REQUIRED`
+  - `E_CONFIRM_TOKEN_REQUIRED`
+  - `E_CONFIRM_TOKEN_EXPIRED`
+  - `E_CONFIRM_TOKEN_MISMATCH`
+- Update `docs/SPEC.md` and `docs/reference/json-api.md` to document the new additive fields.
+- Add/extend tests to assert the new detail fields for both CLI (`--json`) and MCP flows.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- For the listed error codes, `errors[0].details.reason_code` and `errors[0].details.next_actions` are present and stable.
+- Existing detail fields (e.g. `details.command`, `details.hint`) are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-confirm-refusal-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-confirm-refusal-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Confirm-required refusals are machine-actionable
+When a `--json` invocation is refused due to missing explicit confirmation (i.e., `E_CONFIRM_REQUIRED`), the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+#### Scenario: update --json without --yes includes refusal details
+- **WHEN** the user runs `agentpack update --json` without `--yes`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_CONFIRM_REQUIRED`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-confirm-refusal-next-actions/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/add-confirm-refusal-next-actions/specs/agentpack-mcp/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Confirm-token refusals are machine-actionable
+When `deploy_apply` is refused due to confirmation token errors (`E_CONFIRM_TOKEN_REQUIRED`, `E_CONFIRM_TOKEN_EXPIRED`, `E_CONFIRM_TOKEN_MISMATCH`), the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+#### Scenario: deploy_apply with mismatched token includes refusal details
+- **WHEN** a client calls tool `deploy_apply` with `yes=true` and a token that does not match the current deploy plan
+- **THEN** the tool result has `isError=true`
+- **AND** the Agentpack envelope includes `errors[0].code = E_CONFIRM_TOKEN_MISMATCH`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-confirm-refusal-next-actions/tasks.md
+++ b/openspec/changes/add-confirm-refusal-next-actions/tasks.md
@@ -1,0 +1,20 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` and `agentpack-mcp` documenting the new refusal detail fields.
+
+### 1.2 Code changes
+- [x] Extend `UserError::confirm_required` to include stable `reason_code` + `next_actions` in `details` (additive).
+- [x] Extend `UserError::confirm_token_required|expired|mismatch` to include stable `reason_code` + `next_actions` in `details` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new confirm-related refusal detail fields.
+- [x] Update `docs/reference/json-api.md` failure examples and guidance (additive fields).
+
+### 1.4 Tests
+- [x] Add/extend CLI tests to assert `reason_code` + `next_actions` on `E_CONFIRM_REQUIRED`.
+- [x] Add/extend MCP tests to assert `reason_code` + `next_actions` on `E_CONFIRM_TOKEN_*` and `E_CONFIRM_REQUIRED` where applicable.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-confirm-refusal-next-actions --strict --no-interactive`.
+- [x] Run `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --all --locked`.

--- a/src/mcp/tools/deploy_apply.rs
+++ b/src/mcp/tools/deploy_apply.rs
@@ -70,6 +70,8 @@ pub(super) async fn call_deploy_apply_tool(
             return super::tool_result_from_user_error(
                 meta,
                 UserError::confirm_token_mismatch().with_details(serde_json::json!({
+                    "reason_code": "confirm_token_mismatch",
+                    "next_actions": ["call_deploy", "retry_deploy_apply"],
                     "hint": "Re-run the deploy tool and ensure the apply uses the matching confirm_token.",
                     "confirm_plan_hash": current_plan_hash,
                     "expected_confirm_plan_hash": stored_plan_hash,

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -130,7 +130,11 @@ impl UserError {
                 "E_CONFIRM_REQUIRED",
                 format!("refusing to run '{command}' in --json mode without --yes"),
             )
-            .with_details(serde_json::json!({ "command": command })),
+            .with_details(serde_json::json!({
+                "command": command,
+                "reason_code": "confirm_required",
+                "next_actions": ["retry_with_yes"],
+            })),
         )
     }
 
@@ -140,13 +144,19 @@ impl UserError {
             "deploy_apply requires confirm_token from the deploy tool",
         )
         .with_details(serde_json::json!({
+            "reason_code": "confirm_token_required",
+            "next_actions": ["call_deploy", "retry_deploy_apply"],
             "hint": "Call the deploy tool first and pass data.confirm_token to deploy_apply."
         }))
     }
 
     pub fn confirm_token_expired() -> Self {
         Self::new("E_CONFIRM_TOKEN_EXPIRED", "confirm_token is expired").with_details(
-            serde_json::json!({ "hint": "Re-run the deploy tool to obtain a fresh confirm_token." }),
+            serde_json::json!({
+                "reason_code": "confirm_token_expired",
+                "next_actions": ["call_deploy", "retry_deploy_apply"],
+                "hint": "Re-run the deploy tool to obtain a fresh confirm_token.",
+            }),
         )
     }
 
@@ -156,6 +166,8 @@ impl UserError {
             "confirm_token does not match the current deploy plan",
         )
         .with_details(serde_json::json!({
+            "reason_code": "confirm_token_mismatch",
+            "next_actions": ["call_deploy", "retry_deploy_apply"],
             "hint": "Re-run the deploy tool and ensure the apply uses the matching confirm_token."
         }))
     }

--- a/tests/cli_json_command_metadata.rs
+++ b/tests/cli_json_command_metadata.rs
@@ -43,6 +43,12 @@ fn json_error_includes_command_id_and_command_path_for_subcommand() {
     assert_eq!(v["command_id"], "remote set");
     assert_eq!(v["command_path"], serde_json::json!(["remote", "set"]));
     assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+    assert_eq!(v["errors"][0]["details"]["command"], "remote set");
+    assert_eq!(v["errors"][0]["details"]["reason_code"], "confirm_required");
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_yes"])
+    );
 }
 
 #[test]
@@ -56,4 +62,10 @@ fn json_error_includes_command_id_and_command_path_for_mutating_flag_variant() {
     assert_eq!(v["command_id"], "doctor --fix");
     assert_eq!(v["command_path"], serde_json::json!(["doctor", "--fix"]));
     assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+    assert_eq!(v["errors"][0]["details"]["command"], "doctor --fix");
+    assert_eq!(v["errors"][0]["details"]["reason_code"], "confirm_required");
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_yes"])
+    );
 }

--- a/tests/journey_j8_mcp_confirm.rs
+++ b/tests/journey_j8_mcp_confirm.rs
@@ -151,6 +151,18 @@ modules:
     assert!(apply_no_res["result"]["isError"].as_bool().unwrap_or(false));
     assert_eq!(apply_no_env["command"], "deploy");
     assert_eq!(apply_no_env["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+    assert_eq!(
+        apply_no_env["errors"][0]["details"]["command"],
+        "deploy --apply"
+    );
+    assert_eq!(
+        apply_no_env["errors"][0]["details"]["reason_code"],
+        "confirm_required"
+    );
+    assert_eq!(
+        apply_no_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_yes"])
+    );
 
     // deploy_apply with approval but without confirm_token is refused.
     let (apply_missing_res, apply_missing_env) = call_tool(
@@ -170,6 +182,14 @@ modules:
         apply_missing_env["errors"][0]["code"],
         "E_CONFIRM_TOKEN_REQUIRED"
     );
+    assert_eq!(
+        apply_missing_env["errors"][0]["details"]["reason_code"],
+        "confirm_token_required"
+    );
+    assert_eq!(
+        apply_missing_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["call_deploy", "retry_deploy_apply"])
+    );
 
     // deploy_apply with approval but bad confirm_token is refused.
     let (apply_bad_res, apply_bad_env) = call_tool(
@@ -188,6 +208,14 @@ modules:
     assert_eq!(
         apply_bad_env["errors"][0]["code"],
         "E_CONFIRM_TOKEN_MISMATCH"
+    );
+    assert_eq!(
+        apply_bad_env["errors"][0]["details"]["reason_code"],
+        "confirm_token_mismatch"
+    );
+    assert_eq!(
+        apply_bad_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["call_deploy", "retry_deploy_apply"])
     );
 
     // Mutate the repo after planning; apply with the old token must be refused due to plan mismatch.
@@ -209,6 +237,14 @@ modules:
     assert_eq!(
         apply_mismatch_env["errors"][0]["code"],
         "E_CONFIRM_TOKEN_MISMATCH"
+    );
+    assert_eq!(
+        apply_mismatch_env["errors"][0]["details"]["reason_code"],
+        "confirm_token_mismatch"
+    );
+    assert_eq!(
+        apply_mismatch_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["call_deploy", "retry_deploy_apply"])
     );
     assert!(
         !codex_home.join("AGENTS.md").exists(),
@@ -276,6 +312,15 @@ modules:
     assert!(rb_no_res["result"]["isError"].as_bool().unwrap_or(false));
     assert_eq!(rb_no_env["command"], "rollback");
     assert_eq!(rb_no_env["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+    assert_eq!(rb_no_env["errors"][0]["details"]["command"], "rollback");
+    assert_eq!(
+        rb_no_env["errors"][0]["details"]["reason_code"],
+        "confirm_required"
+    );
+    assert_eq!(
+        rb_no_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_yes"])
+    );
 
     // rollback with approval restores snapshot_v2.
     let rb_ok_args = format!(r#"{{"to":"{snapshot_v2}","yes":true}}"#);

--- a/tests/mcp_server_stdio_mutating.rs
+++ b/tests/mcp_server_stdio_mutating.rs
@@ -134,6 +134,18 @@ modules:
         serde_json::json!(["deploy", "--apply"])
     );
     assert_eq!(deploy_no_env["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+    assert_eq!(
+        deploy_no_env["errors"][0]["details"]["command"],
+        "deploy --apply"
+    );
+    assert_eq!(
+        deploy_no_env["errors"][0]["details"]["reason_code"],
+        "confirm_required"
+    );
+    assert_eq!(
+        deploy_no_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_yes"])
+    );
 
     assert!(
         !codex_home.join("AGENTS.md").exists(),
@@ -171,6 +183,14 @@ modules:
         deploy_missing_token_env["errors"][0]["code"],
         "E_CONFIRM_TOKEN_REQUIRED"
     );
+    assert_eq!(
+        deploy_missing_token_env["errors"][0]["details"]["reason_code"],
+        "confirm_token_required"
+    );
+    assert_eq!(
+        deploy_missing_token_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["call_deploy", "retry_deploy_apply"])
+    );
 
     assert!(
         !codex_home.join("AGENTS.md").exists(),
@@ -207,6 +227,14 @@ modules:
     assert_eq!(
         deploy_bad_token_env["errors"][0]["code"],
         "E_CONFIRM_TOKEN_MISMATCH"
+    );
+    assert_eq!(
+        deploy_bad_token_env["errors"][0]["details"]["reason_code"],
+        "confirm_token_mismatch"
+    );
+    assert_eq!(
+        deploy_bad_token_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["call_deploy", "retry_deploy_apply"])
     );
 
     // deploy_apply with approval and correct confirm_token
@@ -268,6 +296,18 @@ modules:
         serde_json::json!(["rollback"])
     );
     assert_eq!(rollback_no_env["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+    assert_eq!(
+        rollback_no_env["errors"][0]["details"]["command"],
+        "rollback"
+    );
+    assert_eq!(
+        rollback_no_env["errors"][0]["details"]["reason_code"],
+        "confirm_required"
+    );
+    assert_eq!(
+        rollback_no_env["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_yes"])
+    );
 
     // rollback with approval
     let rollback_req = format!(


### PR DESCRIPTION
Closes #775.

OpenSpec: `add-confirm-refusal-next-actions`

## Summary
- Adds additive, machine-actionable fields to confirm-related refusal errors:
  - `errors[0].details.reason_code`
  - `errors[0].details.next_actions`
- Covers:
  - `E_CONFIRM_REQUIRED`
  - `E_CONFIRM_TOKEN_REQUIRED` / `E_CONFIRM_TOKEN_EXPIRED` / `E_CONFIRM_TOKEN_MISMATCH`
- Updates `docs/SPEC.md` and `docs/reference/json-api.md` + extends CLI/MCP tests.

## Tests
- openspec validate add-confirm-refusal-next-actions --strict --no-interactive
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all --locked
