### PR TITLE
feat(json): add reason_code/next_actions to overlay conflict errors

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -325,6 +325,9 @@ Patch overlays
   - each `.patch` MUST represent a single-file unified diff, and its header path MUST match the patch filename-derived `<relpath>`
 - a single overlay directory MUST NOT mix directory override files and patch artifacts (treat as configuration error)
 - on patch apply failure, commands return stable error code `E_OVERLAY_PATCH_APPLY_FAILED`
+  - `errors[0].details` MUST include additive, machine-actionable fields:
+    - `reason_code` (currently: `overlay_patch_apply_failed`)
+    - `next_actions` (currently: `["regenerate_patch", "switch_to_dir_overlay", "retry_command"]`)
 
 Patch layout:
 - `<overlay_dir>/.agentpack/patches/<relpath>.patch`
@@ -350,6 +353,9 @@ Implemented options:
   - it merges edited content against the latest upstream version using a 3-way merge
   - on success, it rewrites the patch file to apply cleanly to the latest upstream version
   - on conflicts, it writes conflict-marked full file content under `<overlay_dir>/.agentpack/conflicts/<relpath>` and returns `E_OVERLAY_REBASE_CONFLICT`
+    - `errors[0].details` MUST include additive, machine-actionable fields:
+      - `reason_code` (currently: `overlay_rebase_conflict`)
+      - `next_actions` (currently: `["resolve_overlay_conflicts", "retry_overlay_rebase"]`)
   - if the patch becomes a no-op after rebase, it deletes the patch file (empty patches are not supported) and prunes now-empty parent directories under `.agentpack/patches/`
 - for files that were copied into overlay but not modified (`ours == base`): update them to latest upstream (avoid unintentionally pinning old versions)
 - on success: refresh baseline (so drift warnings are computed from the latest upstream)

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -168,6 +168,7 @@ Meaning: `overlay rebase` produced conflicts that cannot be auto-merged.
 Retryable: yes (after resolving conflicts).
 Recommended action: open the conflict-marked files under the overlay directory (for patch overlays: `.agentpack/conflicts/<relpath>`), resolve, then re-run `agentpack overlay rebase` (or commit overlay changes directly).
 Details: includes `{conflicts, summary, overlay_dir, scope, ...}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_OVERLAY_PATCH_APPLY_FAILED
 Meaning: patch overlay application failed during desired-state generation (the patch could not be applied cleanly).
@@ -176,6 +177,7 @@ Recommended action:
 - regenerate the patch against current upstream (or lower overlays) content, or
 - switch to a directory overlay for that file.
 Details: includes `{module_id, scope, overlay_dir, patch_file, relpath, stderr, ...}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_POLICY_VIOLATIONS
 Meaning: `policy lint` detected one or more governance policy violations.

--- a/openspec/changes/add-overlay-conflict-next-actions/proposal.md
+++ b/openspec/changes/add-overlay-conflict-next-actions/proposal.md
@@ -1,0 +1,25 @@
+# Change: Add `reason_code` and `next_actions` to overlay conflict errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_OVERLAY_REBASE_CONFLICT`, but still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, overlay conflict errors include useful context (conflict file lists, patch stderr, etc.) but do not include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for overlay conflict errors:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Cover these errors:
+  - `E_OVERLAY_REBASE_CONFLICT`
+  - `E_OVERLAY_PATCH_APPLY_FAILED`
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- For each covered overlay conflict error, `errors[0].details.reason_code` and `errors[0].details.next_actions` are present and stable.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-overlay-conflict-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-overlay-conflict-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Overlay conflict errors are machine-actionable
+When a `--json` invocation fails due to an overlay conflict, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to these stable error codes:
+- `E_OVERLAY_REBASE_CONFLICT`
+- `E_OVERLAY_PATCH_APPLY_FAILED`
+
+#### Scenario: overlay conflict errors include guidance fields
+- **GIVEN** an overlay operation fails due to conflicts or patch apply failures
+- **WHEN** the user runs a command that produces `E_OVERLAY_REBASE_CONFLICT` or `E_OVERLAY_PATCH_APPLY_FAILED` in `--json` mode
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-overlay-conflict-next-actions/tasks.md
+++ b/openspec/changes/add-overlay-conflict-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new refusal detail fields for overlay conflict errors.
+
+### 1.2 Code changes
+- [x] Extend overlay conflict error `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new overlay conflict detail fields.
+- [x] Update `docs/reference/error-codes.md` for the affected overlay errors.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on the affected overlay conflict errors.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-overlay-conflict-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/cli/commands/overlay.rs
+++ b/src/cli/commands/overlay.rs
@@ -212,6 +212,8 @@ pub(crate) fn run(ctx: &Ctx<'_>, command: &OverlayCommands) -> anyhow::Result<()
                         "sparsify": sparsify,
                         "conflicts": report.conflicts,
                         "summary": report.summary,
+                        "reason_code": "overlay_rebase_conflict",
+                        "next_actions": ["resolve_overlay_conflicts", "retry_overlay_rebase"],
                     })),
                 ));
             }

--- a/src/overlay/patch/mod.rs
+++ b/src/overlay/patch/mod.rs
@@ -200,6 +200,8 @@ pub(super) fn apply_patch_overlays(
                     "patch_file": patch_file.to_string_lossy(),
                     "relpath": rel_target,
                     "stderr": String::from_utf8_lossy(&out.stderr),
+                    "reason_code": "overlay_patch_apply_failed",
+                    "next_actions": ["regenerate_patch", "switch_to_dir_overlay", "retry_command"],
                     "hint": "regenerate the patch against the current upstream (or lower overlays) content",
                 })),
             ));

--- a/tests/cli_overlay_rebase_conflicts.rs
+++ b/tests/cli_overlay_rebase_conflicts.rs
@@ -109,6 +109,14 @@ fn overlay_rebase_conflicts_return_stable_json_error_code() -> anyhow::Result<()
     let v = parse_stdout_json(&rebase);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_OVERLAY_REBASE_CONFLICT");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("overlay_rebase_conflict")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["resolve_overlay_conflicts", "retry_overlay_rebase"])
+    );
 
     Ok(())
 }

--- a/tests/cli_patch_overlay_rebase.rs
+++ b/tests/cli_patch_overlay_rebase.rs
@@ -243,6 +243,14 @@ fn overlay_rebase_patch_conflict_writes_conflict_artifact_and_returns_error_code
     let v = parse_stdout_json(&rebase);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_OVERLAY_REBASE_CONFLICT");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("overlay_rebase_conflict")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["resolve_overlay_conflicts", "retry_overlay_rebase"])
+    );
 
     let conflict_path = overlay_dir.join(".agentpack/conflicts/SKILL.md");
     assert!(

--- a/tests/cli_patch_overlays_apply.rs
+++ b/tests/cli_patch_overlays_apply.rs
@@ -197,4 +197,12 @@ modules:
     let v = parse_stdout_json(&out);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_OVERLAY_PATCH_APPLY_FAILED");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("overlay_patch_apply_failed")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["regenerate_patch", "switch_to_dir_overlay", "retry_command"])
+    );
 }

--- a/tests/journey_j4_overlay_rebase.rs
+++ b/tests/journey_j4_overlay_rebase.rs
@@ -80,6 +80,14 @@ fn journey_j4_overlay_sparse_materialize_rebase_conflict_then_deploy() {
         rebase["errors"][0]["code"].as_str(),
         Some("E_OVERLAY_REBASE_CONFLICT")
     );
+    assert_eq!(
+        rebase["errors"][0]["details"]["reason_code"].as_str(),
+        Some("overlay_rebase_conflict")
+    );
+    assert_eq!(
+        rebase["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["resolve_overlay_conflicts", "retry_overlay_rebase"])
+    );
     let conflicts = rebase["errors"][0]["details"]["conflicts"]
         .as_array()
         .expect("conflicts array");

--- a/tests/journey_j5_patch_overlay.rs
+++ b/tests/journey_j5_patch_overlay.rs
@@ -93,6 +93,14 @@ fn journey_j5_patch_overlay_generate_rebase_conflict_then_deploy() {
         rebase["errors"][0]["code"].as_str(),
         Some("E_OVERLAY_REBASE_CONFLICT")
     );
+    assert_eq!(
+        rebase["errors"][0]["details"]["reason_code"].as_str(),
+        Some("overlay_rebase_conflict")
+    );
+    assert_eq!(
+        rebase["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["resolve_overlay_conflicts", "retry_overlay_rebase"])
+    );
     let conflicts = rebase["errors"][0]["details"]["conflicts"]
         .as_array()
         .expect("conflicts array");


### PR DESCRIPTION
Closes #799

Adds additive, machine-actionable guidance fields to overlay conflict errors:
- `errors[0].details.reason_code`
- `errors[0].details.next_actions`

Covered error codes:
- `E_OVERLAY_REBASE_CONFLICT` (`overlay_rebase_conflict`, `["resolve_overlay_conflicts", "retry_overlay_rebase"]`)
- `E_OVERLAY_PATCH_APPLY_FAILED` (`overlay_patch_apply_failed`, `["regenerate_patch", "switch_to_dir_overlay", "retry_command"]`)

Docs:
- `docs/SPEC.md`
- `docs/reference/error-codes.md`

Tests:
- `openspec validate add-overlay-conflict-next-actions --strict --no-interactive`
- `just check`
