### PR TITLE
feat(json): add guidance to io errors

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -44,9 +44,9 @@ When `--json` is enabled, common actionable failures must return stable error co
 - `E_POLICY_CONFIG_MISSING`: missing `repo/agentpack.org.yaml` when running governance policy commands (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_POLICY_CONFIG_INVALID`: `repo/agentpack.org.yaml` is invalid (details include additive guidance fields: `reason_code`, `next_actions`).
 - `E_POLICY_CONFIG_UNSUPPORTED_VERSION`: `repo/agentpack.org.yaml` `version` is unsupported (details include additive guidance fields: `reason_code`, `next_actions`).
-- `E_IO_PERMISSION_DENIED`: a filesystem write failed due to permissions (including read-only destinations).
-- `E_IO_INVALID_PATH`: a filesystem write failed because the destination path is invalid for the platform.
-- `E_IO_PATH_TOO_LONG`: a filesystem write failed because the destination path exceeds platform limits.
+- `E_IO_PERMISSION_DENIED`: a filesystem write failed due to permissions (including read-only destinations) (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_IO_INVALID_PATH`: a filesystem write failed because the destination path is invalid for the platform (details include additive guidance fields: `reason_code`, `next_actions`).
+- `E_IO_PATH_TOO_LONG`: a filesystem write failed because the destination path exceeds platform limits (details include additive guidance fields: `reason_code`, `next_actions`).
 
 See: `ERROR_CODES.md`.
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -230,12 +230,14 @@ Recommended action:
 - Ensure the destination path (and its parent directories) are writable.
 - On Windows, ensure the destination is not locked by another process (e.g., an editor) and retry.
 Details: includes `{path, path_posix, raw_os_error?, hint}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_IO_INVALID_PATH
 Meaning: a filesystem write failed because the destination path is invalid for the current platform (e.g., invalid characters on Windows).
 Retryable: no (until path is fixed).
 Recommended action: fix the configured destination path (remove invalid characters / use a valid root) and retry.
 Details: includes `{path, path_posix, raw_os_error?, hint}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ### E_IO_PATH_TOO_LONG
 Meaning: a filesystem write failed because the destination path exceeds platform limits.
@@ -244,6 +246,7 @@ Recommended action:
 - Use a shorter workspace/home path, or
 - On Windows, enable long path support if applicable.
 Details: includes `{path, path_posix, raw_os_error?, hint}`.
+Details also includes additive guidance fields: `{reason_code, next_actions}`.
 
 ## Non-stable / fallback error codes
 

--- a/openspec/changes/add-io-error-next-actions/.openspec.yaml
+++ b/openspec/changes/add-io-error-next-actions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-24

--- a/openspec/changes/add-io-error-next-actions/README.md
+++ b/openspec/changes/add-io-error-next-actions/README.md
@@ -1,0 +1,3 @@
+# add-io-error-next-actions
+
+Add `reason_code` and `next_actions` for stable `E_IO_*` errors

--- a/openspec/changes/add-io-error-next-actions/proposal.md
+++ b/openspec/changes/add-io-error-next-actions/proposal.md
@@ -1,0 +1,26 @@
+# Change: Add `reason_code` and `next_actions` to IO errors
+
+## Why
+Automation can reliably branch on stable IO error codes like `E_IO_PERMISSION_DENIED`, but it still needs structured, machine-actionable guidance for what to do next (without parsing human strings).
+
+Today, these stable `E_IO_*` errors include helpful `hint` strings, but do not consistently include stable `reason_code` + `next_actions` fields that orchestrators can depend on.
+
+## What Changes
+- Add additive fields under `errors[0].details` for stable IO write errors:
+  - `reason_code: string` (stable, enum-like)
+  - `next_actions: string[]` (stable, enum-like action identifiers)
+- Apply to these stable error codes:
+  - `E_IO_PERMISSION_DENIED`
+  - `E_IO_INVALID_PATH`
+  - `E_IO_PATH_TOO_LONG`
+- Update `docs/SPEC.md` and `docs/reference/error-codes.md` to document the new additive fields.
+- Extend conformance tests to assert the new detail fields.
+
+## Impact
+- Backward compatible: additive fields only (no `schema_version` bump).
+- Improves orchestrator ergonomics without changing error codes or exit behavior.
+
+## Acceptance
+- In `--json` mode, IO write failures classified as stable `E_IO_*` codes include `errors[0].details.reason_code` and `errors[0].details.next_actions`.
+- Existing detail fields are preserved.
+- Docs and tests are updated accordingly.

--- a/openspec/changes/add-io-error-next-actions/specs/agentpack-cli/spec.md
+++ b/openspec/changes/add-io-error-next-actions/specs/agentpack-cli/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: IO write errors are machine-actionable
+When a `--json` invocation fails due to a filesystem write error, the system SHALL include additive, machine-actionable fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to these stable error codes:
+- `E_IO_PERMISSION_DENIED`
+- `E_IO_INVALID_PATH`
+- `E_IO_PATH_TOO_LONG`
+
+#### Scenario: deploy --json includes guidance fields on IO failure
+- **GIVEN** a target root that will fail on write (invalid path, read-only destination, or platform path limit)
+- **WHEN** the user runs `agentpack deploy --apply --yes --json`
+- **THEN** stdout is valid JSON with `ok=false`
+- **AND** `errors[0].code` is one of the stable IO error codes above
+- **AND** `errors[0].details.reason_code` is present
+- **AND** `errors[0].details.next_actions` is present

--- a/openspec/changes/add-io-error-next-actions/tasks.md
+++ b/openspec/changes/add-io-error-next-actions/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+### 1.1 Spec deltas
+- [x] Add OpenSpec deltas for `agentpack-cli` documenting guidance detail fields for stable `E_IO_*` errors.
+
+### 1.2 Code changes
+- [x] Ensure stable `E_IO_*` errors include additive `reason_code` + `next_actions` (no behavior changes beyond JSON details).
+
+### 1.3 Docs
+- [x] Update `docs/SPEC.md` to document the new IO error `details` fields.
+- [x] Update `docs/reference/error-codes.md` for `E_IO_PERMISSION_DENIED`, `E_IO_INVALID_PATH`, and `E_IO_PATH_TOO_LONG`.
+
+### 1.4 Tests
+- [x] Extend tests to assert `reason_code` + `next_actions` on stable `E_IO_*` errors.
+
+### 1.5 Validation
+- [x] Run `openspec validate add-io-error-next-actions --strict --no-interactive`.
+- [x] Run `just check`.

--- a/src/user_error.rs
+++ b/src/user_error.rs
@@ -220,6 +220,18 @@ fn add_default_reason_code_and_next_actions(
     details: Option<serde_json::Value>,
 ) -> Option<serde_json::Value> {
     let (reason_code, next_actions) = match code {
+        "E_IO_PERMISSION_DENIED" => (
+            "io_permission_denied",
+            serde_json::json!(["fix_permissions", "retry_command"]),
+        ),
+        "E_IO_INVALID_PATH" => (
+            "io_invalid_path",
+            serde_json::json!(["fix_path", "retry_command"]),
+        ),
+        "E_IO_PATH_TOO_LONG" => (
+            "io_path_too_long",
+            serde_json::json!(["shorten_path", "enable_long_paths", "retry_command"]),
+        ),
         "E_CONFIG_INVALID" => (
             "config_invalid",
             serde_json::json!(["fix_config", "retry_command"]),

--- a/tests/conformance_windows_edge_cases.rs
+++ b/tests/conformance_windows_edge_cases.rs
@@ -93,6 +93,14 @@ fn deploy_json_returns_stable_code_for_invalid_path() {
     let v = parse_stdout_json(&deploy);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_IO_INVALID_PATH");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("io_invalid_path")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["fix_path", "retry_command"])
+    );
 }
 
 #[test]
@@ -132,6 +140,14 @@ fn deploy_json_returns_stable_code_for_path_too_long() {
     let v = parse_stdout_json(&deploy);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_IO_PATH_TOO_LONG");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("io_path_too_long")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["shorten_path", "enable_long_paths", "retry_command"])
+    );
 }
 
 #[test]
@@ -184,4 +200,12 @@ fn deploy_json_returns_stable_code_for_read_only_destination() {
     let v = parse_stdout_json(&deploy2);
     assert_eq!(v["ok"], false);
     assert_eq!(v["errors"][0]["code"], "E_IO_PERMISSION_DENIED");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("io_permission_denied")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["fix_permissions", "retry_command"])
+    );
 }


### PR DESCRIPTION
Refs #835

## Summary
- Add additive `errors[0].details.reason_code` + `errors[0].details.next_actions` for stable IO error codes:
  - `E_IO_PERMISSION_DENIED`
  - `E_IO_INVALID_PATH`
  - `E_IO_PATH_TOO_LONG`
- Document the guidance fields in `docs/SPEC.md` and `docs/reference/error-codes.md`.
- Extend Windows conformance tests to assert the new detail fields.

## OpenSpec
- `openspec/changes/add-io-error-next-actions/`

## Tests
- `openspec validate add-io-error-next-actions --strict --no-interactive`
- `just check`
