### PR TITLE
feat(json): add reason_code/next_actions to git refusal errors

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -572,6 +572,12 @@ Behavior:
 - refuses to sync on detached HEAD (in `--json`, returns `E_GIT_DETACHED_HEAD`)
 - requires the configured remote to exist in the config repo (in `--json`, returns `E_GIT_REMOTE_MISSING` if not)
 - requires `git` to be installed and available on PATH (in `--json`, returns `E_GIT_NOT_FOUND` if not)
+  - For these git refusal error codes, `errors[0].details` MUST include additive, machine-actionable fields:
+    - `E_GIT_REPO_REQUIRED`: `reason_code`=`git_repo_required`, `next_actions`=`["init_git_repo", "retry_command"]`
+    - `E_GIT_WORKTREE_DIRTY`: `reason_code`=`git_worktree_dirty`, `next_actions`=`["commit_or_stash", "retry_command"]`
+    - `E_GIT_DETACHED_HEAD`: `reason_code`=`git_detached_head`, `next_actions`=`["checkout_branch", "retry_command"]`
+    - `E_GIT_REMOTE_MISSING`: `reason_code`=`git_remote_missing`, `next_actions`=`["set_git_remote", "retry_command"]`
+    - `E_GIT_NOT_FOUND`: `reason_code`=`git_not_found`, `next_actions`=`["install_git", "retry_command"]`
 
 ### 4.12 `record` / `score`
 
@@ -598,6 +604,7 @@ Notes:
 - In `--json` mode it requires `--yes` (otherwise `E_CONFIRM_REQUIRED`).
 - Requires the config repo to be a git repository (in `--json`, returns `E_GIT_REPO_REQUIRED` if not).
 - Requires a clean working tree in the config repo; it creates a branch and attempts to commit (in `--json`, returns `E_GIT_WORKTREE_DIRTY` if dirty).
+  - For these git refusal error codes, `errors[0].details` MUST include additive, machine-actionable fields `reason_code` and `next_actions` (see `docs/reference/error-codes.md`).
   - If git identity is missing and commit fails, agentpack prints guidance and keeps the branch and changes.
 - Current behavior is conservative: only generate proposals for drift that can be safely attributed to a single module.
   - By default it only processes outputs with `module_ids.len() == 1`.

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -24,6 +24,7 @@ Typical cases: `sync`, `evolve propose`.
 Retryable: yes.
 Recommended action: commit or stash your changes, then retry.
 Details: includes `{command, repo, repo_posix, hint}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_GIT_REPO_REQUIRED
 Meaning: the command requires the config repo to be a git repository, but `.git` was not found.
@@ -31,6 +32,7 @@ Typical cases: `sync`, `evolve propose`.
 Retryable: yes.
 Recommended action: initialize git in the config repo (e.g. `agentpack init --git`), then retry.
 Details: includes `{command, repo, repo_posix, hint}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_GIT_DETACHED_HEAD
 Meaning: the command refused to run because the config repo is on a detached HEAD.
@@ -38,6 +40,7 @@ Typical cases: `sync`.
 Retryable: yes.
 Recommended action: check out a branch (not detached HEAD), then retry.
 Details: includes `{command, repo, repo_posix, hint}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_GIT_REMOTE_MISSING
 Meaning: the command requires a configured git remote in the config repo, but it was not found.
@@ -45,6 +48,7 @@ Typical cases: `sync`.
 Retryable: yes.
 Recommended action: set the remote via `agentpack remote set <url> --name <remote>` (or `git remote add <remote> <url>`), then retry.
 Details: includes `{command, repo, repo_posix, remote, hint}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_GIT_NOT_FOUND
 Meaning: `git` executable was not found (not installed or not on PATH), but the command requires git operations.
@@ -52,6 +56,7 @@ Typical cases: any command that shells out to `git` (e.g. `sync`, `evolve propos
 Retryable: yes.
 Recommended action: install git and ensure `git` is available on PATH, then retry.
 Details: includes `{cwd, cwd_posix, args, hint}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_CONFIRM_TOKEN_REQUIRED
 Meaning: in MCP mode (`agentpack mcp serve`), `deploy_apply` was called with `yes=true` but without a `confirm_token` from the `deploy` tool.

--- a/openspec/changes/add-git-refusal-next-actions/proposal.md
+++ b/openspec/changes/add-git-refusal-next-actions/proposal.md
@@ -1,0 +1,28 @@
+# Change: Add `reason_code` and `next_actions` to git-related refusal errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_GIT_WORKTREE_DIRTY`, but still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, git-related refusal errors include helpful context (`repo`, `remote`, `hint`, etc.) but do not include stable `reason_code` + `next_actions` for orchestrators.
+
+## What Changes
+- Add additive fields under `errors[0].details` for git-related refusal errors:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Cover these errors:
+  - `E_GIT_REPO_REQUIRED`
+  - `E_GIT_WORKTREE_DIRTY`
+  - `E_GIT_DETACHED_HEAD`
+  - `E_GIT_REMOTE_MISSING`
+  - `E_GIT_NOT_FOUND`
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- For each covered git refusal error, `errors[0].details.reason_code` and `errors[0].details.next_actions` are present and stable.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-git-refusal-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-git-refusal-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Git refusal errors are machine-actionable
+When a `--json` invocation is refused due to a git precondition failure, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to these stable error codes:
+- `E_GIT_REPO_REQUIRED`
+- `E_GIT_WORKTREE_DIRTY`
+- `E_GIT_DETACHED_HEAD`
+- `E_GIT_REMOTE_MISSING`
+- `E_GIT_NOT_FOUND`
+
+#### Scenario: sync --json returns machine-actionable git refusal details
+- **GIVEN** the config repo is missing required git preconditions for `sync` (e.g. not a git repo)
+- **WHEN** the user runs `agentpack sync --json`
+- **THEN** the command exits non-zero
+- **AND** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is one of the git refusal error codes above
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-git-refusal-next-actions/tasks.md
+++ b/openspec/changes/add-git-refusal-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new refusal detail fields for git refusal errors.
+
+### 1.2 Code changes
+- [x] Extend git-related refusal errors `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new git refusal detail fields.
+- [x] Update `docs/reference/error-codes.md` for the affected git errors.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on the affected git refusal errors.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-git-refusal-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -44,6 +44,8 @@ impl UserError {
                 "command": command,
                 "repo": repo_dir.display().to_string(),
                 "repo_posix": crate::paths::path_to_posix_string(repo_dir),
+                "reason_code": "git_repo_required",
+                "next_actions": ["init_git_repo", "retry_command"],
                 "hint": "Initialize git in the config repo (agentpack init --git), or run the command in a git-backed config repo.",
             })),
         )
@@ -63,6 +65,8 @@ impl UserError {
                 "command": command,
                 "repo": repo_dir.display().to_string(),
                 "repo_posix": crate::paths::path_to_posix_string(repo_dir),
+                "reason_code": "git_detached_head",
+                "next_actions": ["checkout_branch", "retry_command"],
                 "hint": "Check out a branch (not detached HEAD), then retry.",
             })),
         )
@@ -84,6 +88,8 @@ impl UserError {
                 "repo": repo_dir.display().to_string(),
                 "repo_posix": crate::paths::path_to_posix_string(repo_dir),
                 "remote": remote,
+                "reason_code": "git_remote_missing",
+                "next_actions": ["set_git_remote", "retry_command"],
                 "hint": format!("Set the remote via `agentpack remote set <url> --name {remote}` (or `git remote add {remote} <url>`), then retry."),
             })),
         )
@@ -99,6 +105,8 @@ impl UserError {
                 "cwd": cwd.display().to_string(),
                 "cwd_posix": crate::paths::path_to_posix_string(cwd),
                 "args": args.iter().map(|s| s.to_string()).collect::<Vec<String>>(),
+                "reason_code": "git_not_found",
+                "next_actions": ["install_git", "retry_command"],
                 "hint": "Install git and ensure `git` is available on PATH, then retry.",
             })),
         )
@@ -118,6 +126,8 @@ impl UserError {
                 "command": command,
                 "repo": repo_dir.display().to_string(),
                 "repo_posix": crate::paths::path_to_posix_string(repo_dir),
+                "reason_code": "git_worktree_dirty",
+                "next_actions": ["commit_or_stash", "retry_command"],
                 "hint": "Commit or stash your changes, then retry.",
             })),
         )

--- a/tests/cli_evolve_propose_git_repo_required.rs
+++ b/tests/cli_evolve_propose_git_repo_required.rs
@@ -86,6 +86,14 @@ modules:
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_GIT_REPO_REQUIRED");
     assert_eq!(v["errors"][0]["details"]["command"], "evolve propose");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("git_repo_required")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["init_git_repo", "retry_command"])
+    );
     assert!(v["errors"][0]["details"]["repo"].is_string());
     assert!(v["errors"][0]["details"]["repo_posix"].is_string());
     assert!(v["errors"][0]["details"]["hint"].is_string());

--- a/tests/cli_evolve_propose_git_worktree_dirty.rs
+++ b/tests/cli_evolve_propose_git_worktree_dirty.rs
@@ -91,6 +91,14 @@ modules:
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_GIT_WORKTREE_DIRTY");
     assert_eq!(v["errors"][0]["details"]["command"], "evolve propose");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("git_worktree_dirty")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["commit_or_stash", "retry_command"])
+    );
     assert!(v["errors"][0]["details"]["repo"].is_string());
     assert!(v["errors"][0]["details"]["repo_posix"].is_string());
     assert!(v["errors"][0]["details"]["hint"].is_string());

--- a/tests/cli_git_not_found.rs
+++ b/tests/cli_git_not_found.rs
@@ -19,6 +19,14 @@ fn stable_error_code_when_git_executable_missing() {
     assert_eq!(v["ok"], false);
     assert_eq!(v["command"], "sync");
     assert_eq!(v["errors"][0]["code"], "E_GIT_NOT_FOUND");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("git_not_found")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["install_git", "retry_command"])
+    );
     assert!(v["errors"][0]["details"]["cwd"].is_string());
     assert!(v["errors"][0]["details"]["cwd_posix"].is_string());
     assert!(v["errors"][0]["details"]["args"].is_array());

--- a/tests/cli_sync_git_detached_head.rs
+++ b/tests/cli_sync_git_detached_head.rs
@@ -33,6 +33,14 @@ fn sync_returns_stable_error_code_when_on_detached_head() {
     assert_eq!(v["command"], "sync");
     assert_eq!(v["errors"][0]["code"], "E_GIT_DETACHED_HEAD");
     assert_eq!(v["errors"][0]["details"]["command"], "sync");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("git_detached_head")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["checkout_branch", "retry_command"])
+    );
     assert!(v["errors"][0]["details"]["repo"].is_string());
     assert!(v["errors"][0]["details"]["repo_posix"].is_string());
     assert!(v["errors"][0]["details"]["hint"].is_string());

--- a/tests/cli_sync_git_remote_missing.rs
+++ b/tests/cli_sync_git_remote_missing.rs
@@ -34,6 +34,14 @@ fn sync_returns_stable_error_code_when_remote_missing() {
     assert_eq!(v["errors"][0]["code"], "E_GIT_REMOTE_MISSING");
     assert_eq!(v["errors"][0]["details"]["command"], "sync");
     assert_eq!(v["errors"][0]["details"]["remote"], "origin");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("git_remote_missing")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["set_git_remote", "retry_command"])
+    );
     assert!(v["errors"][0]["details"]["repo"].is_string());
     assert!(v["errors"][0]["details"]["repo_posix"].is_string());
     assert!(v["errors"][0]["details"]["hint"].is_string());

--- a/tests/cli_sync_git_repo_required.rs
+++ b/tests/cli_sync_git_repo_required.rs
@@ -18,6 +18,14 @@ fn sync_returns_stable_error_code_when_config_repo_is_not_git() {
     assert_eq!(v["command"], "sync");
     assert_eq!(v["errors"][0]["code"], "E_GIT_REPO_REQUIRED");
     assert_eq!(v["errors"][0]["details"]["command"], "sync");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("git_repo_required")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["init_git_repo", "retry_command"])
+    );
     assert!(v["errors"][0]["details"]["repo"].is_string());
     assert!(v["errors"][0]["details"]["repo_posix"].is_string());
     assert!(v["errors"][0]["details"]["hint"].is_string());

--- a/tests/cli_sync_git_worktree_dirty.rs
+++ b/tests/cli_sync_git_worktree_dirty.rs
@@ -26,6 +26,14 @@ fn sync_returns_stable_error_code_when_git_worktree_dirty() {
     assert_eq!(v["command"], "sync");
     assert_eq!(v["errors"][0]["code"], "E_GIT_WORKTREE_DIRTY");
     assert_eq!(v["errors"][0]["details"]["command"], "sync");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("git_worktree_dirty")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["commit_or_stash", "retry_command"])
+    );
     assert!(v["errors"][0]["details"]["repo"].is_string());
     assert!(v["errors"][0]["details"]["repo_posix"].is_string());
     assert!(v["errors"][0]["details"]["hint"].is_string());


### PR DESCRIPTION
Closes #795.

## What
Adds additive refusal guidance fields to these errors:
- `E_GIT_REPO_REQUIRED`: `reason_code="git_repo_required"`, `next_actions=["init_git_repo","retry_command"]`
- `E_GIT_WORKTREE_DIRTY`: `reason_code="git_worktree_dirty"`, `next_actions=["commit_or_stash","retry_command"]`
- `E_GIT_DETACHED_HEAD`: `reason_code="git_detached_head"`, `next_actions=["checkout_branch","retry_command"]`
- `E_GIT_REMOTE_MISSING`: `reason_code="git_remote_missing"`, `next_actions=["set_git_remote","retry_command"]`
- `E_GIT_NOT_FOUND`: `reason_code="git_not_found"`, `next_actions=["install_git","retry_command"]`

## Why
Orchestrators can branch on stable error codes, but still need machine-actionable “what next” signals without parsing human strings.

## Tests
- `openspec validate add-git-refusal-next-actions --strict --no-interactive`
- `just check`
