### PR TITLE
docs(changelog): update Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,11 @@ This project follows SemVer with the following clarifications (especially for au
 ## [Unreleased]
 
 ### Added
+- Expanded additive refusal guidance fields (`errors[0].details.reason_code` and `errors[0].details.next_actions`) across more stable error codes (including IO, config/lockfile validation, target selection, policy, overlays, and deploy refusals).
 
 ### Changed
+- CI now uses `actions/setup-node@v6`.
+- MCP dependency `rmcp` updated to v0.14.0.
 
 ### Fixed
 


### PR DESCRIPTION
Refs #843

Updates `CHANGELOG.md` `[Unreleased]` to reflect post-`v0.9.0` changes.

## Tests
- `cargo test --locked --test docs_contract_version_stamps --test docs_install_snippets_sync`
