### PR TITLE
feat(json): add reason_code/next_actions to E_POLICY_VIOLATIONS

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -729,6 +729,9 @@ Exit codes:
 JSON mode:
 - On success: `command="policy.lint"`, `ok=true`, and `data` contains `{root, root_posix, issues, summary}` (issues will be empty).
 - On violations: `ok=false`, `errors[0].code="E_POLICY_VIOLATIONS"`, and `errors[0].details` contains `{root, root_posix, issues, summary}` (note: `data` is `{}` on failure).
+  - `errors[0].details` MUST include additive, machine-actionable fields:
+    - `reason_code` (currently: `policy_violations`)
+    - `next_actions` (currently: `["fix_policy_violations", "retry_policy_lint"]`)
 
 ### 4.20 `policy lock` (governance, mutating)
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -187,6 +187,7 @@ Recommended action:
 - Run `agentpack policy lint --json` to get machine-readable issues (suitable for CI gating).
 - Fix the reported issues and rerun until `ok=true`.
 Details: includes `{root, root_posix, issues, summary}` where `issues[]` items include `{rule, path, path_posix, message, details?}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_POLICY_CONFIG_MISSING
 Meaning: missing `repo/agentpack.org.yaml` when running governance policy commands that require it (e.g., `agentpack policy lock`).

--- a/openspec/changes/add-policy-violations-next-actions/proposal.md
+++ b/openspec/changes/add-policy-violations-next-actions/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add `reason_code` and `next_actions` to policy violation errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_POLICY_VIOLATIONS`, but still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, policy violations include detailed issue reports, but do not include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for `E_POLICY_VIOLATIONS`:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- `E_POLICY_VIOLATIONS` in `--json` mode includes `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-policy-violations-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-policy-violations-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Policy violation errors are machine-actionable
+When a `--json` invocation fails due to policy violations, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to the stable error code `E_POLICY_VIOLATIONS`.
+
+#### Scenario: policy violations include guidance fields
+- **GIVEN** `policy lint` detects one or more violations
+- **WHEN** the user runs `agentpack policy lint --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_POLICY_VIOLATIONS`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-policy-violations-next-actions/tasks.md
+++ b/openspec/changes/add-policy-violations-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new guidance detail fields for `E_POLICY_VIOLATIONS`.
+
+### 1.2 Code changes
+- [x] Extend `E_POLICY_VIOLATIONS` error `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new `E_POLICY_VIOLATIONS` detail fields.
+- [x] Update `docs/reference/error-codes.md` for `E_POLICY_VIOLATIONS`.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on `E_POLICY_VIOLATIONS`.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-policy-violations-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/cli/commands/policy.rs
+++ b/src/cli/commands/policy.rs
@@ -27,12 +27,24 @@ fn lint(ctx: &Ctx<'_>) -> anyhow::Result<()> {
             return Ok(());
         }
 
+        let mut details = serde_json::to_value(&report).context("serialize policy lint report")?;
+        if let Some(obj) = details.as_object_mut() {
+            obj.insert(
+                "reason_code".to_string(),
+                serde_json::Value::String("policy_violations".to_string()),
+            );
+            obj.insert(
+                "next_actions".to_string(),
+                serde_json::json!(["fix_policy_violations", "retry_policy_lint"]),
+            );
+        }
+
         return Err(anyhow::Error::new(
             UserError::new(
                 "E_POLICY_VIOLATIONS",
                 format!("policy lint found {violations} violation(s)"),
             )
-            .with_details(serde_json::to_value(&report).context("serialize policy lint report")?),
+            .with_details(details),
         ));
     }
 
@@ -44,12 +56,24 @@ fn lint(ctx: &Ctx<'_>) -> anyhow::Result<()> {
         return Ok(());
     }
 
+    let mut details = serde_json::to_value(&report).context("serialize policy lint report")?;
+    if let Some(obj) = details.as_object_mut() {
+        obj.insert(
+            "reason_code".to_string(),
+            serde_json::Value::String("policy_violations".to_string()),
+        );
+        obj.insert(
+            "next_actions".to_string(),
+            serde_json::json!(["fix_policy_violations", "retry_policy_lint"]),
+        );
+    }
+
     Err(anyhow::Error::new(
         UserError::new(
             "E_POLICY_VIOLATIONS",
             format!("policy lint found {violations} violation(s)"),
         )
-        .with_details(serde_json::to_value(&report).context("serialize policy lint report")?),
+        .with_details(details),
     ))
 }
 

--- a/tests/cli_policy_lint.rs
+++ b/tests/cli_policy_lint.rs
@@ -20,6 +20,17 @@ fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
     serde_json::from_str(&stdout).expect("stdout is valid json")
 }
 
+fn assert_policy_violation_guidance(v: &serde_json::Value) {
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("policy_violations")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["fix_policy_violations", "retry_policy_lint"])
+    );
+}
+
 #[test]
 fn policy_lint_json_succeeds_when_no_violations() {
     let td = tempfile::tempdir().expect("tempdir");
@@ -93,6 +104,7 @@ agentpack deploy --apply --json
     let v = parse_stdout_json(&out);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_POLICY_VIOLATIONS");
+    assert_policy_violation_guidance(&v);
 
     let issues = v["errors"][0]["details"]["issues"]
         .as_array()
@@ -147,6 +159,7 @@ modules: []
     let v = parse_stdout_json(&out);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_POLICY_VIOLATIONS");
+    assert_policy_violation_guidance(&v);
 
     let issues = v["errors"][0]["details"]["issues"]
         .as_array()
@@ -205,6 +218,7 @@ modules:
     let v = parse_stdout_json(&out);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_POLICY_VIOLATIONS");
+    assert_policy_violation_guidance(&v);
 
     let issues = v["errors"][0]["details"]["issues"]
         .as_array()
@@ -275,6 +289,7 @@ modules:
     let v = parse_stdout_json(&out);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_POLICY_VIOLATIONS");
+    assert_policy_violation_guidance(&v);
 
     let issues = v["errors"][0]["details"]["issues"]
         .as_array()
@@ -358,6 +373,7 @@ modules: []
     let v = parse_stdout_json(&out);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_POLICY_VIOLATIONS");
+    assert_policy_violation_guidance(&v);
 
     let issues = v["errors"][0]["details"]["issues"]
         .as_array()
@@ -468,6 +484,7 @@ modules:
     let v = parse_stdout_json(&out);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_POLICY_VIOLATIONS");
+    assert_policy_violation_guidance(&v);
 
     let issues = v["errors"][0]["details"]["issues"]
         .as_array()


### PR DESCRIPTION
Closes #807

Adds additive, machine-actionable guidance fields to `E_POLICY_VIOLATIONS`:
- `errors[0].details.reason_code` = `policy_violations`
- `errors[0].details.next_actions` = `["fix_policy_violations", "retry_policy_lint"]`

Docs:
- `docs/SPEC.md`
- `docs/reference/error-codes.md`

Tests:
- `openspec validate add-policy-violations-next-actions --strict --no-interactive`
- `just check`
