### PR TITLE
feat(json): add guidance to overlay baseline errors

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -36,9 +36,9 @@ When `--json` is enabled, common actionable failures must return stable error co
 - `E_LOCKFILE_UNSUPPORTED_VERSION`: `agentpack.lock.json` `version` is unsupported (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_TARGET_UNSUPPORTED`: an unsupported target (manifest targets or CLI `--target` selection).
 - `E_DESIRED_STATE_CONFLICT`: multiple modules produced different content for the same `(target, path)` (refuse silent overwrite).
-- `E_OVERLAY_NOT_FOUND`: overlay directory does not exist (overlay not created yet).
-- `E_OVERLAY_BASELINE_MISSING`: overlay baseline metadata is missing (cannot rebase safely).
-- `E_OVERLAY_BASELINE_UNSUPPORTED`: baseline has no locatable merge base (cannot rebase safely).
+- `E_OVERLAY_NOT_FOUND`: overlay directory does not exist (overlay not created yet) (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_OVERLAY_BASELINE_MISSING`: overlay baseline metadata is missing (cannot rebase safely) (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_OVERLAY_BASELINE_UNSUPPORTED`: baseline has no locatable merge base (cannot rebase safely) (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_OVERLAY_REBASE_CONFLICT`: overlay rebase produced conflicts requiring manual resolution.
 - `E_POLICY_VIOLATIONS`: `policy lint` found one or more governance policy violations.
 - `E_POLICY_CONFIG_MISSING`: missing `repo/agentpack.org.yaml` when running governance policy commands (details include additive guidance fields: `reason_code`, `next_actions`).

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -163,16 +163,19 @@ Details also includes additive refusal guidance fields: `{reason_code, next_acti
 Meaning: requested overlay directory does not exist.
 Retryable: yes.
 Recommended action: run `agentpack overlay edit <module_id>` to create the overlay.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_OVERLAY_BASELINE_MISSING
 Meaning: overlay metadata is missing (`<overlay_dir>/.agentpack/baseline.json`), so rebase cannot proceed.
 Retryable: yes.
 Recommended action: re-run `agentpack overlay edit <module_id>` to regenerate metadata.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_OVERLAY_BASELINE_UNSUPPORTED
 Meaning: overlay baseline cannot locate a merge base, so rebase cannot proceed safely.
 Retryable: depends on baseline repair.
 Recommended action: usually recreate the overlay (new baseline), or ensure upstream is traceable (git) and recreate.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_OVERLAY_REBASE_CONFLICT
 Meaning: `overlay rebase` produced conflicts that cannot be auto-merged.

--- a/openspec/changes/add-overlay-baseline-next-actions/.openspec.yaml
+++ b/openspec/changes/add-overlay-baseline-next-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-24

--- a/openspec/changes/add-overlay-baseline-next-actions/README.md
+++ b/openspec/changes/add-overlay-baseline-next-actions/README.md
@@ -1,0 +1,3 @@
+# add-overlay-baseline-next-actions
+
+Add reason_code and next_actions for overlay baseline errors

--- a/openspec/changes/add-overlay-baseline-next-actions/proposal.md
+++ b/openspec/changes/add-overlay-baseline-next-actions/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add `reason_code` and `next_actions` to overlay baseline errors
+
+## Why
+Automation can reliably branch on stable overlay error codes like `E_OVERLAY_NOT_FOUND`, but it still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, some overlay errors include human `hint` strings, but do not consistently include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for overlay baseline errors:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Apply to these stable error codes:
+  - `E_OVERLAY_NOT_FOUND`
+  - `E_OVERLAY_BASELINE_MISSING`
+  - `E_OVERLAY_BASELINE_UNSUPPORTED`
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- Overlay baseline errors in `--json` mode include `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-overlay-baseline-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-overlay-baseline-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Overlay baseline errors are machine-actionable
+When a `--json` invocation fails due to missing/unsupported overlays or overlay baseline metadata, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to these stable error codes:
+- `E_OVERLAY_NOT_FOUND`
+- `E_OVERLAY_BASELINE_MISSING`
+- `E_OVERLAY_BASELINE_UNSUPPORTED`
+
+#### Scenario: overlay not found includes guidance fields
+- **GIVEN** a module exists but its overlay directory does not exist
+- **WHEN** the user runs `agentpack overlay rebase <module_id> --scope global --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_OVERLAY_NOT_FOUND`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present
+
+#### Scenario: overlay baseline missing includes guidance fields
+- **GIVEN** an overlay directory exists but its baseline metadata is missing
+- **WHEN** the user runs `agentpack overlay rebase <module_id> --scope global --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_OVERLAY_BASELINE_MISSING`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present
+
+#### Scenario: overlay baseline unsupported includes guidance fields
+- **GIVEN** an overlay directory exists but its baseline cannot locate a merge base
+- **WHEN** the user runs `agentpack overlay rebase <module_id> --scope global --json --yes`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is `E_OVERLAY_BASELINE_UNSUPPORTED`
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-overlay-baseline-next-actions/tasks.md
+++ b/openspec/changes/add-overlay-baseline-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting the new guidance detail fields for overlay baseline error codes.
+
+### 1.2 Code changes
+- [x] Extend overlay baseline errors to include stable `reason_code` + `next_actions` (additive).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new overlay baseline error `details` fields.
+- [x] Update `docs/reference/error-codes.md` for `E_OVERLAY_NOT_FOUND`, `E_OVERLAY_BASELINE_MISSING`, and `E_OVERLAY_BASELINE_UNSUPPORTED`.
+
+### 1.4 Tests
+- [x] Extend CLI tests to assert `reason_code` + `next_actions` on overlay baseline error codes.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-overlay-baseline-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -228,6 +228,23 @@ fn add_default_reason_code_and_next_actions(
             "config_unsupported_version",
             serde_json::json!(["upgrade_agentpack", "fix_config_version", "retry_command"]),
         ),
+        "E_OVERLAY_NOT_FOUND" => (
+            "overlay_not_found",
+            serde_json::json!(["run_overlay_edit", "retry_command"]),
+        ),
+        "E_OVERLAY_BASELINE_MISSING" => (
+            "overlay_baseline_missing",
+            serde_json::json!(["run_overlay_edit", "retry_command"]),
+        ),
+        "E_OVERLAY_BASELINE_UNSUPPORTED" => (
+            "overlay_baseline_unsupported",
+            serde_json::json!([
+                "init_git_repo",
+                "commit_or_stash",
+                "run_overlay_edit",
+                "retry_command"
+            ]),
+        ),
         _ => return details,
     };
 

--- a/tests/cli_overlay_baseline_errors.rs
+++ b/tests/cli_overlay_baseline_errors.rs
@@ -1,0 +1,236 @@
+use std::path::Path;
+use std::process::Command;
+
+use agentpack::config::{LocalPathSource, Manifest, Module, ModuleType, Source};
+use agentpack::ids::module_fs_key;
+
+fn agentpack_in(home: &Path, cwd: &Path, args: &[&str]) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_agentpack");
+    Command::new(bin)
+        .current_dir(cwd)
+        .args(args)
+        .env("AGENTPACK_HOME", home)
+        .env("EDITOR", "")
+        .output()
+        .expect("run agentpack")
+}
+
+fn parse_stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout).expect("stdout is valid json")
+}
+
+fn git_ok(cwd: &Path, args: &[&str]) -> anyhow::Result<()> {
+    let out = Command::new("git").current_dir(cwd).args(args).output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(())
+}
+
+fn add_local_path_skill_module(repo_dir: &Path, module_id: &str) -> anyhow::Result<()> {
+    let module_root = repo_dir.join("modules").join(module_id);
+    std::fs::create_dir_all(&module_root)?;
+    std::fs::write(module_root.join("SKILL.md"), "line1\nline2\nline3\n")?;
+
+    let manifest_path = repo_dir.join("agentpack.yaml");
+    let mut manifest = Manifest::load(&manifest_path)?;
+    manifest.modules.push(Module {
+        id: module_id.to_string(),
+        module_type: ModuleType::Skill,
+        enabled: true,
+        tags: Vec::new(),
+        targets: Vec::new(),
+        source: Source {
+            local_path: Some(LocalPathSource {
+                path: format!("modules/{module_id}"),
+            }),
+            git: None,
+        },
+        metadata: Default::default(),
+    });
+    manifest.save(&manifest_path)?;
+    Ok(())
+}
+
+#[test]
+fn overlay_rebase_json_includes_guidance_when_overlay_is_missing() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path();
+
+    let project_dir = home.join("project");
+    std::fs::create_dir_all(&project_dir)?;
+
+    let init = agentpack_in(home, &project_dir, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    add_local_path_skill_module(&repo_dir, "skill_test")?;
+
+    let rebase = agentpack_in(
+        home,
+        &project_dir,
+        &[
+            "overlay",
+            "rebase",
+            "skill_test",
+            "--scope",
+            "global",
+            "--json",
+            "--yes",
+        ],
+    );
+    assert!(
+        !rebase.status.success(),
+        "rebase should fail when overlay is missing"
+    );
+
+    let v = parse_stdout_json(&rebase);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_OVERLAY_NOT_FOUND");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("overlay_not_found")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["run_overlay_edit", "retry_command"])
+    );
+
+    Ok(())
+}
+
+#[test]
+fn overlay_rebase_json_includes_guidance_when_baseline_is_missing() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path();
+
+    let project_dir = home.join("project");
+    std::fs::create_dir_all(&project_dir)?;
+
+    let init = agentpack_in(home, &project_dir, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+    add_local_path_skill_module(&repo_dir, "skill_test")?;
+
+    // Create overlay dir without baseline metadata.
+    let overlay_dir = repo_dir.join("overlays").join(module_fs_key("skill_test"));
+    std::fs::create_dir_all(&overlay_dir)?;
+
+    let rebase = agentpack_in(
+        home,
+        &project_dir,
+        &[
+            "overlay",
+            "rebase",
+            "skill_test",
+            "--scope",
+            "global",
+            "--json",
+            "--yes",
+        ],
+    );
+    assert!(
+        !rebase.status.success(),
+        "rebase should fail when baseline metadata is missing"
+    );
+
+    let v = parse_stdout_json(&rebase);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_OVERLAY_BASELINE_MISSING");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("overlay_baseline_missing")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["run_overlay_edit", "retry_command"])
+    );
+
+    Ok(())
+}
+
+#[test]
+fn overlay_rebase_json_includes_guidance_when_baseline_is_unsupported() -> anyhow::Result<()> {
+    let tmp = tempfile::tempdir()?;
+    let home = tmp.path();
+
+    let project_dir = home.join("project");
+    std::fs::create_dir_all(&project_dir)?;
+
+    let init = agentpack_in(home, &project_dir, &["init"]);
+    assert!(init.status.success());
+
+    let repo_dir = home.join("repo");
+
+    // Put the config repo under git so local-path baselines can locate merge bases.
+    git_ok(&repo_dir, &["init"])?;
+    git_ok(&repo_dir, &["config", "user.email", "test@example.com"])?;
+    git_ok(&repo_dir, &["config", "user.name", "Test"])?;
+    git_ok(&repo_dir, &["add", "."])?;
+    git_ok(&repo_dir, &["commit", "-m", "init"])?;
+
+    add_local_path_skill_module(&repo_dir, "skill_test")?;
+    git_ok(&repo_dir, &["add", "."])?;
+    git_ok(&repo_dir, &["commit", "-m", "add skill_test module"])?;
+
+    // Create overlay baseline file without upstream identity.
+    let overlay_meta_dir = repo_dir
+        .join("overlays")
+        .join(module_fs_key("skill_test"))
+        .join(".agentpack");
+    std::fs::create_dir_all(&overlay_meta_dir)?;
+    let baseline_path = overlay_meta_dir.join("baseline.json");
+    std::fs::write(
+        baseline_path,
+        r#"{
+  "version": 1,
+  "created_at": "t",
+  "upstream_sha256": "deadbeef",
+  "file_manifest": []
+}
+"#,
+    )?;
+
+    let rebase = agentpack_in(
+        home,
+        &project_dir,
+        &[
+            "overlay",
+            "rebase",
+            "skill_test",
+            "--scope",
+            "global",
+            "--json",
+            "--yes",
+        ],
+    );
+    assert!(
+        !rebase.status.success(),
+        "rebase should fail when baseline cannot locate merge base"
+    );
+
+    let v = parse_stdout_json(&rebase);
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["errors"][0]["code"], "E_OVERLAY_BASELINE_UNSUPPORTED");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("overlay_baseline_unsupported")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!([
+            "init_git_repo",
+            "commit_or_stash",
+            "run_overlay_edit",
+            "retry_command"
+        ])
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #831.

## Summary
- Adds additive `errors[0].details.reason_code` + `next_actions` for:
  - `E_OVERLAY_NOT_FOUND`
  - `E_OVERLAY_BASELINE_MISSING`
  - `E_OVERLAY_BASELINE_UNSUPPORTED`
- Updates docs to document the new additive fields.
- Adds tests asserting the guidance fields for `agentpack overlay rebase ... --json`.

## Spec
- OpenSpec change: `openspec/changes/add-overlay-baseline-next-actions/`

## Testing
- `openspec validate add-overlay-baseline-next-actions --strict --no-interactive`
- `just check`
