### PR TITLE
feat(json): add lockfile refusal guidance

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -31,9 +31,9 @@ When `--json` is enabled, common actionable failures must return stable error co
 - `E_CONFIG_MISSING`: missing `repo/agentpack.yaml` (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_CONFIG_INVALID`: `agentpack.yaml` is syntactically or semantically invalid (e.g. missing default profile, duplicate module id, invalid source config).
 - `E_CONFIG_UNSUPPORTED_VERSION`: `agentpack.yaml` `version` is unsupported.
-- `E_LOCKFILE_MISSING`: missing `repo/agentpack.lock.json` but the command requires it (e.g. `fetch`).
-- `E_LOCKFILE_INVALID`: `agentpack.lock.json` is invalid JSON.
-- `E_LOCKFILE_UNSUPPORTED_VERSION`: `agentpack.lock.json` `version` is unsupported.
+- `E_LOCKFILE_MISSING`: missing `repo/agentpack.lock.json` but the command requires it (e.g. `fetch`) (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_LOCKFILE_INVALID`: `agentpack.lock.json` is invalid JSON (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_LOCKFILE_UNSUPPORTED_VERSION`: `agentpack.lock.json` `version` is unsupported (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_TARGET_UNSUPPORTED`: an unsupported target (manifest targets or CLI `--target` selection).
 - `E_DESIRED_STATE_CONFLICT`: multiple modules produced different content for the same `(target, path)` (refuse silent overwrite).
 - `E_OVERLAY_NOT_FOUND`: overlay directory does not exist (overlay not created yet).

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -121,17 +121,22 @@ Details: typically includes `{version, supported}`.
 Meaning: missing `repo/agentpack.lock.json` but the command requires it (e.g., `fetch`).
 Retryable: yes.
 Recommended action: run `agentpack lock` or `agentpack update`.
+Details: includes `{path, hint}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_LOCKFILE_INVALID
 Meaning: `agentpack.lock.json` is invalid JSON or cannot be parsed.
 Retryable: depends on repair/rebuild.
 Recommended action: fix JSON or delete it and regenerate via `agentpack update`.
+Details: includes `{path, error}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_LOCKFILE_UNSUPPORTED_VERSION
 Meaning: `agentpack.lock.json` `version` is unsupported.
 Retryable: depends on upgrading agentpack or regenerating lockfile.
 Recommended action: upgrade agentpack, or regenerate the lockfile via `agentpack lock` / `agentpack update`.
-Details: typically includes `{version, supported}`.
+Details: includes `{path, version, supported, hint}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_TARGET_UNSUPPORTED
 Meaning:

--- a/openspec/changes/add-lockfile-next-actions/.openspec.yaml
+++ b/openspec/changes/add-lockfile-next-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-24

--- a/openspec/changes/add-lockfile-next-actions/README.md
+++ b/openspec/changes/add-lockfile-next-actions/README.md
@@ -1,0 +1,3 @@
+# add-lockfile-next-actions
+
+Add reason_code and next_actions for lockfile-related error codes

--- a/openspec/changes/add-lockfile-next-actions/proposal.md
+++ b/openspec/changes/add-lockfile-next-actions/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add `reason_code` and `next_actions` to lockfile-related errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_LOCKFILE_MISSING`, but it still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, lockfile-related errors include human `hint` strings, but do not include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for lockfile errors:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Apply to these stable error codes:
+  - `E_LOCKFILE_MISSING`
+  - `E_LOCKFILE_INVALID`
+  - `E_LOCKFILE_UNSUPPORTED_VERSION`
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- Lockfile errors in `--json` mode include `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-lockfile-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-lockfile-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Lockfile errors are machine-actionable
+When a `--json` invocation fails due to a missing/invalid/unsupported lockfile, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to these stable error codes:
+- `E_LOCKFILE_MISSING`
+- `E_LOCKFILE_INVALID`
+- `E_LOCKFILE_UNSUPPORTED_VERSION`
+
+#### Scenario: lockfile missing includes guidance fields
+- **GIVEN** the config repo does not contain `repo/agentpack.lock.json`
+- **WHEN** the user runs `agentpack fetch --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_LOCKFILE_MISSING`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present
+
+#### Scenario: lockfile invalid includes guidance fields
+- **GIVEN** the config repo contains an invalid `repo/agentpack.lock.json`
+- **WHEN** the user runs `agentpack fetch --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_LOCKFILE_INVALID`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present
+
+#### Scenario: lockfile unsupported version includes guidance fields
+- **GIVEN** the config repo contains `repo/agentpack.lock.json` with an unsupported `version`
+- **WHEN** the user runs `agentpack fetch --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_LOCKFILE_UNSUPPORTED_VERSION`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-lockfile-next-actions/tasks.md
+++ b/openspec/changes/add-lockfile-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new guidance detail fields for lockfile error codes.
+
+### 1.2 Code changes
+- [x] Extend lockfile-related errors to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new lockfile error `details` fields.
+- [x] Update `docs/reference/error-codes.md` for lockfile error codes.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on lockfile error codes.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-lockfile-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -68,6 +68,8 @@ impl Lockfile {
                     UserError::new("E_LOCKFILE_MISSING", format!("missing lockfile: {}", path.display()))
                         .with_details(serde_json::json!({
                             "path": path.to_string_lossy(),
+                            "reason_code": "lockfile_missing",
+                            "next_actions": ["run_lock", "run_update", "retry_command"],
                             "hint": "run `agentpack update` (or `agentpack lock`) to generate agentpack.lock.json",
                         })),
                 ));
@@ -86,6 +88,8 @@ impl Lockfile {
                 .with_details(serde_json::json!({
                     "path": path.to_string_lossy(),
                     "error": err.to_string(),
+                    "reason_code": "lockfile_invalid_json",
+                    "next_actions": ["regenerate_lockfile", "retry_command"],
                 })),
             )
         })?;
@@ -100,6 +104,8 @@ impl Lockfile {
                     "path": path.to_string_lossy(),
                     "version": lock.version,
                     "supported": [LOCKFILE_VERSION],
+                    "reason_code": "lockfile_unsupported_version",
+                    "next_actions": ["upgrade_agentpack", "regenerate_lockfile", "retry_command"],
                     "hint": "upgrade agentpack or regenerate agentpack.lock.json with `agentpack lock`",
                 })),
             ));

--- a/tests/cli_error_codes.rs
+++ b/tests/cli_error_codes.rs
@@ -90,6 +90,14 @@ fn json_error_code_lockfile_missing_for_fetch() {
     assert!(!out.status.success());
     let v = parse_stdout_json(&out);
     assert_eq!(v["errors"][0]["code"], "E_LOCKFILE_MISSING");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("lockfile_missing")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["run_lock", "run_update", "retry_command"])
+    );
 }
 
 #[test]
@@ -107,6 +115,14 @@ fn json_error_code_lockfile_invalid_for_fetch() {
     assert!(!out.status.success());
     let v = parse_stdout_json(&out);
     assert_eq!(v["errors"][0]["code"], "E_LOCKFILE_INVALID");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("lockfile_invalid_json")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["regenerate_lockfile", "retry_command"])
+    );
 }
 
 #[test]
@@ -124,6 +140,14 @@ fn json_error_code_lockfile_unsupported_version_for_fetch() {
     assert!(!out.status.success());
     let v = parse_stdout_json(&out);
     assert_eq!(v["errors"][0]["code"], "E_LOCKFILE_UNSUPPORTED_VERSION");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("lockfile_unsupported_version")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["upgrade_agentpack", "regenerate_lockfile", "retry_command"])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #819

## Summary
- Add additive `reason_code` + `next_actions` to lockfile-related `--json` errors:
  - `E_LOCKFILE_MISSING`
  - `E_LOCKFILE_INVALID`
  - `E_LOCKFILE_UNSUPPORTED_VERSION`
- Document the new detail fields in `docs/SPEC.md` and `docs/reference/error-codes.md`.
- Extend `tests/cli_error_codes.rs` to assert the new fields.

## Testing
- `just check`
- `openspec validate add-lockfile-next-actions --strict --no-interactive`
