### PR TITLE
feat(json): add guidance to config validation errors

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -29,8 +29,8 @@ When `--json` is enabled, common actionable failures must return stable error co
 - `E_CONFIRM_REQUIRED`: in `--json` mode, a mutating command is missing `--yes`.
 - `E_ADOPT_CONFIRM_REQUIRED`: would overwrite an existing unmanaged file (`adopt_update`), but `--adopt` was not provided.
 - `E_CONFIG_MISSING`: missing `repo/agentpack.yaml` (details include additive guidance fields: `reason_code`, `next_actions`).
-- `E_CONFIG_INVALID`: `agentpack.yaml` is syntactically or semantically invalid (e.g. missing default profile, duplicate module id, invalid source config).
-- `E_CONFIG_UNSUPPORTED_VERSION`: `agentpack.yaml` `version` is unsupported.
+- `E_CONFIG_INVALID`: `agentpack.yaml` is syntactically or semantically invalid (e.g. missing default profile, duplicate module id, invalid source config) (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_CONFIG_UNSUPPORTED_VERSION`: `agentpack.yaml` `version` is unsupported (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_LOCKFILE_MISSING`: missing `repo/agentpack.lock.json` but the command requires it (e.g. `fetch`) (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_LOCKFILE_INVALID`: `agentpack.lock.json` is invalid JSON (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_LOCKFILE_UNSUPPORTED_VERSION`: `agentpack.lock.json` `version` is unsupported (details include additive guidance fields: `reason_code`, `next_actions`).

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -110,12 +110,14 @@ Retryable: depends on fixing config.
 Recommended action: fix YAML based on `details` and/or error message (e.g., missing default profile, duplicate module id, invalid source, missing target config).
 
 This code MAY also be used when a configured module is structurally invalid (e.g., a `skill` module’s `SKILL.md` has missing/invalid YAML frontmatter).
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_CONFIG_UNSUPPORTED_VERSION
 Meaning: `agentpack.yaml` `version` is unsupported.
 Retryable: depends on fixing config or upgrading agentpack.
 Recommended action: set `version` to a supported value (currently `1`) or upgrade agentpack.
 Details: typically includes `{version, supported}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_LOCKFILE_MISSING
 Meaning: missing `repo/agentpack.lock.json` but the command requires it (e.g., `fetch`).

--- a/openspec/changes/add-config-validation-next-actions/.openspec.yaml
+++ b/openspec/changes/add-config-validation-next-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-24

--- a/openspec/changes/add-config-validation-next-actions/README.md
+++ b/openspec/changes/add-config-validation-next-actions/README.md
@@ -1,0 +1,3 @@
+# add-config-validation-next-actions
+
+Add reason_code and next_actions for E_CONFIG_INVALID and E_CONFIG_UNSUPPORTED_VERSION

--- a/openspec/changes/add-config-validation-next-actions/proposal.md
+++ b/openspec/changes/add-config-validation-next-actions/proposal.md
@@ -1,0 +1,25 @@
+# Change: Add `reason_code` and `next_actions` to config validation errors
+
+## Why
+Automation can reliably branch on stable error codes like `E_CONFIG_INVALID`, but it still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, config validation failures may include human-oriented `hint` fields, but do not consistently include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for config validation errors:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Apply to these stable error codes:
+  - `E_CONFIG_INVALID`
+  - `E_CONFIG_UNSUPPORTED_VERSION`
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- Config validation errors in `--json` mode include `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-config-validation-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-config-validation-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Config validation errors are machine-actionable
+When a `--json` invocation fails due to an invalid/unsupported config manifest, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to these stable error codes:
+- `E_CONFIG_INVALID`
+- `E_CONFIG_UNSUPPORTED_VERSION`
+
+#### Scenario: config invalid includes guidance fields
+- **GIVEN** the config repo contains an invalid `repo/agentpack.yaml`
+- **WHEN** the user runs `agentpack plan --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_CONFIG_INVALID`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present
+
+#### Scenario: config unsupported version includes guidance fields
+- **GIVEN** the config repo contains `repo/agentpack.yaml` with an unsupported `version`
+- **WHEN** the user runs `agentpack plan --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_CONFIG_UNSUPPORTED_VERSION`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-config-validation-next-actions/tasks.md
+++ b/openspec/changes/add-config-validation-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new guidance detail fields for config validation error codes.
+
+### 1.2 Code changes
+- [x] Extend config validation errors to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new config validation error `details` fields.
+- [x] Update `docs/reference/error-codes.md` for `E_CONFIG_INVALID` and `E_CONFIG_UNSUPPORTED_VERSION`.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on config validation error codes.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-config-validation-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/tests/cli_error_codes.rs
+++ b/tests/cli_error_codes.rs
@@ -51,6 +51,14 @@ fn json_error_code_config_invalid_yaml() {
     assert!(!out.status.success());
     let v = parse_stdout_json(&out);
     assert_eq!(v["errors"][0]["code"], "E_CONFIG_INVALID");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("config_invalid")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["fix_config", "retry_command"])
+    );
 }
 
 #[test]
@@ -79,6 +87,14 @@ modules: []
     assert!(!out.status.success());
     let v = parse_stdout_json(&out);
     assert_eq!(v["errors"][0]["code"], "E_CONFIG_UNSUPPORTED_VERSION");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("config_unsupported_version")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["upgrade_agentpack", "fix_config_version", "retry_command"])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #827.

## Summary
- Adds additive `errors[0].details.reason_code` + `next_actions` for:
  - `E_CONFIG_INVALID`
  - `E_CONFIG_UNSUPPORTED_VERSION`
- Updates docs to document the new additive fields.
- Extends tests to assert the guidance fields.

## Spec
- OpenSpec change: `openspec/changes/add-config-validation-next-actions/`

## Testing
- `openspec validate add-config-validation-next-actions --strict --no-interactive`
- `just check`
