### PR TITLE
feat(json): add reason_code/next_actions to E_CONFIG_MISSING

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -28,7 +28,7 @@ All commands default to human-readable output; pass `--json` for machine-readabl
 When `--json` is enabled, common actionable failures must return stable error codes in `errors[0].code`:
 - `E_CONFIRM_REQUIRED`: in `--json` mode, a mutating command is missing `--yes`.
 - `E_ADOPT_CONFIRM_REQUIRED`: would overwrite an existing unmanaged file (`adopt_update`), but `--adopt` was not provided.
-- `E_CONFIG_MISSING`: missing `repo/agentpack.yaml`.
+- `E_CONFIG_MISSING`: missing `repo/agentpack.yaml` (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_CONFIG_INVALID`: `agentpack.yaml` is syntactically or semantically invalid (e.g. missing default profile, duplicate module id, invalid source config).
 - `E_CONFIG_UNSUPPORTED_VERSION`: `agentpack.yaml` `version` is unsupported.
 - `E_LOCKFILE_MISSING`: missing `repo/agentpack.lock.json` but the command requires it (e.g. `fetch`).

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -102,6 +102,7 @@ Meaning: missing `repo/agentpack.yaml`.
 Retryable: yes.
 Recommended action: run `agentpack init` to create a skeleton, or point to the correct repo via `--repo`.
 Details: typically includes `{path, hint}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_CONFIG_INVALID
 Meaning: `agentpack.yaml` is syntactically or semantically invalid.

--- a/openspec/changes/add-config-missing-next-actions/proposal.md
+++ b/openspec/changes/add-config-missing-next-actions/proposal.md
@@ -1,0 +1,22 @@
+# Change: Add `reason_code` and `next_actions` to config-missing errors
+
+## Why
+Automation can reliably branch on the stable error code `E_CONFIG_MISSING`, but still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, `E_CONFIG_MISSING` includes a human `hint`, but does not include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for `E_CONFIG_MISSING`:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- `E_CONFIG_MISSING` in `--json` mode includes `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-config-missing-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-config-missing-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Config missing errors are machine-actionable
+When a `--json` invocation fails due to a missing config manifest, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to the stable error code `E_CONFIG_MISSING`.
+
+#### Scenario: config missing includes guidance fields
+- **GIVEN** the config repo does not contain `repo/agentpack.yaml`
+- **WHEN** the user runs `agentpack plan --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_CONFIG_MISSING`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-config-missing-next-actions/tasks.md
+++ b/openspec/changes/add-config-missing-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new guidance detail fields for `E_CONFIG_MISSING`.
+
+### 1.2 Code changes
+- [x] Extend `E_CONFIG_MISSING` error `details` to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new `E_CONFIG_MISSING` detail fields.
+- [x] Update `docs/reference/error-codes.md` for `E_CONFIG_MISSING`.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on `E_CONFIG_MISSING`.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-config-missing-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,6 +141,8 @@ impl Manifest {
                     )
                     .with_details(serde_json::json!({
                         "path": path.to_string_lossy(),
+                        "reason_code": "config_missing",
+                        "next_actions": ["run_init", "retry_with_repo", "retry_command"],
                         "hint": "run `agentpack init` to create a repo skeleton",
                     })),
                 ));

--- a/tests/cli_error_codes.rs
+++ b/tests/cli_error_codes.rs
@@ -26,6 +26,14 @@ fn json_error_code_config_missing() {
     assert!(!out.status.success());
     let v = parse_stdout_json(&out);
     assert_eq!(v["errors"][0]["code"], "E_CONFIG_MISSING");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("config_missing")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["run_init", "retry_with_repo", "retry_command"])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #815.

Adds additive guidance fields to E_CONFIG_MISSING error details:
- errors[0].details.reason_code
- errors[0].details.next_actions

Also updates docs + tests and includes OpenSpec change add-config-missing-next-actions.