### PR TITLE
docs(json): document confirm error guidance

### DIFF
--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -17,6 +17,7 @@ Typical cases: `deploy --apply --json`, `update --json`, `overlay edit --json`, 
 Retryable: yes.
 Recommended action: confirm you intend to write, then retry with `--yes`, or drop `--json` and use interactive confirmation.
 Details: usually includes `{"command": "..."}`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_GIT_WORKTREE_DIRTY
 Meaning: the command requires a clean config repo git working tree, but uncommitted changes were detected.
@@ -62,16 +63,19 @@ Details also includes additive refusal guidance fields: `{reason_code, next_acti
 Meaning: in MCP mode (`agentpack mcp serve`), `deploy_apply` was called with `yes=true` but without a `confirm_token` from the `deploy` tool.
 Retryable: yes.
 Recommended action: call the `deploy` tool, obtain `data.confirm_token`, then retry `deploy_apply` with that token.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_CONFIRM_TOKEN_EXPIRED
 Meaning: in MCP mode (`agentpack mcp serve`), the provided `confirm_token` is expired.
 Retryable: yes.
 Recommended action: call the `deploy` tool again to obtain a fresh token, then retry `deploy_apply`.
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_CONFIRM_TOKEN_MISMATCH
 Meaning: in MCP mode (`agentpack mcp serve`), the provided `confirm_token` does not match the current `deploy` plan.
 Retryable: yes.
 Recommended action: call the `deploy` tool again and ensure the subsequent `deploy_apply` uses the matching token (and the same repo/profile/target/machine inputs).
+Details also includes additive refusal guidance fields: `{reason_code, next_actions}`.
 
 ### E_TTY_REQUIRED
 Meaning: the command requires a real TTY (stdin and stdout must be terminals), but the current context is non-interactive.

--- a/openspec/changes/update-confirm-error-guidance-docs/.openspec.yaml
+++ b/openspec/changes/update-confirm-error-guidance-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-01-24

--- a/openspec/changes/update-confirm-error-guidance-docs/README.md
+++ b/openspec/changes/update-confirm-error-guidance-docs/README.md
@@ -1,0 +1,3 @@
+# update-confirm-error-guidance-docs
+
+Document confirm-related guidance fields in the error code registry and add a CLI assertion test.

--- a/openspec/changes/update-confirm-error-guidance-docs/proposal.md
+++ b/openspec/changes/update-confirm-error-guidance-docs/proposal.md
@@ -1,0 +1,17 @@
+# Change: Document confirm-related guidance fields in error code registry
+
+## Why
+The implementation already includes additive `errors[0].details.reason_code` and `errors[0].details.next_actions` for confirm-related stable errors (e.g. `E_CONFIRM_REQUIRED` and MCP `E_CONFIRM_TOKEN_*`).
+
+However, `docs/reference/error-codes.md` does not currently state that these codes include the guidance fields, and a CLI test that exercises `E_CONFIRM_REQUIRED` does not assert the presence of the fields. This creates avoidable uncertainty for automation users and weakens regression protection.
+
+## What Changes
+- Update `docs/reference/error-codes.md` to document that confirm-related stable error codes include additive guidance fields `{reason_code, next_actions}`.
+- Extend a CLI test to assert `errors[0].details.reason_code` and `errors[0].details.next_actions` for `E_CONFIRM_REQUIRED`.
+
+## Impact
+- Backward compatible: documentation + test coverage only; no runtime behavior changes.
+
+## Acceptance
+- `docs/reference/error-codes.md` mentions guidance fields for `E_CONFIRM_REQUIRED` and MCP `E_CONFIRM_TOKEN_*` errors.
+- CLI test coverage asserts `E_CONFIRM_REQUIRED` includes `details.reason_code` and `details.next_actions`.

--- a/openspec/changes/update-confirm-error-guidance-docs/specs/agentpack-cli/spec.md
+++ b/openspec/changes/update-confirm-error-guidance-docs/specs/agentpack-cli/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Error code registry documents confirm guidance fields
+The stable error code registry (`docs/reference/error-codes.md`) SHALL document that confirm-related stable errors include additive guidance fields under `errors[0].details`:
+- `reason_code: string` (stable, enum-like)
+- `next_actions: string[]` (stable, enum-like action identifiers)
+
+This requirement applies to these stable error codes:
+- `E_CONFIRM_REQUIRED`
+- `E_CONFIRM_TOKEN_REQUIRED`
+- `E_CONFIRM_TOKEN_EXPIRED`
+- `E_CONFIRM_TOKEN_MISMATCH`
+
+#### Scenario: confirm errors are documented with guidance fields
+- **WHEN** a maintainer updates `docs/reference/error-codes.md`
+- **THEN** the sections for the confirm-related error codes above mention `reason_code` and `next_actions` as additive guidance fields

--- a/openspec/changes/update-confirm-error-guidance-docs/tasks.md
+++ b/openspec/changes/update-confirm-error-guidance-docs/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+### 1.1 Docs
+- [x] Update `docs/reference/error-codes.md` to document guidance fields for confirm-related errors.
+
+### 1.2 Tests
+- [x] Extend an existing CLI test to assert `E_CONFIRM_REQUIRED` includes `details.reason_code` and `details.next_actions`.
+
+### 1.3 Validation
+- [x] Run `openspec validate update-confirm-error-guidance-docs --strict --no-interactive`.
+- [x] Run `just check`.

--- a/tests/cli_update.rs
+++ b/tests/cli_update.rs
@@ -25,6 +25,14 @@ fn json_mode_requires_yes_for_update() {
     assert_eq!(v["ok"], false);
     assert_eq!(v["command"], "update");
     assert_eq!(v["errors"][0]["code"], "E_CONFIRM_REQUIRED");
+    assert_eq!(
+        v["errors"][0]["details"]["reason_code"].as_str(),
+        Some("confirm_required")
+    );
+    assert_eq!(
+        v["errors"][0]["details"]["next_actions"],
+        serde_json::json!(["retry_with_yes"])
+    );
 }
 
 #[test]


### PR DESCRIPTION
Refs #839

## Summary
- Document `{reason_code, next_actions}` as additive guidance fields for confirm-related stable errors in `docs/reference/error-codes.md`:
  - `E_CONFIRM_REQUIRED`
  - `E_CONFIRM_TOKEN_REQUIRED`
  - `E_CONFIRM_TOKEN_EXPIRED`
  - `E_CONFIRM_TOKEN_MISMATCH`
- Extend `tests/cli_update.rs` to assert `E_CONFIRM_REQUIRED` includes `details.reason_code` + `details.next_actions`.

## OpenSpec
- `openspec/changes/update-confirm-error-guidance-docs/`

## Tests
- `openspec validate update-confirm-error-guidance-docs --strict --no-interactive`
- `just check`
