### PR TITLE
feat(json): add reason_code/next_actions to adopt refusals

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -502,6 +502,9 @@ Default behavior:
 Notes:
 - `--json` + `--apply` requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
 - If the plan contains any `adopt_update`, apply requires `--adopt`; in `--json` mode, missing `--adopt` returns `E_ADOPT_CONFIRM_REQUIRED`.
+  - `errors[0].details` MUST include additive, machine-actionable fields:
+    - `reason_code` (currently: `adopt_confirm_required`)
+    - `next_actions` (currently: `["retry_with_adopt"]`)
 - Even if the plan is empty, if the target root is missing a manifest, agentpack writes a manifest (so drift/safe-delete works going forward).
 
 ### 4.7 `status`

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -82,6 +82,7 @@ Recommended action:
 - Run `preview --diff` to confirm scope/impact.
 - If you truly want to take over and overwrite, retry with `--adopt`.
 Details: includes `{flag, adopt_updates, sample_paths}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_IMPORT_CONFLICT
 Meaning: `import --apply` would overwrite an existing path in the config repo (module file/dir destination already exists), and Agentpack refused to overwrite.

--- a/docs/reference/json-api.md
+++ b/docs/reference/json-api.md
@@ -121,7 +121,7 @@ Below are the most commonly consumed commands in automation. Field lists focus o
 - When `applied` is true: `snapshot_id`
 
 Tip:
-- If the plan contains `adopt_update`, you must pass `--adopt` or the command returns `E_ADOPT_CONFIRM_REQUIRED` (details include `sample_paths`).
+- If the plan contains `adopt_update`, you must pass `--adopt` or the command returns `E_ADOPT_CONFIRM_REQUIRED` (details include `flag`, `sample_paths`, `reason_code`, and `next_actions`).
 
 ### status
 

--- a/openspec/changes/add-adopt-refusal-next-actions/proposal.md
+++ b/openspec/changes/add-adopt-refusal-next-actions/proposal.md
@@ -1,0 +1,24 @@
+# Change: Add `reason_code` and `next_actions` to adopt-related refusal errors
+
+## Why
+Automation (and MCP hosts) can reliably branch on stable error codes like `E_ADOPT_CONFIRM_REQUIRED`, but still need structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, adopt-related refusal errors include useful context like `sample_paths`, but do not include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for adopt-related refusals:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Cover this error:
+  - `E_ADOPT_CONFIRM_REQUIRED`
+- Update `docs/SPEC.md`, `docs/reference/json-api.md`, and `docs/reference/error-codes.md` to document the new additive fields.
+- Add/extend tests to assert the new detail fields for both CLI (`--json`) and MCP flows.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- For `E_ADOPT_CONFIRM_REQUIRED`, `errors[0].details.reason_code` and `errors[0].details.next_actions` are present and stable.
+- Existing detail fields (e.g. `details.flag`, `details.adopt_updates`, `details.sample_paths`) are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-adopt-refusal-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-adopt-refusal-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Adopt-confirm refusals are machine-actionable
+When a `--json` invocation is refused due to missing explicit adopt confirmation (i.e., `E_ADOPT_CONFIRM_REQUIRED`), the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+#### Scenario: deploy --apply --json without --adopt includes refusal details
+- **GIVEN** the deploy plan contains at least one `adopt_update`
+- **WHEN** the user runs `agentpack deploy --apply --json --yes` without `--adopt`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_ADOPT_CONFIRM_REQUIRED`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-adopt-refusal-next-actions/specs/agentpack-mcp/spec.md
+++ b/openspec/changes/add-adopt-refusal-next-actions/specs/agentpack-mcp/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Adopt-confirm refusals are machine-actionable
+When `deploy_apply` is refused due to missing explicit adopt confirmation (`E_ADOPT_CONFIRM_REQUIRED`), the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+#### Scenario: deploy_apply without adopt includes refusal details
+- **GIVEN** the deploy plan contains at least one `adopt_update`
+- **WHEN** a client calls tool `deploy_apply` with `yes=true`, a valid `confirm_token`, and `adopt=false`
+- **THEN** the tool result has `isError=true`
+- **AND** the Agentpack envelope includes `errors[0].code = E_ADOPT_CONFIRM_REQUIRED`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-adopt-refusal-next-actions/tasks.md
+++ b/openspec/changes/add-adopt-refusal-next-actions/tasks.md
@@ -1,0 +1,20 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` and `agentpack-mcp` documenting the new refusal detail fields for `E_ADOPT_CONFIRM_REQUIRED`.
+
+### 1.2 Code changes
+- [x] Extend the `E_ADOPT_CONFIRM_REQUIRED` error `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new adopt-related refusal detail fields.
+- [x] Update `docs/reference/json-api.md` guidance (additive fields).
+- [x] Update `docs/reference/error-codes.md` for `E_ADOPT_CONFIRM_REQUIRED` details.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on `E_ADOPT_CONFIRM_REQUIRED`.
+- [x] Extend MCP tests to assert `reason_code` + `next_actions` on `E_ADOPT_CONFIRM_REQUIRED`.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-adopt-refusal-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/handlers/deploy.rs
+++ b/src/handlers/deploy.rs
@@ -90,6 +90,8 @@ fn ensure_adopt_ok(plan: &crate::deploy::PlanResult, adopt: bool) -> anyhow::Res
         )
         .with_details(serde_json::json!({
             "flag": "--adopt",
+            "reason_code": "adopt_confirm_required",
+            "next_actions": ["retry_with_adopt"],
             "adopt_updates": adopt_updates.len(),
             "sample_paths": sample_paths,
         })),

--- a/tests/cli_deploy_adopt_confirmation.rs
+++ b/tests/cli_deploy_adopt_confirmation.rs
@@ -77,6 +77,14 @@ modules:
     let v = parse_stdout_json(&refused);
     assert_eq!(v["errors"][0]["code"], "E_ADOPT_CONFIRM_REQUIRED");
     assert_eq!(
+        v["errors"][0]["details"]["reason_code"],
+        "adopt_confirm_required"
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_adopt"])
+    );
+    assert_eq!(
         std::fs::read_to_string(&existing_path).expect("read existing prompt"),
         "# old\n"
     );

--- a/tests/journey_j3_adopt_update.rs
+++ b/tests/journey_j3_adopt_update.rs
@@ -27,6 +27,14 @@ fn journey_j3_adopt_update_refuse_then_adopt_then_managed_update() {
         refused["errors"][0]["details"]["flag"].as_str(),
         Some("--adopt")
     );
+    assert_eq!(
+        refused["errors"][0]["details"]["reason_code"].as_str(),
+        Some("adopt_confirm_required")
+    );
+    assert_eq!(
+        refused["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_adopt"])
+    );
     assert!(
         refused["errors"][0]["details"]["adopt_updates"]
             .as_u64()


### PR DESCRIPTION
Closes #781

## Summary
- Adds additive `errors[0].details.reason_code` and `errors[0].details.next_actions` for `E_ADOPT_CONFIRM_REQUIRED` (CLI + MCP).
- Documents the new fields in `docs/SPEC.md`, `docs/reference/json-api.md`, and `docs/reference/error-codes.md`.
- Extends CLI + journey + MCP stdio tests to lock the contract.

## Validation
- `openspec validate add-adopt-refusal-next-actions --strict --no-interactive`
- `just check`
