### PR TITLE
feat(json): add policy config refusal guidance

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -41,9 +41,9 @@ When `--json` is enabled, common actionable failures must return stable error co
 - `E_OVERLAY_BASELINE_UNSUPPORTED`: baseline has no locatable merge base (cannot rebase safely).
 - `E_OVERLAY_REBASE_CONFLICT`: overlay rebase produced conflicts requiring manual resolution.
 - `E_POLICY_VIOLATIONS`: `policy lint` found one or more governance policy violations.
-- `E_POLICY_CONFIG_MISSING`: missing `repo/agentpack.org.yaml` when running governance policy commands.
-- `E_POLICY_CONFIG_INVALID`: `repo/agentpack.org.yaml` is invalid.
-- `E_POLICY_CONFIG_UNSUPPORTED_VERSION`: `repo/agentpack.org.yaml` `version` is unsupported.
+- `E_POLICY_CONFIG_MISSING`: missing `repo/agentpack.org.yaml` when running governance policy commands (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_POLICY_CONFIG_INVALID`: `repo/agentpack.org.yaml` is invalid (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_POLICY_CONFIG_UNSUPPORTED_VERSION`: `repo/agentpack.org.yaml` `version` is unsupported (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_IO_PERMISSION_DENIED`: a filesystem write failed due to permissions (including read-only destinations).
 - `E_IO_INVALID_PATH`: a filesystem write failed because the destination path is invalid for the platform.
 - `E_IO_PATH_TOO_LONG`: a filesystem write failed because the destination path exceeds platform limits.

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -202,18 +202,21 @@ Meaning: missing `repo/agentpack.org.yaml` when running governance policy comman
 Retryable: yes.
 Recommended action: create `repo/agentpack.org.yaml` (governance is opt-in) and retry.
 Details: includes `{path, hint}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_POLICY_CONFIG_INVALID
 Meaning: `repo/agentpack.org.yaml` is syntactically or semantically invalid (e.g., invalid YAML, missing/empty `policy_pack.source`, unsupported `policy_pack.source` syntax).
 Retryable: depends on fixing config.
 Recommended action: fix YAML based on `details` and retry.
 Details: includes `{path, error?}` and MAY include `{field, value, hint}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_POLICY_CONFIG_UNSUPPORTED_VERSION
 Meaning: `repo/agentpack.org.yaml` `version` is unsupported.
 Retryable: depends on upgrading agentpack or fixing config.
 Recommended action: set `version` to a supported value (currently `1`) or upgrade agentpack.
 Details: includes `{path, version, supported}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_IO_PERMISSION_DENIED
 Meaning: a filesystem write failed due to permissions (including read-only destination files) or an access-denied condition.

--- a/openspec/changes/add-policy-config-next-actions/.openspec.yaml
+++ b/openspec/changes/add-policy-config-next-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-24

--- a/openspec/changes/add-policy-config-next-actions/README.md
+++ b/openspec/changes/add-policy-config-next-actions/README.md
@@ -1,0 +1,3 @@
+# add-policy-config-next-actions
+
+Add reason_code and next_actions for policy config error codes

--- a/openspec/changes/add-policy-config-next-actions/proposal.md
+++ b/openspec/changes/add-policy-config-next-actions/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add `reason_code` and `next_actions` to policy config errors
+
+## Why
+Automation can reliably branch on stable policy error codes like `E_POLICY_CONFIG_MISSING`, but it still needs structured, machine-actionable guidance for remediation (without parsing human strings).
+
+Today, policy config errors include human `hint` strings, but do not consistently include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for policy config errors:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Apply to these stable error codes:
+  - `E_POLICY_CONFIG_MISSING`
+  - `E_POLICY_CONFIG_INVALID`
+  - `E_POLICY_CONFIG_UNSUPPORTED_VERSION`
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- Policy config errors in `--json` mode include `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-policy-config-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-policy-config-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Policy config errors are machine-actionable
+When a `--json` invocation fails due to a missing/invalid/unsupported policy config, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to these stable error codes:
+- `E_POLICY_CONFIG_MISSING`
+- `E_POLICY_CONFIG_INVALID`
+- `E_POLICY_CONFIG_UNSUPPORTED_VERSION`
+
+#### Scenario: policy config missing includes guidance fields
+- **GIVEN** the config repo does not contain `repo/agentpack.org.yaml`
+- **WHEN** the user runs `agentpack policy lock --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_POLICY_CONFIG_MISSING`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present
+
+#### Scenario: policy config invalid includes guidance fields
+- **GIVEN** the config repo contains an invalid `repo/agentpack.org.yaml`
+- **WHEN** the user runs `agentpack policy lock --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_POLICY_CONFIG_INVALID`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present
+
+#### Scenario: policy config unsupported version includes guidance fields
+- **GIVEN** the config repo contains `repo/agentpack.org.yaml` with an unsupported `version`
+- **WHEN** the user runs `agentpack policy lock --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_POLICY_CONFIG_UNSUPPORTED_VERSION`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-policy-config-next-actions/tasks.md
+++ b/openspec/changes/add-policy-config-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new guidance detail fields for policy config error codes.
+
+### 1.2 Code changes
+- [x] Extend policy config errors to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new policy config error `details` fields.
+- [x] Update `docs/reference/error-codes.md` for policy config error codes.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on policy config error codes.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-policy-config-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/policy_pack.rs
+++ b/src/policy_pack.rs
@@ -61,6 +61,8 @@ impl OrgConfig {
                     )
                     .with_details(serde_json::json!({
                         "path": path.to_string_lossy(),
+                        "reason_code": "policy_config_missing",
+                        "next_actions": ["create_policy_config", "retry_command"],
                         "hint": "create repo/agentpack.org.yaml (governance is opt-in)",
                     })),
                 ));
@@ -77,6 +79,8 @@ impl OrgConfig {
                 .with_details(serde_json::json!({
                     "path": path.to_string_lossy(),
                     "error": err.to_string(),
+                    "reason_code": "policy_config_invalid",
+                    "next_actions": ["fix_policy_config", "retry_command"],
                 })),
             )
         })?;
@@ -91,6 +95,8 @@ impl OrgConfig {
                     "path": path.to_string_lossy(),
                     "version": cfg.version,
                     "supported": [ORG_CONFIG_VERSION],
+                    "reason_code": "policy_config_unsupported_version",
+                    "next_actions": ["upgrade_agentpack", "fix_policy_config_version", "retry_command"],
                 })),
             ));
         }
@@ -172,6 +178,8 @@ pub(crate) fn lock_policy_pack(
             .with_details(serde_json::json!({
                 "path": cfg_path.to_string_lossy(),
                 "missing": ["policy_pack"],
+                "reason_code": "policy_config_invalid",
+                "next_actions": ["fix_policy_config", "retry_command"],
                 "hint": "add policy_pack.source (local:... or git:...)",
             })),
         ));
@@ -185,6 +193,8 @@ pub(crate) fn lock_policy_pack(
             .with_details(serde_json::json!({
                 "path": cfg_path.to_string_lossy(),
                 "field": "policy_pack.source",
+                "reason_code": "policy_config_invalid",
+                "next_actions": ["fix_policy_config", "retry_command"],
             })),
         ));
     }
@@ -200,6 +210,8 @@ pub(crate) fn lock_policy_pack(
                 "field": "policy_pack.source",
                 "value": pack.source,
                 "error": err.to_string(),
+                "reason_code": "policy_config_invalid",
+                "next_actions": ["fix_policy_config", "retry_command"],
                 "hint": "expected local:... or git:...#ref=...&subdir=...",
             })),
         )
@@ -220,6 +232,8 @@ pub(crate) fn lock_policy_pack(
                         .with_details(serde_json::json!({
                             "path": cfg_path.to_string_lossy(),
                             "field": "supply_chain_policy.allowed_git_remotes",
+                            "reason_code": "policy_config_invalid",
+                            "next_actions": ["fix_policy_config", "retry_command"],
                         })),
                     ));
                 }
@@ -252,6 +266,8 @@ pub(crate) fn lock_policy_pack(
                             "remote": gs.url,
                             "remote_normalized": normalized_remote,
                             "allowed_git_remotes": allowed_git_remotes,
+                            "reason_code": "policy_config_invalid",
+                            "next_actions": ["fix_policy_config", "retry_command"],
                             "hint": "update supply_chain_policy.allowed_git_remotes or change policy_pack.source",
                         })),
                     ));


### PR DESCRIPTION
Closes #823

## Summary
- Add additive `reason_code` + `next_actions` to policy config-related `--json` errors:
  - `E_POLICY_CONFIG_MISSING`
  - `E_POLICY_CONFIG_INVALID`
  - `E_POLICY_CONFIG_UNSUPPORTED_VERSION`
- Document the new detail fields in `docs/SPEC.md` and `docs/reference/error-codes.md`.
- Extend `tests/cli_policy_lock.rs` to assert the new fields.

## Testing
- `just check`
- `openspec validate add-policy-config-next-actions --strict --no-interactive`
