### PR TITLE
feat(json): add reason_code/next_actions to E_TTY_REQUIRED

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -410,6 +410,9 @@ Optional:
   - prompts (minimum): targets, target scope (`project` or `both`), and whether to bootstrap after init
   - if stdin or stdout is not a terminal: MUST fail early and MUST NOT write any files
   - in `--json` mode, non-TTY usage MUST return stable error code `E_TTY_REQUIRED`
+    - `errors[0].details` MUST include additive, machine-actionable fields:
+      - `reason_code` (currently: `tty_required`)
+      - `next_actions` (currently: `["retry_in_tty", "retry_without_guided"]`)
 - `--git`: ensure `.gitignore` contains `.agentpack.manifest*.json` (idempotent).
 - `--bootstrap`: install operator assets into the config repo after init (equivalent to `agentpack bootstrap --scope project`).
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -74,6 +74,7 @@ Typical cases: `init --guided --json` in CI or when stdout is redirected/piped.
 Retryable: yes.
 Recommended action: run the command in an interactive terminal (avoid redirecting stdout; ensure stdin is a terminal).
 Details: includes `{stdin_is_terminal, stdout_is_terminal, hint}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_ADOPT_CONFIRM_REQUIRED
 Meaning: `deploy --apply` would overwrite an existing unmanaged file (`adopt_update`), but `--adopt` was not provided.

--- a/openspec/changes/add-tty-refusal-next-actions/proposal.md
+++ b/openspec/changes/add-tty-refusal-next-actions/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add `reason_code` and `next_actions` to TTY-related refusal errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_TTY_REQUIRED`, but still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, `init --guided --json` in a non-TTY context returns `E_TTY_REQUIRED` with useful context fields, but does not include stable `reason_code` + `next_actions` for orchestrators.
+
+## What Changes
+- Add additive fields under `errors[0].details` for `E_TTY_REQUIRED`:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- For `E_TTY_REQUIRED`, `errors[0].details.reason_code` and `errors[0].details.next_actions` are present and stable.
+- Existing detail fields (e.g. `stdin_is_terminal`, `stdout_is_terminal`, `hint`) are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-tty-refusal-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-tty-refusal-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: TTY-required refusals are machine-actionable
+When a `--json` invocation is refused because a command requires a TTY (i.e., `E_TTY_REQUIRED`), the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+#### Scenario: init --guided --json without a TTY includes refusal details
+- **GIVEN** stdin or stdout is not a terminal
+- **WHEN** the user runs `agentpack init --guided --json`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_TTY_REQUIRED`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-tty-refusal-next-actions/tasks.md
+++ b/openspec/changes/add-tty-refusal-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new refusal detail fields for `E_TTY_REQUIRED`.
+
+### 1.2 Code changes
+- [x] Extend the `E_TTY_REQUIRED` error `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new TTY-related refusal detail fields.
+- [x] Update `docs/reference/error-codes.md` for `E_TTY_REQUIRED` details.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on `E_TTY_REQUIRED`.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-tty-refusal-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -318,6 +318,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, guided: bool, git: bool, bootstrap: bool) -> an
                         serde_json::json!({
                             "stdin_is_terminal": stdin_is_terminal,
                             "stdout_is_terminal": stdout_is_terminal,
+                            "reason_code": "tty_required",
+                            "next_actions": ["retry_in_tty", "retry_without_guided"],
                             "hint": "run init --guided in an interactive terminal",
                         }),
                     ),

--- a/tests/cli_init_guided.rs
+++ b/tests/cli_init_guided.rs
@@ -53,6 +53,14 @@ fn init_guided_json_non_tty_returns_e_tty_required_and_does_not_write() {
     assert_eq!(v["ok"], false);
     assert_eq!(v["command"], "init");
     assert_eq!(v["errors"][0]["code"], "E_TTY_REQUIRED");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("tty_required")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_in_tty", "retry_without_guided"])
+    );
 
     assert!(!tmp.path().join("repo").exists());
 }


### PR DESCRIPTION
Closes #787.

## What
- Add additive refusal guidance fields to `E_TTY_REQUIRED` details:
  - `reason_code: "tty_required"`
  - `next_actions: ["retry_in_tty", "retry_without_guided"]`

## Why
- Orchestrators can branch on stable error codes, but still need machine-actionable “what next” signals without parsing human strings.

## Tests
- `openspec validate add-tty-refusal-next-actions --strict --no-interactive`
- `just check`
