### PR TITLE
feat(json): add reason_code/next_actions to E_IMPORT_CONFLICT

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -428,6 +428,9 @@ Optional:
 Notes:
 - In `--json` mode, `import --apply` is treated as mutating and requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
 - If an import destination already exists inside the config repo, the command refuses to overwrite and returns `E_IMPORT_CONFLICT`.
+  - `errors[0].details` MUST include additive, machine-actionable fields:
+    - `reason_code` (currently: `import_conflict`)
+    - `next_actions` (currently: `["resolve_import_conflict", "retry_import_apply"]`)
 - In `--json` dry-run, the command MAY report conflicts via additive fields (see `docs/JSON_API.md`).
 - If project-scope assets are imported, agentpack MAY create a project-scoped profile (e.g. `project-<project_id>`) to avoid applying project assets under the default profile.
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -90,6 +90,7 @@ Meaning: `import --apply` would overwrite an existing path in the config repo (m
 Retryable: yes.
 Recommended action: delete or move the conflicting destination paths, then re-run `agentpack import --apply`.
 Details: includes `{count, sample_paths, sample_paths_posix, hint}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_CONFIG_MISSING
 Meaning: missing `repo/agentpack.yaml`.

--- a/openspec/changes/add-import-conflict-next-actions/proposal.md
+++ b/openspec/changes/add-import-conflict-next-actions/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add `reason_code` and `next_actions` to import conflict refusal errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_IMPORT_CONFLICT`, but still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, `import --apply --yes --json` can fail with `E_IMPORT_CONFLICT` and useful context like `sample_paths`, but does not include stable `reason_code` + `next_actions` for orchestrators.
+
+## What Changes
+- Add additive fields under `errors[0].details` for `E_IMPORT_CONFLICT`:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- For `E_IMPORT_CONFLICT`, `errors[0].details.reason_code` and `errors[0].details.next_actions` are present and stable.
+- Existing detail fields (e.g. `count`, `sample_paths`, `sample_paths_posix`, `hint`) are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-import-conflict-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-import-conflict-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Import-conflict refusals are machine-actionable
+When a `--json` invocation is refused because an import destination already exists (i.e., `E_IMPORT_CONFLICT`), the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+#### Scenario: import --apply --json fails with refusal details on destination conflicts
+- **GIVEN** a config repo where an import destination path already exists
+- **WHEN** the user runs `agentpack import --apply --yes --json`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` equals `E_IMPORT_CONFLICT`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-import-conflict-next-actions/tasks.md
+++ b/openspec/changes/add-import-conflict-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new refusal detail fields for `E_IMPORT_CONFLICT`.
+
+### 1.2 Code changes
+- [x] Extend the `E_IMPORT_CONFLICT` error `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new import-conflict refusal detail fields.
+- [x] Update `docs/reference/error-codes.md` for `E_IMPORT_CONFLICT` details.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on `E_IMPORT_CONFLICT`.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-import-conflict-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/cli/commands/import.rs
+++ b/src/cli/commands/import.rs
@@ -927,6 +927,8 @@ fn apply_imports(
                 "count": conflicts.len(),
                 "sample_paths": sample.iter().map(|p| p.to_string_lossy().to_string()).collect::<Vec<_>>(),
                 "sample_paths_posix": sample.iter().map(|p| crate::paths::path_to_posix_string(p)).collect::<Vec<_>>(),
+                "reason_code": "import_conflict",
+                "next_actions": ["resolve_import_conflict", "retry_import_apply"],
                 "hint": "delete or move the conflicting destination paths in the config repo, then re-run import",
             })),
         ));

--- a/tests/cli_import.rs
+++ b/tests/cli_import.rs
@@ -465,6 +465,14 @@ fn import_apply_refuses_to_overwrite_existing_dest_path() -> anyhow::Result<()> 
     assert_eq!(v["ok"], false);
     assert_eq!(v["command"], "import");
     assert_eq!(v["errors"][0]["code"], "E_IMPORT_CONFLICT");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("import_conflict")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["resolve_import_conflict", "retry_import_apply"])
+    );
     assert_eq!(v["errors"][0]["details"]["count"], 1);
     assert!(
         v["errors"][0]["details"]["sample_paths_posix"]


### PR DESCRIPTION
Closes #791.

## What
- Add additive refusal guidance fields to `E_IMPORT_CONFLICT` details:
  - `reason_code: "import_conflict"`
  - `next_actions: ["resolve_import_conflict", "retry_import_apply"]`

## Why
- Orchestrators can branch on stable error codes, but still need machine-actionable “what next” signals without parsing human strings.

## Tests
- `openspec validate add-import-conflict-next-actions --strict --no-interactive`
- `just check`
