### PR TITLE
chore(release): v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,15 +23,21 @@ This project follows SemVer with the following clarifications (especially for au
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+### Security
+
+## [0.9.1] - 2026-01-24
+
+### Added
 - Expanded additive refusal guidance fields (`errors[0].details.reason_code` and `errors[0].details.next_actions`) across more stable error codes (including IO, config/lockfile validation, target selection, policy, overlays, and deploy refusals).
 
 ### Changed
 - CI now uses `actions/setup-node@v6`.
 - MCP dependency `rmcp` updated to v0.14.0.
-
-### Fixed
-
-### Security
 
 ## [0.9.0] - 2026-01-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agentpack"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentpack"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["liqiongyu <li@libiao.co>"]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cargo install agentpack --locked
 If crates.io install is not available yet, install from source:
 
 ```bash
-cargo install --git https://github.com/liqiongyu/agentpack --tag v0.9.0 --locked
+cargo install --git https://github.com/liqiongyu/agentpack --tag v0.9.1 --locked
 ```
 
 ### Prebuilt binaries

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,7 +90,7 @@ cargo install agentpack --locked
 如果暂时无法从 crates.io 安装，可以从源码安装：
 
 ```bash
-cargo install --git https://github.com/liqiongyu/agentpack --tag v0.9.0 --locked
+cargo install --git https://github.com/liqiongyu/agentpack --tag v0.9.1 --locked
 ```
 
 ### 预编译二进制

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,6 +1,6 @@
 # Spec (implementation contract)
 
-> Current as of **v0.9.0** (2026-01-23). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
+> Current as of **v0.9.1** (2026-01-24). This is the project’s **single authoritative spec**, aligned to the current implementation. Historical iterations live in git history; the repo no longer keeps `docs/versions/` snapshots.
 
 ## 0. Conventions
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -1,6 +1,6 @@
 # ERROR_CODES.md (stable error code registry)
 
-> Current as of **v0.9.0** (2026-01-23). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
+> Current as of **v0.9.1** (2026-01-24). `SPEC.md` is the semantic source of truth; this file is the stable registry for `--json` automation (`errors[0].code`).
 
 This file defines stable, externally-consumable error codes for `--json` mode (`errors[0].code`).
 

--- a/docs/reference/json-api.md
+++ b/docs/reference/json-api.md
@@ -1,6 +1,6 @@
 # JSON API (the `--json` output contract)
 
-> Current as of **v0.9.0** (2026-01-23). `SPEC.md` is the semantic source of truth; this file focuses on the stable `--json` contract.
+> Current as of **v0.9.1** (2026-01-24). `SPEC.md` is the semantic source of truth; this file focuses on the stable `--json` contract.
 
 ## 1) Stability guarantees (principles)
 
@@ -35,7 +35,7 @@ Failure example:
   "command": "deploy",
   "command_id": "deploy --apply",
   "command_path": ["deploy", "--apply"],
-  "version": "0.9.0",
+  "version": "0.9.1",
   "data": {},
   "warnings": [],
   "errors": [

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -36,7 +36,7 @@ Common “heavy user” setups (pick one to start):
   - From crates.io:
     - `cargo install agentpack --locked`
   - If you see `could not find \`agentpack\` in registry \`crates-io\``, install from source:
-    - Latest tagged release (recommended): `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.9.0 --locked`
+    - Latest tagged release (recommended): `cargo install --git https://github.com/liqiongyu/agentpack --tag v0.9.1 --locked`
     - Bleeding edge (`main`): `cargo install --git https://github.com/liqiongyu/agentpack --branch main --locked`
 - Non-Rust users:
   - Download a prebuilt binary from GitHub Releases (see the repository README).

--- a/docs/zh-CN/tutorials/quickstart.md
+++ b/docs/zh-CN/tutorials/quickstart.md
@@ -36,7 +36,7 @@
   - 从 crates.io 安装：
     - `cargo install agentpack --locked`
   - 如果你遇到 `could not find \`agentpack\` in registry \`crates-io\``，可以从源码安装：
-    - 最新 tag（推荐）：`cargo install --git https://github.com/liqiongyu/agentpack --tag v0.9.0 --locked`
+    - 最新 tag（推荐）：`cargo install --git https://github.com/liqiongyu/agentpack --tag v0.9.1 --locked`
     - main 分支（尝鲜）：`cargo install --git https://github.com/liqiongyu/agentpack --branch main --locked`
 - 非 Rust 用户：
   - 从 GitHub Releases 下载对应平台二进制（见仓库 README）。


### PR DESCRIPTION
Refs #845

Prepares `v0.9.1` release:
- Bumps crate version + lockfile.
- Updates contract docs version stamps and JSON API example version.
- Updates install snippets (`--tag v0.9.1`).
- Moves `[Unreleased]` entries into `[0.9.1]`.

## Tests
- `cargo test --locked --test docs_contract_version_stamps`
- `cargo test --locked --test docs_install_tag_sync --test docs_install_snippets_sync`
- `just check`

## Follow-up
After merge, tag and push: `git tag -a v0.9.1 -m "v0.9.1" && git push origin v0.9.1`.
