### PR TITLE
feat(json): add reason_code/next_actions to E_DESIRED_STATE_CONFLICT

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -492,6 +492,9 @@ Notes:
 - if multiple modules produce the same `(target, path)`:
   - same content: merge `module_ids` (for provenance/explain)
   - different content: error and return `E_DESIRED_STATE_CONFLICT` (block apply by default)
+    - `errors[0].details` MUST include additive, machine-actionable fields:
+      - `reason_code` (currently: `desired_state_conflict`)
+      - `next_actions` (currently: `["resolve_desired_state_conflict", "retry_command"]`)
 
 `agentpack diff`
 - prints per-file text diffs; in JSON mode prints diff summary + file hash changes

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -147,6 +147,7 @@ Meaning: multiple modules produced different content for the same `(target, path
 Retryable: depends on config/overlay fixes.
 Recommended action: adjust modules/overlays so only one module produces that path, or make the contents identical.
 Details: includes both sides’ sha256 and module_ids.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_OVERLAY_NOT_FOUND
 Meaning: requested overlay directory does not exist.

--- a/openspec/changes/add-desired-state-conflict-next-actions/proposal.md
+++ b/openspec/changes/add-desired-state-conflict-next-actions/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add `reason_code` and `next_actions` to desired-state conflict errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_DESIRED_STATE_CONFLICT`, but still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, desired-state conflict errors include useful context (module_ids + hashes on both sides) but do not include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for `E_DESIRED_STATE_CONFLICT`:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- `E_DESIRED_STATE_CONFLICT` in `--json` mode includes `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-desired-state-conflict-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-desired-state-conflict-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Desired-state conflict errors are machine-actionable
+When a `--json` invocation fails due to conflicting desired outputs, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to the stable error code `E_DESIRED_STATE_CONFLICT`.
+
+#### Scenario: desired-state conflict includes guidance fields
+- **GIVEN** multiple modules produce different content for the same `(target, path)`
+- **WHEN** the user runs a command that produces `E_DESIRED_STATE_CONFLICT` in `--json` mode
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-desired-state-conflict-next-actions/tasks.md
+++ b/openspec/changes/add-desired-state-conflict-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new guidance detail fields for `E_DESIRED_STATE_CONFLICT`.
+
+### 1.2 Code changes
+- [x] Extend `E_DESIRED_STATE_CONFLICT` error `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new `E_DESIRED_STATE_CONFLICT` detail fields.
+- [x] Update `docs/reference/error-codes.md` for `E_DESIRED_STATE_CONFLICT`.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on `E_DESIRED_STATE_CONFLICT`.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-desired-state-conflict-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -56,6 +56,8 @@ pub fn insert_desired_file(
                 "sha256": sha256_hex(&bytes),
                 "module_ids": module_ids,
             },
+            "reason_code": "desired_state_conflict",
+            "next_actions": ["resolve_desired_state_conflict", "retry_command"],
         });
 
         return Err(anyhow::Error::new(

--- a/tests/cli_desired_state_conflict.rs
+++ b/tests/cli_desired_state_conflict.rs
@@ -83,6 +83,14 @@ modules:
     let v = parse_stdout_json(&plan);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_DESIRED_STATE_CONFLICT");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("desired_state_conflict")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["resolve_desired_state_conflict", "retry_command"])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #803

Adds additive, machine-actionable guidance fields to `E_DESIRED_STATE_CONFLICT`:
- `errors[0].details.reason_code` = `desired_state_conflict`
- `errors[0].details.next_actions` = `["resolve_desired_state_conflict", "retry_command"]`

Docs:
- `docs/SPEC.md`
- `docs/reference/error-codes.md`

Tests:
- `openspec validate add-desired-state-conflict-next-actions --strict --no-interactive`
- `just check`
