### PR TITLE
feat(json): add reason_code/next_actions to E_TARGET_UNSUPPORTED

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -772,6 +772,7 @@ Build-time target selection:
 - Default builds include all built-in targets.
 - `agentpack help --json` includes `data.targets[]` listing targets compiled into the running binary.
 - Selecting a non-compiled target is treated as unsupported (`E_TARGET_UNSUPPORTED`).
+  - In `--json`, `E_TARGET_UNSUPPORTED` errors include additive guidance fields under `errors[0].details`: `reason_code` and `next_actions`.
 
 ### 5.1 `codex` target
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -141,6 +141,8 @@ Retryable: yes.
 Recommended action:
 - `--target` must be `all|codex|claude_code|cursor|vscode|jetbrains|zed` (but feature-gated builds may support a subset; see `agentpack help --json` `data.targets[]`).
 - Manifest targets must be built-in targets that are compiled into the running binary.
+Details: includes `{target, allowed, missing?, compiled?}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_DESIRED_STATE_CONFLICT
 Meaning: multiple modules produced different content for the same `(target, path)`. Agentpack refuses to silently overwrite.

--- a/openspec/changes/add-target-unsupported-next-actions/proposal.md
+++ b/openspec/changes/add-target-unsupported-next-actions/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add `reason_code` and `next_actions` to target-unsupported errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_TARGET_UNSUPPORTED`, but still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, target selection/validation errors include useful context (e.g., `allowed`, `compiled`, `missing`), but do not consistently include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for `E_TARGET_UNSUPPORTED`:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- `E_TARGET_UNSUPPORTED` in `--json` mode includes `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-target-unsupported-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-target-unsupported-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Target unsupported errors are machine-actionable
+When a `--json` invocation fails due to an unsupported target selection, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to the stable error code `E_TARGET_UNSUPPORTED`.
+
+#### Scenario: target unsupported includes guidance fields
+- **WHEN** the user runs `agentpack plan --target nope --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_TARGET_UNSUPPORTED`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-target-unsupported-next-actions/tasks.md
+++ b/openspec/changes/add-target-unsupported-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new guidance detail fields for `E_TARGET_UNSUPPORTED`.
+
+### 1.2 Code changes
+- [x] Extend `E_TARGET_UNSUPPORTED` error `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new `E_TARGET_UNSUPPORTED` detail fields.
+- [x] Update `docs/reference/error-codes.md` for `E_TARGET_UNSUPPORTED`.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on `E_TARGET_UNSUPPORTED`.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-target-unsupported-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,6 +272,13 @@ fn validate_manifest(manifest: &Manifest) -> anyhow::Result<()> {
                     .with_details(serde_json::json!({
                         "target": target_name,
                         "allowed": crate::target_registry::COMPILED_TARGETS,
+                        "reason_code": "target_not_compiled",
+                        "next_actions": [
+                            "inspect_help_json",
+                            "edit_manifest_targets",
+                            "rebuild_with_target_feature",
+                            "retry_command",
+                        ],
                     })),
                 ));
             }
@@ -305,6 +312,13 @@ fn validate_manifest(manifest: &Manifest) -> anyhow::Result<()> {
                         "module_id": m.id,
                         "target": t,
                         "allowed": crate::target_registry::COMPILED_TARGETS,
+                        "reason_code": "target_not_compiled",
+                        "next_actions": [
+                            "inspect_help_json",
+                            "edit_manifest_targets",
+                            "rebuild_with_target_feature",
+                            "retry_command",
+                        ],
                     })),
                 ));
             }

--- a/src/target_selection.rs
+++ b/src/target_selection.rs
@@ -22,6 +22,13 @@ pub fn selected_targets(manifest: &Manifest, target_filter: &str) -> anyhow::Res
                         "target": "all",
                         "missing": missing,
                         "compiled": crate::target_registry::COMPILED_TARGETS,
+                        "reason_code": "target_not_compiled",
+                        "next_actions": [
+                            "inspect_help_json",
+                            "edit_manifest_targets",
+                            "rebuild_with_target_feature",
+                            "retry_command",
+                        ],
                     })),
                 ));
             }
@@ -47,6 +54,8 @@ pub fn selected_targets(manifest: &Manifest, target_filter: &str) -> anyhow::Res
             .with_details(serde_json::json!({
                 "target": other,
                 "allowed": crate::target_registry::allowed_target_filters(),
+                "reason_code": "target_filter_unsupported",
+                "next_actions": ["inspect_help_json", "retry_with_supported_target"],
             })),
         )),
     }


### PR DESCRIPTION
Closes #811.

Adds additive guidance fields to E_TARGET_UNSUPPORTED error details:
- errors[0].details.reason_code
- errors[0].details.next_actions

Also updates docs + tests and includes OpenSpec change add-target-unsupported-next-actions.